### PR TITLE
Misc changes and clean up

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -112,7 +112,7 @@ Not all commands in the [`flutter`](https://flutter.dev/docs/reference/flutter-c
 
 - ### `emulators`
 
-  List and launch Tizen emulators.
+  List and launch emulators. Currently only works with Tizen emulators.
 
   ```sh
   # List all emulator instances.

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -5,7 +5,6 @@
 
 import 'package:flutter_tools/executable.dart' as flutter;
 import 'package:flutter_tools/runner.dart' as runner;
-import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -32,6 +31,7 @@ import 'commands/drive.dart';
 import 'commands/install.dart';
 import 'commands/packages.dart';
 import 'commands/run.dart';
+import 'tizen_artifacts.dart';
 import 'tizen_device_discovery.dart';
 import 'tizen_doctor.dart';
 import 'tizen_emulator.dart';
@@ -61,9 +61,9 @@ Future<void> main(List<String> args) async {
             ConfigCommand(verboseHelp: verboseHelp),
             DevicesCommand(),
             DoctorCommand(verbose: verboseHelp),
+            EmulatorsCommand(),
             FormatCommand(),
             LogsCommand(),
-            EmulatorsCommand(),
             // Commands extended for Tizen.
             TizenAnalyzeCommand(verboseHelp: verboseHelp),
             TizenAttachCommand(verboseHelp: verboseHelp),
@@ -83,15 +83,17 @@ Future<void> main(List<String> args) async {
         DeviceManager: () => TizenDeviceManager(),
         TemplateRenderer: () => const MustacheTemplateRenderer(),
         DoctorValidatorsProvider: () => TizenDoctorValidatorsProvider(),
+        TizenSdk: () => TizenSdk.locateSdk(),
+        TizenArtifacts: () => TizenArtifacts(),
+        TizenWorkflow: () => TizenWorkflow(),
+        TizenValidator: () => TizenValidator(),
         EmulatorManager: () => TizenEmulatorManager(
-              tizenSdk: TizenSdk.instance,
-              androidSdk: globals.androidSdk,
+              tizenSdk: tizenSdk,
+              tizenWorkflow: tizenWorkflow,
               processManager: globals.processManager,
               logger: globals.logger,
               fileSystem: globals.fs,
-              androidWorkflow: androidWorkflow,
             ),
-        // [LoggerFactory] is not needed for now.
         if (verbose)
           Logger: () => VerboseLogger(StdoutLogger(
                 timeoutConfiguration: timeoutConfiguration,

--- a/lib/tizen_artifacts.dart
+++ b/lib/tizen_artifacts.dart
@@ -4,9 +4,12 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+
+TizenArtifacts get tizenArtifacts => context.get<TizenArtifacts>();
 
 /// See: [getNameForTargetPlatform] in `build_info.dart`
 String getArchForTargetPlatform(TargetPlatform platform) {
@@ -35,8 +38,6 @@ TargetPlatform getTargetPlatformForArch(String arch) {
 /// It's unable to extend [Artifacts] directly because it has no visible
 /// constructor.
 class TizenArtifacts extends CachedArtifacts {
-  static TizenArtifacts get instance => TizenArtifacts();
-
   /// See: [Cache.getArtifactDirectory] in `cache.dart`
   Directory getArtifactDirectory(String name) {
     return globals.fs

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -79,9 +79,8 @@ class TizenPlugins extends Target {
           buildDir.childFile('lib' + (plugin.toMap()['sofile'] as String));
 
       for (final String arch in targetArchs) {
-        final TizenSdk tizenSdk = TizenSdk.instance;
-        final Directory engineDir = TizenArtifacts.instance
-            .getEngineDirectory(getTargetPlatformForArch(arch), buildMode);
+        final Directory engineDir = tizenArtifacts.getEngineDirectory(
+            getTargetPlatformForArch(arch), buildMode);
         final Directory commonDir = engineDir.parent.childDirectory('common');
         final Directory clientWrapperDir =
             commonDir.childDirectory('client_wrapper');
@@ -194,8 +193,8 @@ abstract class DotnetTpk extends Target {
           .childDirectory(arch)
             ..createSync(recursive: true);
 
-      final Directory engineDir = TizenArtifacts.instance
-          .getEngineDirectory(getTargetPlatformForArch(arch), buildMode);
+      final Directory engineDir = tizenArtifacts.getEngineDirectory(
+          getTargetPlatformForArch(arch), buildMode);
       final File engineBinary = engineDir.childFile('libflutter.so');
       final File icuData =
           engineDir.parent.childDirectory('common').childFile('icudtl.dat');
@@ -450,8 +449,8 @@ abstract class NativeTpk extends Target {
     final Directory libDir = tizenDir.childDirectory('lib')
       ..createSync(recursive: true);
 
-    final Directory engineDir = TizenArtifacts.instance
-        .getEngineDirectory(getTargetPlatformForArch(targetArch), buildMode);
+    final Directory engineDir = tizenArtifacts.getEngineDirectory(
+        getTargetPlatformForArch(targetArch), buildMode);
     final File engineBinary = engineDir.childFile('libflutter.so');
     final File icuData =
         engineDir.parent.childDirectory('common').childFile('icudtl.dat');
@@ -488,7 +487,6 @@ abstract class NativeTpk extends Target {
           .addAll(await pluginProject.getPropertyAsAbsolutePaths('USER_SRCS'));
     }
 
-    final TizenSdk tizenSdk = TizenSdk.instance;
     final Directory commonDir = engineDir.parent.childDirectory('common');
     final Directory clientWrapperDir =
         commonDir.childDirectory('client_wrapper');

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -82,7 +82,7 @@ class TizenBuilder {
       buildDir: project.dartTool.childDirectory('flutter_build'),
       cacheDir: globals.cache.getRoot(),
       flutterRootDir: globals.fs.directory(Cache.flutterRoot),
-      engineVersion: TizenArtifacts.instance.isLocalEngine
+      engineVersion: tizenArtifacts.isLocalEngine
           ? null
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
@@ -101,7 +101,7 @@ class TizenBuilder {
         if (buildInfo.extraFrontEndOptions?.isNotEmpty ?? false)
           kExtraFrontEndOptions: buildInfo.extraFrontEndOptions.join(','),
       },
-      artifacts: TizenArtifacts.instance,
+      artifacts: tizenArtifacts,
       fileSystem: globals.fs,
       logger: globals.logger,
       processManager: globals.processManager,

--- a/lib/tizen_device_discovery.dart
+++ b/lib/tizen_device_discovery.dart
@@ -21,6 +21,7 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'tizen_device.dart';
+import 'tizen_doctor.dart';
 import 'tizen_sdk.dart';
 
 /// An extended [DeviceManager] for managing Tizen devices.
@@ -51,7 +52,8 @@ class TizenDeviceManager extends FlutterDeviceManager {
   @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[
         ...super.deviceDiscoverers,
-        TizenDevices(
+        TizenDeviceDiscovery(
+          tizenWorkflow: tizenWorkflow,
           logger: globals.logger,
           processManager: globals.processManager,
         ),
@@ -61,26 +63,28 @@ class TizenDeviceManager extends FlutterDeviceManager {
 /// Device discovery for Tizen devices.
 ///
 /// Source: [AndroidDevices] in `android_device_discovery.dart`
-class TizenDevices extends PollingDeviceDiscovery {
-  TizenDevices({
+class TizenDeviceDiscovery extends PollingDeviceDiscovery {
+  TizenDeviceDiscovery({
+    @required TizenWorkflow tizenWorkflow,
     @required ProcessManager processManager,
     @required Logger logger,
-  })  : _logger = logger,
+  })  : _tizenWorkflow = tizenWorkflow,
+        _logger = logger,
         _processManager = processManager,
-        _processUtils = ProcessUtils(
-            logger: logger ?? globals.logger,
-            processManager: processManager ?? globals.processManager),
+        _processUtils =
+            ProcessUtils(logger: logger, processManager: processManager),
         super('Tizen devices');
 
+  final TizenWorkflow _tizenWorkflow;
   final Logger _logger;
   final ProcessManager _processManager;
   final ProcessUtils _processUtils;
 
   @override
-  bool get supportsPlatform => true;
+  bool get supportsPlatform => _tizenWorkflow.appliesToHostPlatform;
 
   @override
-  bool get canListAnything => getSdbPath() != null;
+  bool get canListAnything => _tizenWorkflow.canListDevices;
 
   @override
   Future<List<Device>> pollingGetDevices({Duration timeout}) async {

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -4,10 +4,14 @@
 
 import 'package:flutter_tools/src/android/android_studio_validator.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import 'tizen_sdk.dart';
+
+TizenWorkflow get tizenWorkflow => context.get<TizenWorkflow>();
+TizenValidator get tizenValidator => context.get<TizenValidator>();
 
 /// See: [_DefaultDoctorValidatorsProvider] in `doctor.dart`
 class TizenDoctorValidatorsProvider extends DoctorValidatorsProvider {
@@ -19,7 +23,7 @@ class TizenDoctorValidatorsProvider extends DoctorValidatorsProvider {
       // Append before any IDE validators.
       if (validator is AndroidStudioValidator ||
           validator is NoAndroidStudioValidator) {
-        validators.insert(validators.indexOf(validator), TizenValidator());
+        validators.insert(validators.indexOf(validator), tizenValidator);
         break;
       }
     }
@@ -29,7 +33,7 @@ class TizenDoctorValidatorsProvider extends DoctorValidatorsProvider {
   @override
   List<Workflow> get workflows => <Workflow>[
         ...DoctorValidatorsProvider.defaultInstance.workflows,
-        TizenWorkflow(),
+        tizenWorkflow,
       ];
 }
 
@@ -38,7 +42,7 @@ class TizenValidator extends DoctorValidator {
   TizenValidator() : super('Tizen toolchain - develop for Tizen devices');
 
   bool _checkPackages(List<ValidationMessage> messages) {
-    final TizenSdk tizenSdk = TizenSdk.instance;
+    // tizenSdk is not null here.
     final String platformVersion = tizenSdk.defaultTargetPlatform;
     final String gccVersion = tizenSdk.defaultGccVersion;
 
@@ -106,11 +110,11 @@ class TizenWorkflow extends Workflow {
   bool get appliesToHostPlatform => globals.platform.isLinux;
 
   @override
-  bool get canLaunchDevices => getSdbPath() != null;
+  bool get canLaunchDevices => tizenSdk != null;
 
   @override
-  bool get canListDevices => getSdbPath() != null;
+  bool get canListDevices => tizenSdk != null;
 
   @override
-  bool get canListEmulators => getSdbPath() != null;
+  bool get canListEmulators => tizenSdk != null && tizenSdk.emCli.existsSync();
 }


### PR DESCRIPTION
- Make more use of context overrides instead of singletons
- Rename TizenDevices to TizenDeviceDiscovery
- Unsupport Android emulators in TizenEmulatorManager to suppress
  exceptions when Android SDK is missing
- Fix a state error when no platform images are available
- Replace parseIniLines with parseIniFile to avoid a naming conflict
- Make use of TizenWorkflow in tizen_emulator.dart
- General clean-ups