### PR TITLE
Log unhandled exceptions

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -212,7 +212,7 @@ abstract class DotnetTpk extends Target {
 
     // For now a constant value is used instead of reading from a file.
     // Keep this value in sync with the latest published nuget version.
-    const String embeddingVersion = '1.0.2';
+    const String embeddingVersion = '1.0.3';
 
     // Run .NET build.
     if (getDotnetCliPath() == null) {

--- a/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -44,14 +44,15 @@ namespace Tizen.Flutter.Embedding
             // Parse engine arguments passed from the tool. This should be reworked.
             for (int i = args.Length - 1; i >= 0; i--)
             {
-                if (args[i].StartsWith("FLUTTER_ENGINE_ARGS"))
+                var arg = args[i].Trim('\'');
+                if (arg.StartsWith("FLUTTER_ENGINE_ARGS"))
                 {
-                    args[i] = args[i].Substring(args[i].IndexOf(' ')).Trim();
-                    InternalLog.Debug(LogTag, "Run with: " + args[i]);
+                    var engineArgs = arg.Substring(arg.IndexOf(' '));
+                    InternalLog.Debug(LogTag, "Running with: " + engineArgs);
 
                     // A regex is used here to correctly parse "quoted" strings.
                     // TODO: Avoid using Linq to reduce the memory pressure.
-                    EngineArgs.AddRange(Regex.Matches(args[i], @"[\""].+?[\""]|[^ ]+")
+                    EngineArgs.AddRange(Regex.Matches(engineArgs, @"[\""].+?[\""]|[^ ]+")
                         .Cast<Match>()
                         .Select(x => x.Value.Trim('"')));
                     break;

--- a/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -34,12 +34,20 @@ namespace Tizen.Flutter.Embedding
 
         public override void Run(string[] args)
         {
+            // Log any unhandled exception.
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+            {
+                var exception = e.ExceptionObject as Exception;
+                InternalLog.Error(LogTag, $"Unhandled exception: {exception}");
+            };
+
+            // Parse engine arguments passed from the tool. This should be reworked.
             for (int i = args.Length - 1; i >= 0; i--)
             {
                 if (args[i].StartsWith("FLUTTER_ENGINE_ARGS"))
                 {
                     args[i] = args[i].Substring(args[i].IndexOf(' ')).Trim();
-                    Log.Debug(LogTag, "Run with: " + args[i]);
+                    InternalLog.Debug(LogTag, "Run with: " + args[i]);
 
                     // A regex is used here to correctly parse "quoted" strings.
                     // TODO: Avoid using Linq to reduce the memory pressure.
@@ -61,7 +69,7 @@ namespace Tizen.Flutter.Embedding
             if (!Information.TryGetValue("http://tizen.org/feature/screen.width", out int width) ||
                 !Information.TryGetValue("http://tizen.org/feature/screen.height", out int height))
             {
-                Log.Error(LogTag, "Could not obtain the screen size.");
+                InternalLog.Error(LogTag, "Could not obtain the screen size.");
                 return;
             }
             var windowProperties = new FlutterWindowProperties

--- a/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Tizen.Flutter.Embedding</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>flutter-tizen</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/flutter-tizen</PackageProjectUrl>


### PR DESCRIPTION
- Log any unhandled exception raised by the .NET runtime. This is useful when `System.DllNotFoundException` is thrown due to unresolved dependency or missing `.so` files.
- Use `InternalLog` instead of `Log` for better debugging experience on TV
- Bump the nuget package version to 1.0.3