### PR TITLE
Allow tabs when splitting by pattern in pollingGetDevices

### DIFF
--- a/lib/tizen_device_discovery.dart
+++ b/lib/tizen_device_discovery.dart
@@ -110,7 +110,7 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
         continue;
       }
 
-      final List<String> splitLine = line.split(RegExp(r'\s{2,}'));
+      final List<String> splitLine = line.split(RegExp(r'\s{2,}|\t'));
       if (splitLine.length != 3) {
         continue;
       }


### PR DESCRIPTION
Tested in https://regexr.com with this example text:
```
Device ID   device   Model
Device_ID	device	Model
Device_ID 	device  Model
Device_ID	  device  Model
```