### PR TITLE
Add windows&macos platform support

### DIFF
--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -4,18 +4,12 @@
 # found in the LICENSE file.
 
 import os
-import platform
 import shutil
 import subprocess
 import sys
 import urllib.request
 import zipfile
-
-def isWin():
-    return sys.platform.startswith(('cygwin', 'win')) and platform.machine() == 'AMD64'
-
-def isLinux():
-    return sys.platform == 'linux' and platform.machine() == 'x86_64'
+from platform import machine
 
 def revision(sourceDir):
     command = f'cd {sourceDir} && git rev-parse HEAD'
@@ -41,11 +35,15 @@ def download(message, url, location):
         print(f'{message} Done     ')
 
 def main():
-    # Currently, gen_snapshot is only available for linux-x64.
-    
-    if not isWin() and not isLinux():
+    if not machine().endswith('64'):
         print('Not supported platform.')
         exit(1)
+    if sys.platform.startswith(('cygwin', 'win')):
+        platform = 'windows'
+    elif sys.platform == 'darwin':
+        platform = 'darwin'
+    else:
+        platform = 'linux'
 
     rootDir = os.path.abspath(__file__ + '/../..')
     cacheDir = rootDir + '/bin/cache'
@@ -82,9 +80,9 @@ def main():
               f'Remove directory {flutterDir} and try again.')
         exit(1)
 
-    flutterPath = flutterDir + '/bin/flutter'
-    if isWin():
-        flutterPath += '.bat'
+    exeSuffix = '.exe' if platform == 'windows' else ''
+    batSuffix = '.bat' if platform == 'windows' else ''
+    flutterPath = flutterDir + '/bin/flutter' + batSuffix
         
     flutterCacheDir = flutterDir + '/bin/cache'
     flutterStampPath = flutterCacheDir + '/flutter_tools.stamp'
@@ -95,11 +93,8 @@ def main():
         subprocess.run([flutterPath, '--version'], check=True)
 
     # Validate the Dart SDK.
-    dartPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/dart')
-    pubPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/pub')
-    if isWin():
-        dartPath += '.exe'
-        pubPath += '.bat'
+    dartPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/dart' + exeSuffix)
+    pubPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/pub' + batSuffix)
     if not os.path.isfile(dartPath) or not os.path.isfile(pubPath):
         print('Could not locate the Dart SDK.\n'
               f'Remove directory {flutterDir} and try again.')
@@ -143,11 +138,6 @@ def main():
     engineVersion = read(engineVersionPath)
     engineStampPath = engineCacheDir + '/engine.stamp'
     engineStamp = read(engineStampPath)
-    
-    if isLinux():
-        engineArchiveName = 'linux-x64'
-    else:
-        engineArchiveName = 'windows-x64'
 
     if engineVersion != engineStamp:
         if os.path.isdir(engineCacheDir):
@@ -158,11 +148,11 @@ def main():
             baseUrl = os.environ['BASE_URL']
         else:
             baseUrl = 'https://github.com/flutter-tizen/engine/releases'
-        archiveUrl = f'{baseUrl}/download/{engineVersion[:7]}/{engineArchiveName}.zip'
+        archiveUrl = f'{baseUrl}/download/{engineVersion[:7]}/{platform}-x64.zip'
         archivePath = engineCacheDir + '/artifacts.zip'
 
         try:
-            download(f'Downloading {engineArchiveName} tools...', archiveUrl, archivePath)
+            download(f'Downloading {platform}-x64 tools...', archiveUrl, archivePath)
         except:
             print(f'Failed to download engine artifacts from:\n  {archiveUrl}')
             raise
@@ -178,7 +168,7 @@ def main():
             os.remove(archivePath)
 
         # ZipFile.extractall() does not retain file permissions.
-        if isLinux():
+        if platform != 'windows':
             for root, _, files in os.walk(engineCacheDir):
                 for path in [f'{root}/{f}' for f in files if f == 'gen_snapshot']:
                     os.chmod(path, 0o755)

--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -11,6 +11,12 @@ import sys
 import urllib.request
 import zipfile
 
