### PR TITLE
Fix run command hanging for secure protocol device

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -318,7 +318,9 @@ class TizenDevice extends Device {
     }
 
     _logger.printTrace("Stopping app '${package.name}' on $name.");
-    await stopApp(package, userIdentifier: userIdentifier);
+    if (await isAppInstalled(package)) {
+      await stopApp(package, userIdentifier: userIdentifier);
+    }
 
     if (!await _installLatestApp(package)) {
       return LaunchResult.failed();


### PR DESCRIPTION
Problem

Running `flutter-tizen run` hangs on secure_protocol enabled TV device. 

The `flutter-tizen run` command roughly takes the following steps:
- build tpk
- stop the app on target
- install the app on target
- start the app on target

For secure_protocol enabled devices, `sdb shell 0 kill <app_name>`
is executed to stop the app. At this point, if the app is running on the device,
the command will kill the app, otherwise it will report that the app
is already terminated. However, if the app was not even installed
in the first place, the command is irresponsive.

Solution

A quick solution is checking if the app is installed on the device before
running the command to stop the app. This adds about 500ms to the
`flutter-tizen run` command.