### PR TITLE
Fix engine arugments passing on TV devices

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -82,7 +82,7 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
     final TizenBuildInfo tizenBuildInfo = TizenBuildInfo(
       buildInfo,
       targetArchs: stringsArg('target-arch'),
-      profile: stringArg('security-profile'),
+      securityProfile: stringArg('security-profile'),
     );
     validateBuild(tizenBuildInfo);
 

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -211,7 +211,7 @@ abstract class DotnetTpk extends Target {
 
     // For now a constant value is used instead of reading from a file.
     // Keep this value in sync with the latest published nuget version.
-    const String embeddingVersion = '1.0.3';
+    const String embeddingVersion = '1.1.0';
 
     // Run .NET build.
     if (getDotnetCliPath() == null) {
@@ -246,7 +246,7 @@ abstract class DotnetTpk extends Target {
     // We need to re-generate the TPK by signing with a correct profile.
     // TODO(swift-kim): Apply the profile during .NET build for efficiency.
     // Password descryption by secret-tool will be needed for full automation.
-    if (buildInfo.profile?.isEmpty ?? true) {
+    if (buildInfo.securityProfile?.isEmpty ?? true) {
       environment.logger.printStatus('The active profile is used for signing.');
     }
     result = await _processUtils.run(<String>[
@@ -254,9 +254,9 @@ abstract class DotnetTpk extends Target {
       'package',
       '-t',
       'tpk',
-      if (buildInfo.profile?.isNotEmpty ?? false) ...<String>[
+      if (buildInfo.securityProfile?.isNotEmpty ?? false) ...<String>[
         '-s',
-        buildInfo.profile,
+        buildInfo.securityProfile,
       ],
       '--',
       outputDir.childFile(tizenProject.outputTpkName).path,
@@ -541,9 +541,9 @@ abstract class NativeTpk extends Target {
       'package',
       '-t',
       'tpk',
-      if (buildInfo.profile?.isNotEmpty ?? false) ...<String>[
+      if (buildInfo.securityProfile?.isNotEmpty ?? false) ...<String>[
         '-s',
-        buildInfo.profile,
+        buildInfo.securityProfile,
       ],
       '--',
       buildDir.path,

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -35,12 +35,12 @@ class TizenBuildInfo {
   const TizenBuildInfo(
     this.buildInfo, {
     @required this.targetArchs,
-    this.profile,
+    this.securityProfile,
   });
 
   final BuildInfo buildInfo;
   final List<String> targetArchs;
-  final String profile;
+  final String securityProfile;
 }
 
 /// See:

--- a/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>tizen60</TargetFramework>
+    <TargetFramework>tizen40</TargetFramework>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Tizen.Flutter.Embedding</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.1.0</Version>
     <Authors>flutter-tizen</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/flutter-tizen</PackageProjectUrl>

--- a/templates/app/csharp/Runner.csproj
+++ b/templates/app/csharp/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen60</TargetFramework>
+    <TargetFramework>tizen40</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/templates/app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/app/csharp/tizen-manifest.xml.tmpl
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest package="{{androidIdentifier}}" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
+<manifest package="{{androidIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{androidIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="6" launch_mode="single">
+    <ui-application appid="{{androidIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>


### PR DESCRIPTION
- Rename `TizenBuildInfo.profile` to `TizenBuildInfo.securityProfile` for clarity
- Do not use `__DLP_UNIT_TEST_ARG__` to pass engine arguments to an app any more. Instead, the tool writes the arguments to a plain text file `/home/owner/share/tmp/sdk_tools/{packageId}.rpm` before launching an app and the app reads it on launch (and deletes). This is the only workaround that works for any device type including secure protocol devices. I tried to make the file automatically expire after some time period (10 seconds) but failed after all. No side effect or problem has been found so far.
- Increase the embedding nuget version to 1.1.0
- Add Tizen 4.0 support to the app template
  - Change the API version to 4.0
  - Change the target framework moniker to tizen40
  - Change the C# API version to 4