### PR TITLE
Improve flutter-tizen.bat script

### DIFF
--- a/bin/flutter-tizen.bat
+++ b/bin/flutter-tizen.bat
@@ -1,23 +1,22 @@
 @ECHO off
 REM Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
-REM Copyright 2014 The Flutter Authors. All rights reserved.
 REM Use of this source code is governed by a BSD-style license that can be
 REM found in the LICENSE file.
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-REM Test if python3 is installed on the host
-SET PYTHON_EXE=python3
-WHERE %PYTHON_EXE% > NUL 2> NUL
-IF !ERRORLEVEL! NEQ 0 (
-    ECHO Error: Python3 isn't installed on the host.
-    ECHO        The flutter-tizen tool requires python3 to run.
-    ECHO        Install Python3 from the official website and try again.
-    ECHO        https://www.python.org/downloads/
-    EXIT /B !ERRORLEVEL!
+REM Test if python3 is installed on the host.
+where /q python3 || (
+    ECHO Error: Unable to find python3 in your PATH.
+    EXIT /B 1
+)
+python3 -V >NUL 2>NUL
+IF errorlevel 9009 (
+    ECHO Run "python3" to install python and try again.
+    EXIT /B 1
 )
 
-REM Run flutter-tizen python script
+REM Run the flutter-tizen python script.
 SET FLUTTER_TIZEN_ROOT=%~dp0..
-%PYTHON_EXE% "%FLUTTER_TIZEN_ROOT%\bin\flutter-tizen" %*
+python3 "%FLUTTER_TIZEN_ROOT%\bin\flutter-tizen" %*
 EXIT /B !ERRORLEVEL!


### PR DESCRIPTION
On some Windows 10 installation, `where python3` returns `C:\Users\[user]\AppData\Local\Microsoft\WindowsApps\python3.exe` which just redirects to the python installation page in Microsoft Store. Therefore we should double check whether `python3 -V` exits with 9009.
