### PR TITLE
Add 'emulators' subcommand to flutter-tizen

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -85,7 +85,7 @@ Future<void> main(List<String> args) async {
         TemplateRenderer: () => const MustacheTemplateRenderer(),
         DoctorValidatorsProvider: () => TizenDoctorValidatorsProvider(),
         EmulatorManager: () => TizenEmulatorManager(
-              tizenSdk: TizenSdk.locateSdk(),
+              tizenSdk: TizenSdk.instance,
               androidSdk: globals.androidSdk,
               processManager: globals.processManager,
               logger: globals.logger,

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -5,6 +5,7 @@
 
 import 'package:flutter_tools/executable.dart' as flutter;
 import 'package:flutter_tools/runner.dart' as runner;
+import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -13,9 +14,11 @@ import 'package:flutter_tools/src/build_runner/mustache_template.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/commands/config.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
+import 'package:flutter_tools/src/commands/emulators.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/commands/format.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
+import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -32,6 +35,8 @@ import 'commands/packages.dart';
 import 'commands/run.dart';
 import 'tizen_device_discovery.dart';
 import 'tizen_doctor.dart';
+import 'tizen_emulator.dart';
+import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
 
 /// Main entry point for commands.
@@ -59,6 +64,7 @@ Future<void> main(List<String> args) async {
             DoctorCommand(verbose: verboseHelp),
             FormatCommand(),
             LogsCommand(),
+            EmulatorsCommand(),
             // Commands extended for Tizen.
             TizenAnalyzeCommand(verboseHelp: verboseHelp),
             TizenAttachCommand(verboseHelp: verboseHelp),
@@ -78,6 +84,14 @@ Future<void> main(List<String> args) async {
         DeviceManager: () => TizenDeviceManager(),
         TemplateRenderer: () => const MustacheTemplateRenderer(),
         DoctorValidatorsProvider: () => TizenDoctorValidatorsProvider(),
+        EmulatorManager: () => TizenEmulatorManager(
+              tizenSdk: TizenSdk.locateSdk(),
+              androidSdk: globals.androidSdk,
+              processManager: globals.processManager,
+              logger: globals.logger,
+              fileSystem: globals.fs,
+              androidWorkflow: androidWorkflow,
+            ),
         // [LoggerFactory] is not needed for now.
         if (verbose)
           Logger: () => VerboseLogger(StdoutLogger(

--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -75,16 +75,14 @@ class TizenEmulatorManager extends EmulatorManager {
 
     final PlatformImage platformImage = _getPreferredPlatformImage();
     if (platformImage == null) {
-      return CreateEmulatorResult(name,
-          success: false,
-          error:
-              'No suitable Tizen platform images are available. You may need to install these'
-              ' using the Tizen Package Manager.'
-              'Visit the link below to see how to create Tizen platform images for emulators:'
-              ' https://docs.tizen.org/application/tizen-studio/setup/update-sdk/#installing-additional-packages');
+      return CreateEmulatorResult(
+        name,
+        success: false,
+        error: 'No suitable Tizen platform images are available.\n'
+               'You may need to install these using the Tizen Package Manager.',
+      );
     }
 
-    // throwOnError: when should we use or not use?
     final RunResult runResult = await _processUtils.run(
       <String>[
         _tizenSdk.emCli.path,
@@ -238,10 +236,7 @@ class TizenEmulators extends EmulatorDiscovery {
   bool get canListAnything => _tizenSdk?.emCli?.existsSync() ?? false;
 
   @override
-  Future<List<Emulator>> get emulators => _getEmulators();
-
-  // set future and async but not using await?
-  Future<List<Emulator>> _getEmulators() async {
+  Future<List<Emulator>> get emulators async {
     if (!canListAnything) {
       // Although this method doesn't run the `tizenSdk.emCli` command
       // to get emulator info, logically, emulator info shouldn't be
@@ -332,10 +327,13 @@ class TizenEmulator extends Emulator {
   /// See [AndroidEmulator.launch] in [android_emulator.dart] (simplified)
   @override
   Future<void> launch() async {
-    // Null checking on _tizenSdk.emCli.path is already
-    // done at `TizenEmulators._getEmulators`.
+    final String emCliPath = _tizenSdk?.emCli?.path;
+    if (emCliPath == null) {
+      throwToolExit('Unable to locate Tizen Emulator Manager.');
+    }
+
     final List<String> args = <String>[
-      _tizenSdk.emCli.path,
+      emCliPath,
       'launch',
       '--name',
       id,
@@ -343,7 +341,7 @@ class TizenEmulator extends Emulator {
 
     final RunResult runResult = await _processUtils.run(args);
     if (runResult.exitCode == 0) {
-      globals.printStatus('Successfully launched a Tizen emulator, $id.');
+      globals.printStatus('Successfully launched Tizen emulator, $id.');
     } else if (runResult.exitCode == 2) {
       globals.printStatus('Tizen emulator $id is already running.');
     } else {

--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -1,0 +1,346 @@
+// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/emulator.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+import 'package:xml/xml.dart';
+
+class TizenEmulatorManager extends EmulatorManager {
+  TizenEmulatorManager({
+    @required AndroidSdk androidSdk,
+    @required AndroidWorkflow androidWorkflow,
+    @required FileSystem fileSystem,
+    @required Logger logger,
+    @required ProcessManager processManager,
+    @required TizenSdk tizenSdk,
+  })  : _processUtils =
+            ProcessUtils(logger: logger, processManager: processManager),
+        _tizenSdk = tizenSdk,
+        _tizenEmulators = TizenEmulators(
+          fileSystem: fileSystem,
+          logger: logger,
+          processManager: processManager,
+          tizenSdk: tizenSdk,
+        ),
+        super(
+          androidSdk: androidSdk,
+          androidWorkflow: androidWorkflow,
+          fileSystem: fileSystem,
+          logger: logger,
+          processManager: processManager,
+        );
+
+  final ProcessUtils _processUtils;
+  final TizenSdk _tizenSdk;
+  final TizenEmulators _tizenEmulators;
+
+  /// Create Tizen emulators
+  @override
+  Future<CreateEmulatorResult> createEmulator({String name}) async {
+    if (name == null || name.isEmpty) {
+      const String autoName = 'flutter_emulator';
+      final List<Emulator> all = await getAllAvailableEmulators();
+      final Set<String> takenNames = all
+          .map<String>((Emulator e) => e.id)
+          .where((String id) => id.startsWith(autoName))
+          .toSet();
+      int suffix = 1;
+      name = autoName;
+      while (takenNames.contains(name)) {
+        name = '${autoName}_${++suffix}';
+      }
+    }
+    if (!_tizenEmulators.canLaunchAnything) {
+      return CreateEmulatorResult(name,
+          success: false,
+          error: 'emulator manager is missing from the Tizen Studio');
+    }
+
+    final PlatformImage platformImage = await _getPreferredPlatformImage();
+    if (platformImage == null) {
+      return CreateEmulatorResult(name,
+          success: false,
+          error:
+              'No suitable Tizen platform images are available. You may need to install these'
+              ' using the package manager.');
+    }
+    final RunResult runResult = await _processUtils.run(<String>[
+      getEmCliPath(),
+      'create',
+      '-n',
+      name,
+      '-p',
+      platformImage.name,
+      '-t',
+      preferredDevices[platformImage.profile],
+    ]);
+    return CreateEmulatorResult(name,
+        success: runResult.exitCode == 0, output: runResult.stdout);
+  }
+
+  static const Map<String, String> preferredDevices = <String, String>{
+    'tv': 'HD1080 TV',
+    'wearable': 'Wearable Circle',
+  };
+
+  static const Map<String, int> profilePriority = <String, int>{
+    'tv': 1,
+    'wearable': 2,
+  };
+
+  Future<List<PlatformImage>> _loadAllPlatformImages() async {
+    final Directory platforms = _tizenSdk.directory.childDirectory('platforms');
+    if (!await platforms.exists()) {
+      return <PlatformImage>[];
+    }
+
+    final List<PlatformImage> platformImages = <PlatformImage>[];
+    await for (final FileSystemEntity entity in platforms.list()) {
+      if (entity is Directory) {
+        platformImages.addAll(await _loadPlatformImagesPerVersion(entity));
+      }
+    }
+    return platformImages;
+  }
+
+  Future<List<PlatformImage>> _loadPlatformImagesPerVersion(
+      Directory platformDirectory) async {
+    final List<PlatformImage> platformImages = <PlatformImage>[];
+    await for (final FileSystemEntity entity in platformDirectory.list()) {
+      if (entity is Directory) {
+        platformImages.addAll(await _loadPlatformImagesPerProfile(entity));
+      }
+    }
+    return platformImages;
+  }
+
+  Future<List<PlatformImage>> _loadPlatformImagesPerProfile(
+      Directory profileDirectory) async {
+    final Directory emulatorImages =
+        profileDirectory.childDirectory('emulator-images');
+    if (!await emulatorImages.exists()) {
+      return <PlatformImage>[];
+    }
+
+    final List<PlatformImage> platformImages = <PlatformImage>[];
+    await for (final FileSystemEntity entity in emulatorImages.list()) {
+      if (entity is Directory && entity.basename != 'add-ons') {
+        final File infoFile = entity.childFile('info.ini');
+        if (await infoFile.exists()) {
+          final Map<String, String> info =
+              parseIniLines(await infoFile.readAsLines());
+          if (info.containsKey('name') &&
+              info.containsKey('profile') &&
+              info.containsKey('version')) {
+            platformImages.add(PlatformImage(
+              name: info['name'],
+              profile: info['profile'],
+              version: info['version'],
+            ));
+          }
+        }
+      }
+    }
+    return platformImages;
+  }
+
+  Future<PlatformImage> _getPreferredPlatformImage() async {
+    final List<PlatformImage> platformImages = await _loadAllPlatformImages();
+    
+    // Selects an image with the highest platform version among available profiles. 
+    // TV profiles have priority over wearable profiles.
+    platformImages?.sort((PlatformImage a, PlatformImage b) {
+      if (a.profile == b.profile) {
+        return -a.version.compareTo(b.version);
+      }
+      return profilePriority[a.profile].compareTo(profilePriority[b.profile]);
+    });
+    return platformImages?.first;
+  }
+
+  @override
+  Future<List<Emulator>> getAllAvailableEmulators() async {
+    final List<Emulator> emulators = await _tizenEmulators.emulators;
+    emulators.addAll(await super.getAllAvailableEmulators());
+    return emulators;
+  }
+
+  @override
+  bool get canListAnything {
+    return super.canListAnything || _tizenEmulators.canListAnything;
+  }
+}
+
+class PlatformImage {
+  PlatformImage(
+      {@required this.name, @required this.profile, @required this.version});
+
+  final String name;
+  final String profile;
+  final String version;
+
+  @override
+  String toString() => '$name $profile $version';
+}
+
+class TizenEmulators extends EmulatorDiscovery {
+  TizenEmulators({
+    @required FileSystem fileSystem,
+    @required Logger logger,
+    @required ProcessManager processManager,
+    @required TizenSdk tizenSdk,
+  })  : _fileSystem = fileSystem,
+        _logger = logger,
+        _processManager = processManager,
+        _tizenSdk = tizenSdk;
+
+  final FileSystem _fileSystem;
+  final Logger _logger;
+  final ProcessManager _processManager;
+  final TizenSdk _tizenSdk;
+
+  Directory _emulatorDirectory;
+
+  @override
+  // TODO(HakkyuKim): fix the code so that it actually evaluates the bool value
+  bool get canLaunchAnything => true;
+  @override
+  // TODO(HakkyuKim): fix the code so that it actually evaluates the bool value
+  bool get canListAnything => true;
+
+  @override
+  Future<List<Emulator>> get emulators => _getEmulators();
+
+  Future<Directory> _getTizenSdkDataDirectory() async {
+    final File sdkInfo = _tizenSdk.directory.childFile('sdk.info');
+    if (await sdkInfo.exists()) {
+      final List<String> lines = await sdkInfo.readAsLines();
+      for (final String line in lines) {
+        final List<String> tokens = line.split('=');
+        if (tokens[0].trim() == 'TIZEN_SDK_DATA_PATH') {
+          return _fileSystem.directory(tokens[1].trim());
+        }
+      }
+    }
+    return null;
+  }
+
+  Future<List<Emulator>> _getEmulators() async {
+    final Directory tizenSdkDataDirectory = await _getTizenSdkDataDirectory();
+    if (tizenSdkDataDirectory == null) {
+      return <Emulator>[];
+    }
+    _emulatorDirectory =
+        tizenSdkDataDirectory.childDirectory('emulator').childDirectory('vms');
+
+    final List<Emulator> emulators = <Emulator>[];
+    if (await _emulatorDirectory.exists()) {
+      await for (final FileSystemEntity entity in _emulatorDirectory.list()) {
+        if (entity is Directory &&
+            await entity.childFile('vm_config.xml').exists()) {
+          final String id = entity.basename;
+          emulators.add(await _loadEmulatorInfo(id));
+        }
+      }
+    }
+    return emulators;
+  }
+
+  Future<TizenEmulator> _loadEmulatorInfo(String id) async {
+    id = id.trim();
+    final File configFile =
+        _emulatorDirectory.childDirectory(id).childFile('vm_config.xml');
+    final Map<String, String> properties = <String, String>{};
+
+    final XmlDocument xmlDocument =
+        XmlDocument.parse(await configFile.readAsString());
+    final String name = xmlDocument.findAllElements('name').first.text;
+    final XmlElement diskImage = xmlDocument.findAllElements('diskImage').first;
+    final String profile = diskImage.getAttribute('profile');
+    final String version = diskImage.getAttribute('version');
+    properties['name'] = name;
+    properties['profile'] = profile;
+    properties['version'] = version;
+
+    return TizenEmulator(id,
+        properties: properties,
+        logger: _logger,
+        processManager: _processManager);
+  }
+
+  @override
+  // TODO(HakkyuKim): fix the code so that it actually evaluates the bool value
+  bool get supportsPlatform => true;
+}
+
+class TizenEmulator extends Emulator {
+  TizenEmulator(String id,
+      {Map<String, String> properties,
+      @required Logger logger,
+      @required ProcessManager processManager})
+      : _properties = properties,
+        _processUtils =
+            ProcessUtils(logger: logger, processManager: processManager),
+        super(id, properties != null && properties.isNotEmpty);
+
+  final Map<String, String> _properties;
+  final ProcessUtils _processUtils;
+
+  String _prop(String name) => _properties != null ? _properties[name] : null;
+
+  // Should we subcategorize it based on Tizen profile?
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  Future<void> launch() async {
+    // TODO(HakkyuKim): launch is overly simplified, for example, it currently doesn't record the emulator process.
+    /// See [AndroidEmulator.launch()] in [android_emulator.dart]
+    final List<String> args = <String>[getEmCliPath(), 'launch', '--name', id];
+    await _processUtils.run(args);
+    return;
+  }
+
+  @override
+  String get manufacturer => 'Samsung';
+
+  @override
+  String get name => id;
+
+  // This should be changed to Tizen later
+  @override
+  PlatformType get platformType => PlatformType.linux;
+
+  String get profile => _prop('profile');
+
+  String get version => _prop('version');
+}
+
+Map<String, String> parseIniLines(List<String> contents) {
+  final Map<String, String> results = <String, String>{};
+
+  final Iterable<List<String>> properties = contents
+      .map<String>((String l) => l.trim())
+      // Strip blank lines/comments
+      .where((String l) => l != '' && !l.startsWith('#'))
+      // Discard anything that isn't simple name=value
+      .where((String l) => l.contains('='))
+      // Split into name/value
+      .map<List<String>>((String l) => l.split('='));
+
+  for (final List<String> property in properties) {
+    results[property[0].trim()] = property[1].trim();
+  }
+
+  return results;
+}

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -7,6 +7,10 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
+String getEmCliPath() {
+  return TizenSdk.instance?.emCli?.path;
+}
+
 String getSdbPath() {
   return TizenSdk.instance?.sdb?.path;
 }
@@ -49,6 +53,11 @@ class TizenSdk {
   Directory get platformsDirectory => directory.childDirectory('platforms');
 
   Directory get toolsDirectory => directory.childDirectory('tools');
+
+  File get emCli => toolsDirectory
+      .childDirectory('emulator')
+      .childDirectory('bin')
+      .childFile('em-cli');
 
   File get sdb => toolsDirectory.childFile('sdb');
 

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -7,10 +7,6 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
-String getEmCliPath() {
-  return TizenSdk.instance?.emCli?.path;
-}
-
 String getSdbPath() {
   return TizenSdk.instance?.sdb?.path;
 }
@@ -51,6 +47,17 @@ class TizenSdk {
   final Directory directory;
 
   Directory get platformsDirectory => directory.childDirectory('platforms');
+
+  Directory get sdkDataDirectory {
+    final File sdkInfo = directory.childFile('sdk.info');
+    if (sdkInfo.existsSync()) {
+       final Map<String, String> info = parseIniLines(sdkInfo.readAsLinesSync());
+       if(info.containsKey('TIZEN_SDK_DATA_PATH')){
+         return globals.fs.directory(info['TIZEN_SDK_DATA_PATH']);
+       }
+    }
+    return null;
+  }
 
   Directory get toolsDirectory => directory.childDirectory('tools');
 
@@ -94,4 +101,28 @@ class TizenSdk {
 
     return rootstrapName;
   }
+}
+
+Map<String, String> parseIniLines(List<String> contents) {
+  final Map<String, String> results = <String, String>{};
+
+  final Iterable<List<String>> properties = contents
+      .map<String>((String l) => l.trim())
+      // Strip blank lines/comments
+      .where((String l) => l != '' && !l.startsWith('#'))
+      // Discard anything that isn't simple name=value
+      .where((String l) => l.contains('='))
+      // Split into name/value
+      // The parser method assumes no equal signs(=) in 'name',
+      // so the method splits the string at the first equal sign.
+      .map<List<String>>((String l){
+        final int splitPos = l.indexOf('=');
+        return <String>[l.substring(0, splitPos), l.substring(splitPos + 1)];
+      });
+
+  for (final List<String> property in properties) {
+    results[property[0].trim()] = property[1].trim();
+  }
+
+  return results;
 }


### PR DESCRIPTION
This pr adds `flutter-tizen emulators` subcommand feature.

+ `flutter-tizen emulators` : lists created emulators.
+ `flutter-tizen emulators --launch <name>`: launches one of the created emulators with the name `<name>`. `<name>` can also be specified as a prefix of one of the emulators.
+ `flutter-tizen emulators --create --name <name>`: creates a new TV or wearable emulator. If both images are installed, TV profiles have priority over wearable ones. If multiple platform versions of the same profile are installed, the one with the highest version will be chosen.

Limitation

+ `flutter-tizen emulators -h` help message currently describes about creating Android emulators.
+ Android Studio(AVD Manager) must be installed for the command to work.

Both limitations can be resolved by creating the `TizenEmulatorCommand` class that inherits the `FlutterCommand`. This should be revisited when its necessary.