### PR TITLE
Set '-d tizen' automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ flutter-tizen doctor
 flutter-tizen devices
 
 # Add Tizen files if a Flutter project already exists in the current directory.
-fluttze-tizen create .
+flutter-tizen create .
 
 # Build a TPK (application package) without installing.
 flutter-tizen build tpk

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ flutter-tizen create .
 flutter-tizen build tpk
 
 # Build the project and run on a Tizen device. Use `-d [id]` to specify a device ID.
-flutter-tizen run -d tizen
+flutter-tizen run
 
 # Run integration tests.
-flutter-tizen drive -d tizen --driver=... --target=...
+flutter-tizen drive --driver=... --target=...
 ```
 
 #### Notice

--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -49,7 +49,7 @@ def main():
     if os.path.isfile(flutterDir) or os.path.islink(flutterDir):
         os.remove(flutterDir)
     if not os.path.isdir(flutterDir):
-        cloneCommand = f'git clone --depth=1 {flutterRepo}'
+        cloneCommand = f'cd {rootDir} && git clone --depth=1 {flutterRepo}'
         subprocess.run(cloneCommand, shell=True, check=True)
 
     # Upgrade flutter if needed.

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -41,10 +41,14 @@ Future<void> main(List<String> args) async {
   final bool verbose = args.contains('-v') || args.contains('--verbose');
   final bool help = args.contains('-h') || args.contains('--help');
   final bool verboseHelp = help && verbose;
+  final bool specifiedId = args.contains('-d') || args.contains('--device-id');
 
-  // Suppress flutter analytics as we are not actually using the tools, but just
-  // depending on their source code.
-  args = <String>['--suppress-analytics', '--no-version-check', ...args];
+  args = <String>[
+    '--suppress-analytics', // Suppress flutter analytics by default.
+    '--no-version-check',
+    if (!specifiedId) ...<String>['-d', 'tizen'],
+    ...args,
+  ];
 
   await runner.run(
       args,

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -130,7 +130,7 @@ class TizenDevice extends Device {
   Future<String> get sdkNameAndVersion async => 'Tizen $platformVersion';
 
   @override
-  String get name => getCapability('device_name');
+  String get name => 'Tizen';
 
   bool get usesSecureProtocol => getCapability('secure_protocol') == 'enabled';
 

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -96,8 +96,8 @@ mixin TizenExtension on FlutterCommand {
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
     if (super.shouldRunPub) {
-      final FlutterProject project = FlutterProject.current();
-      await injectTizenPlugins(project);
+      // TODO(swift-kim): Should run pub get first before injecting plugins.
+      await injectTizenPlugins(FlutterProject.current());
     }
     return await super.verifyThenRunCommand(commandPath);
   }
@@ -117,8 +117,12 @@ Future<String> _createEntrypoint(
   }
 
   final TizenProject tizenProject = TizenProject.fromFlutter(project);
+  if (!tizenProject.existsSync()) {
+    return targetFile;
+  }
   final Directory registryDirectory = tizenProject.managedDirectory;
-  final File entrypoint = registryDirectory.childFile('main.dart');
+  final File entrypoint = registryDirectory.childFile('main.dart')
+    ..createSync(recursive: true);
   final PackageConfig packageConfig = await loadPackageConfigWithLogging(
     project.directory.childFile('.packages'),
     logger: globals.logger,


### PR DESCRIPTION
- All device names are hard-coded as 'Tizen'
- '-d tizen' is set automatically if the device ID is not specified
- Fix an issue with initializing the flutter repo at first launch
- Check if the project is valid before creating an entrypoint file