### PR TITLE
Enable building plugins for Tizen 4.0

### DIFF
--- a/doc/install-tizen-sdk.md
+++ b/doc/install-tizen-sdk.md
@@ -26,6 +26,7 @@ The following packages are required by the flutter-tizen tool.
   - _[Tizen SDK tools] - [Native CLI]_
   - _[Tizen SDK tools] - [Native toolchain] - [Gcc 9.2 toolchain]_
   - _[Tizen SDK tools] - [Baseline SDK] - [Certificate Manager]_
+  - _[4.0 Wearable] - [Advanced] - [Native app. development (CLI)]_
   - _[5.5 Wearable] - [Advanced] - [Native app. development (CLI)]_
   - _[Extension SDK] - [Samsung Certificate Extension]_
 - **Optional**

--- a/doc/wsl-guide.md
+++ b/doc/wsl-guide.md
@@ -18,7 +18,8 @@ You can try out [flutter-tizen](https://github.com/flutter-tizen/flutter-tizen) 
 
    # Install required packages using package-manager-cli.
    ~/tizen-studio/package-manager/package-manager-cli.bin install \
-     NativeCLI NativeToolchain-Gcc-9.2 Certificate-Manager WEARABLE-5.5-NativeAppDevelopment-CLI
+     NativeCLI NativeToolchain-Gcc-9.2 Certificate-Manager \
+     WEARABLE-4.0-NativeAppDevelopment-CLI WEARABLE-5.5-NativeAppDevelopment-CLI
    ```
 
 1. (Linux) Install flutter-tizen and add to PATH.

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -4,6 +4,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:flutter_tizen/tizen_tpk.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/build.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -60,8 +61,11 @@ class TizenPlugins extends Target {
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
 
-    // Clear the output directory.
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
+    final String profile =
+        TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
+
+    // Clear the output directory.
     final Directory ephemeralDir = tizenProject.ephemeralDirectory;
     if (ephemeralDir.existsSync()) {
       ephemeralDir.deleteSync(recursive: true);
@@ -72,9 +76,6 @@ class TizenPlugins extends Target {
         await findTizenPlugins(project, filterNative: true);
 
     for (final TizenPlugin plugin in nativePlugins) {
-      final TizenNativeProject pluginProject = TizenNativeProject(plugin.path);
-      final String profile = pluginProject.getProperty('profile');
-
       final Directory pluginDir = environment.fileSystem.directory(plugin.path);
       final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
       final Directory buildDir = pluginDir.childDirectory(buildConfig);
@@ -433,10 +434,13 @@ abstract class NativeTpk extends Target {
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
 
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+    final String profile =
+        TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
+
     // Copy ephemeral files.
     // TODO(swift-kim): Use ephemeral directory instead of editable directory.
     final Directory outputDir = environment.outputDir;
-    final TizenProject tizenProject = TizenProject.fromFlutter(project);
     final Directory tizenDir = tizenProject.editableDirectory;
     final Directory resDir = tizenDir.childDirectory('res')
       ..createSync(recursive: true);
@@ -473,10 +477,6 @@ abstract class NativeTpk extends Target {
     // Prepare for build.
     final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
     final Directory buildDir = tizenDir.childDirectory(buildConfig);
-
-    final TizenNativeProject projectManifest =
-        TizenNativeProject(tizenProject.editableDirectory.path);
-    final String profile = projectManifest.getProperty('profile');
 
     final List<String> userIncludes = <String>[];
     final List<String> userSources = <String>[];

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:meta/meta.dart';
 
 TizenSdk get tizenSdk => context.get<TizenSdk>();
 
@@ -73,16 +74,20 @@ class TizenSdk {
       .childDirectory('bin')
       .childFile('tizen');
 
-  String get defaultTargetPlatform => '5.5';
+  String get defaultTargetPlatform => '4.0';
 
   String get defaultNativeCompiler => 'llvm-10.0';
 
   String get defaultGccVersion => '9.2';
 
-  String getFlutterRootstrap(String arch) {
-    // TODO(swift-kim): Always use wearable 5.5 rootstrap for plugin builds?
-    final String rootstrapName =
-        'wearable-5.5-${arch == 'x86' ? 'emulator' : 'device'}.flutter';
+  String getFlutterRootstrap({
+    String profile,
+    @required String arch,
+  }) {
+    final String version =
+        profile == null ? defaultTargetPlatform : profile.split('-').last;
+    final String type = arch == 'x86' ? 'emulator' : 'device';
+    final String rootstrapName = 'wearable-$version-$type.flutter';
 
     // Tizen SBI creates a list of rootstraps from this directory.
     final Directory pluginsDir = toolsDirectory

--- a/rootstraps/wearable-4.0-device.flutter.xml
+++ b/rootstraps/wearable-4.0-device.flutter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<extension point="rootstrapDefinition">
+  <rootstrap id="wearable-4.0-device.flutter" name="Tizen Device 4.0" version="Wearable 4.0" architecture="armel" path="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/wearable-4.0-device.core" supportToolchainType="tizen.core">
+    <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/info/wearable-4.0-device.core.dev.xml" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
+    <toolchain name="gcc" version="9.2" />
+    <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-4.0/common/efl-tool/efl-tools/bin/edje_cc" />
+  </rootstrap>
+</extension>

--- a/rootstraps/wearable-4.0-emulator.flutter.xml
+++ b/rootstraps/wearable-4.0-emulator.flutter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<extension point="rootstrapDefinition">
+  <rootstrap id="wearable-4.0-emulator.flutter" name="Tizen Emulator 4.0" version="Wearable 4.0" architecture="i586" path="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/wearable-4.0-emulator.core" supportToolchainType="tizen.core">
+    <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/info/wearable-4.0-emulator.core.dev.xml" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
+    <toolchain name="gcc" version="9.2" />
+    <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-4.0/common/efl-tool/efl-tools/bin/edje_cc" />
+  </rootstrap>
+</extension>

--- a/rootstraps/wearable-5.5-device.flutter.xml
+++ b/rootstraps/wearable-5.5-device.flutter.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <extension point="rootstrapDefinition">
-	<rootstrap id="wearable-5.5-device.flutter" name="Tizen Device 5.5" version="Wearable 5.5" architecture="armel" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-device.core" supportToolchainType="tizen.core">
-		<property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-device.core.dev.xml" />
-		<property key="LINKER_MISCELLANEOUS_OPTION" value="" />
-		<property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
-		<toolchain name="gcc" version="9.2" />
-		<tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />
-	</rootstrap>
+  <rootstrap id="wearable-5.5-device.flutter" name="Tizen Device 5.5" version="Wearable 5.5" architecture="armel" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-device.core" supportToolchainType="tizen.core">
+    <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-device.core.dev.xml" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
+    <toolchain name="gcc" version="9.2" />
+    <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />
+  </rootstrap>
 </extension>

--- a/rootstraps/wearable-5.5-emulator.flutter.xml
+++ b/rootstraps/wearable-5.5-emulator.flutter.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <extension point="rootstrapDefinition">
-	<rootstrap id="wearable-5.5-emulator.flutter" name="Tizen Emulator 5.5" version="Wearable 5.5" architecture="i586" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-emulator.core" supportToolchainType="tizen.core">
-		<property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-emulator.core.dev.xml" />
-		<property key="LINKER_MISCELLANEOUS_OPTION" value="" />
-		<property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
-		<toolchain name="gcc" version="9.2" />
-		<tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />
-	</rootstrap>
+  <rootstrap id="wearable-5.5-emulator.flutter" name="Tizen Emulator 5.5" version="Wearable 5.5" architecture="i586" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-emulator.core" supportToolchainType="tizen.core">
+    <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-emulator.core.dev.xml" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17" />
+    <toolchain name="gcc" version="9.2" />
+    <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />
+  </rootstrap>
 </extension>

--- a/templates/app/cpp/project_def.prop
+++ b/templates/app/cpp/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = flutterapp
 type = app
-profile = common-5.5
+profile = common-4.0
 
 # Source files
 USER_SRCS += src/flutterapp.cc

--- a/templates/app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/app/cpp/tizen-manifest.xml.tmpl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<manifest package="{{androidIdentifier}}" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
+<manifest package="{{androidIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="{{androidIdentifier}}" exec="flutterapp" type="capp" multiple="false" nodisplay="false" taskmanage="true">
         <label>{{projectName}}</label>

--- a/templates/plugin/cpp/project_def.prop.tmpl
+++ b/templates/plugin/cpp/project_def.prop.tmpl
@@ -3,7 +3,7 @@
 
 APPNAME = {{projectName}}_plugin
 type = sharedLib
-profile = common-5.5
+profile = common-4.0
 
 # Source files
 USER_SRCS += src/{{projectName}}_plugin.cc


### PR DESCRIPTION
- Set Tizen 4.0 as a default build platform
- Add Tizen 4.0 rootstraps
- Read target profiles (such as `common-4.0`, `wearable-5.5`) for native builds from tizen-manifest.xml file
- Efficiently read properties from manifest files (`project_def.prop`, `tizen-manifeset.xml`, `author-signature.xml`)