### PR TITLE
Use model id as tizen device name

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -130,7 +130,7 @@ class TizenDevice extends Device {
   Future<String> get sdkNameAndVersion async => 'Tizen $platformVersion';
 
   @override
-  String get name => 'Tizen';
+  String get name => 'Tizen ' + _modelId;
 
   bool get usesSecureProtocol => getCapability('secure_protocol') == 'enabled';
 


### PR DESCRIPTION
Me and swift-kim came to the conclusion that this way is best without any upstream modification.

## After landing this PR
```bash
flutter-tizen devices
8 connected devices:

SM N950N (mobile)                • ce0717175871bf22017e • android-arm64  • Android 9 (API 28)
Linux (desktop)                  • linux                • linux-x64      • Linux
Web Server (web)                 • web-server           • web-javascript • Flutter Tools
Chrome (web)                     • chrome               • web-javascript • Google Chrome 87.0.4280.66
Tizen W-6.0-circle-x86 (mobile)  • emulator-26121       • flutter-tester • Tizen 6.0 (emulator)
Tizen T-samsung-5.5-x86 (mobile) • emulator-26111       • flutter-tester • Tizen 5.5 (emulator)
Tizen M-6.0-x86 (mobile)         • emulator-26101       • flutter-tester • Tizen 6.0 (emulator)
Tizen TM1 (mobile)               • 0000d84f00006200     • flutter-tester • Tizen 6.0

```
``` bash
flutter-tizen run
Multiple devices found:
Tizen W-6.0-circle-x86 (mobile)  • emulator-26121   • flutter-tester • Tizen 6.0 (emulator)
Tizen T-samsung-5.5-x86 (mobile) • emulator-26111   • flutter-tester • Tizen 5.5 (emulator)
Tizen M-6.0-x86 (mobile)         • emulator-26101   • flutter-tester • Tizen 6.0 (emulator)
Tizen TM1 (mobile)               • 0000d84f00006200 • flutter-tester • Tizen 6.0
[0]: Tizen W-6.0-circle-x86 (emulator-26121)
[1]: Tizen T-samsung-5.5-x86 (emulator-26111)
[2]: Tizen M-6.0-x86 (emulator-26101)
[3]: Tizen TM1 (0000d84f00006200)
Please choose one (To quit, press "q/Q"): 
```
Signed-off-by: Boram Bae <boram21.bae@samsung.com>