+def isWin():
+    return sys.platform.startswith(('cygwin', 'win')) and platform.machine() == 'AMD64'
+
+def isLinux():
+    return sys.platform == 'linux' and platform.machine() == 'x86_64'
+
 def revision(sourceDir):
     command = f'cd {sourceDir} && git rev-parse HEAD'
     return subprocess.run(
@@ -36,7 +42,8 @@ def download(message, url, location):
 
 def main():
     # Currently, gen_snapshot is only available for linux-x64.
-    if sys.platform != 'linux' or platform.machine() != 'x86_64':
+    
+    if not isWin() and not isLinux():
         print('Not supported platform.')
         exit(1)
 
@@ -76,6 +83,9 @@ def main():
         exit(1)
 
     flutterPath = flutterDir + '/bin/flutter'
+    if isWin():
+        flutterPath += '.bat'
+        
     flutterCacheDir = flutterDir + '/bin/cache'
     flutterStampPath = flutterCacheDir + '/flutter_tools.stamp'
     flutterStamp = read(flutterStampPath)
@@ -87,6 +97,9 @@ def main():
     # Validate the Dart SDK.
     dartPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/dart')
     pubPath = os.path.realpath(flutterCacheDir + '/dart-sdk/bin/pub')
+    if isWin():
+        dartPath += '.exe'
+        pubPath += '.bat'
     if not os.path.isfile(dartPath) or not os.path.isfile(pubPath):
         print('Could not locate the Dart SDK.\n'
               f'Remove directory {flutterDir} and try again.')
@@ -130,6 +143,11 @@ def main():
     engineVersion = read(engineVersionPath)
     engineStampPath = engineCacheDir + '/engine.stamp'
     engineStamp = read(engineStampPath)
+    
+    if isLinux():
+        engineArchiveName = 'linux-x64'
+    else:
+        engineArchiveName = 'windows-x64'
 
     if engineVersion != engineStamp:
         if os.path.isdir(engineCacheDir):
@@ -140,11 +158,11 @@ def main():
             baseUrl = os.environ['BASE_URL']
         else:
             baseUrl = 'https://github.com/flutter-tizen/engine/releases'
-        archiveUrl = f'{baseUrl}/download/{engineVersion[:7]}/linux-x64.zip'
+        archiveUrl = f'{baseUrl}/download/{engineVersion[:7]}/{engineArchiveName}.zip'
         archivePath = engineCacheDir + '/artifacts.zip'
 
         try:
-            download('Downloading linux-x64 tools...', archiveUrl, archivePath)
+            download(f'Downloading {engineArchiveName} tools...', archiveUrl, archivePath)
         except:
             print(f'Failed to download engine artifacts from:\n  {archiveUrl}')
             raise
@@ -160,9 +178,10 @@ def main():
             os.remove(archivePath)
 
         # ZipFile.extractall() does not retain file permissions.
-        for root, _, files in os.walk(engineCacheDir):
-            for path in [f'{root}/{f}' for f in files if f == 'gen_snapshot']:
-                os.chmod(path, 0o755)
+        if isLinux():
+            for root, _, files in os.walk(engineCacheDir):
+                for path in [f'{root}/{f}' for f in files if f == 'gen_snapshot']:
+                    os.chmod(path, 0o755)
 
         with open(engineStampPath, 'w') as f:
             f.write(engineVersion)

--- a/bin/flutter-tizen.bat
+++ b/bin/flutter-tizen.bat
@@ -1,0 +1,23 @@
+@ECHO off
+REM Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+REM Copyright 2014 The Flutter Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM Test if python3 is installed on the host
+SET PYTHON_EXE=python3
+WHERE %PYTHON_EXE% > NUL 2> NUL
+IF !ERRORLEVEL! NEQ 0 (
+    ECHO Error: Python3 isn't installed on the host.
+    ECHO        The flutter-tizen tool requires python3 to run.
+    ECHO        Install Python3 from the official website any try again.
+    ECHO        https://www.python.org/downloads/
+    EXIT /B !ERRORLEVEL!
+)
+
+REM Run flutter-tizen python script
+SET FLUTTER_TIZEN_ROOT=%~dp0..
+%PYTHON_EXE% "%FLUTTER_TIZEN_ROOT%\bin\flutter-tizen" %*
+EXIT /B !ERRORLEVEL!

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -107,7 +107,8 @@ class TizenValidator extends DoctorValidator {
 /// See: [AndroidWorkflow] in `android_workflow.dart`
 class TizenWorkflow extends Workflow {
   @override
-  bool get appliesToHostPlatform => globals.platform.isLinux;
+  bool get appliesToHostPlatform =>
+      globals.platform.isLinux || globals.platform.isWindows;
 
   @override
   bool get canLaunchDevices => tizenSdk != null;

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -108,7 +108,9 @@ class TizenValidator extends DoctorValidator {
 class TizenWorkflow extends Workflow {
   @override
   bool get appliesToHostPlatform =>
-      globals.platform.isLinux || globals.platform.isWindows;
+      globals.platform.isLinux ||
+      globals.platform.isWindows ||
+      globals.platform.isMacOS;
 
   @override
   bool get canLaunchDevices => tizenSdk != null;

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -64,14 +64,15 @@ class TizenSdk {
   File get emCli => toolsDirectory
       .childDirectory('emulator')
       .childDirectory('bin')
-      .childFile('em-cli');
+      .childFile(globals.platform.isWindows ? 'em-cli.bat' : 'em-cli');
 
-  File get sdb => toolsDirectory.childFile('sdb');
+  File get sdb =>
+      toolsDirectory.childFile(globals.platform.isWindows ? 'sdb.exe' : 'sdb');
 
   File get tizenCli => toolsDirectory
       .childDirectory('ide')
       .childDirectory('bin')
-      .childFile('tizen');
+      .childFile(globals.platform.isWindows ? 'tizen.bat' : 'tizen');
 
   String get defaultTargetPlatform => '5.5';
 


### PR DESCRIPTION
This pr adds support for the Windows and macOS platforms.

- added batch script file to run `flutter-tizen` in cmd without `python3` command
- updated python and dart code to allow running on Windows and macOS.
- updated python and dart code to find files with Windows extension, such as `.exe` and `.bat`