### PR TITLE
Add the test command

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   analysis:
     runs-on: ubuntu-latest
-    container:
-      image: google/dart:2.10.0-110.3.beta
     steps:
       - uses: actions/checkout@v2
       - name: Fetch Flutter SDK
@@ -20,8 +18,8 @@ jobs:
           git fetch --depth=1 https://github.com/flutter/flutter.git `cat ../bin/flutter.version`
           git checkout FETCH_HEAD
       - name: Install pub dependencies
-        run: dart pub get
+        run: flutter/bin/flutter pub get
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed lib
+        run: flutter/bin/dart format --output=none --set-exit-if-changed lib
       - name: Analyze project source
-        run: dart analyze --fatal-infos lib
+        run: flutter/bin/dart analyze --fatal-infos lib

--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -93,9 +93,7 @@ def main():
     # Validate the Dart SDK.
     dartPath = os.path.realpath(
         flutterCacheDir + '/dart-sdk/bin/dart' + exeSuffix)
-    pubPath = os.path.realpath(
-        flutterCacheDir + '/dart-sdk/bin/pub' + batSuffix)
-    if not os.path.isfile(dartPath) or not os.path.isfile(pubPath):
+    if not os.path.isfile(dartPath):
         print('Could not locate the Dart SDK.\n'
               f'Remove directory {flutterDir} and try again.')
         exit(1)
@@ -116,7 +114,7 @@ def main():
             revision(rootDir) != read(stampPath) or \
             os.path.getmtime(pubspecPath) > os.path.getmtime(publockPath):
         print('Running pub upgrade...')
-        upgradeCommand = [pubPath, 'upgrade', '--no-precompile']
+        upgradeCommand = [flutterPath, 'pub', 'upgrade']
         subprocess.run(upgradeCommand, cwd=rootDir, check=True)
 
         print('Compiling flutter-tizen...')

--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -175,7 +175,7 @@ def main():
         with open(engineStampPath, 'w') as f:
             f.write(engineVersion)
 
-    # Set --flutter-root and run.
+    # Run the snapshot.
     command = [dartPath, '--disable-dart-dev', '--packages=' + packagesPath,
                snapshotPath, '--flutter-root', flutterDir]
     command.extend(sys.argv[1:])

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -174,3 +174,11 @@ Not all commands in the [`flutter`](https://flutter.dev/docs/reference/flutter-c
   # Specify the device ID to run on.
   flutter-tizen run -d emulator-26101
   ```
+
+- ### `test`
+
+  Run tests in this package.
+
+  ```sh
+  flutter-tizen test test/general
+  ```

--- a/doc/debug-flutter-tizen.md
+++ b/doc/debug-flutter-tizen.md
@@ -5,20 +5,28 @@ The flutter-tizen tool is written in Dart. It extends the original [Flutter CLI]
 - The flutter-tizen tool creates its snapshot (compiled Dart code) when it's run for the first time. To run the tool directly from source, run this in the repository root:
 
   ```sh
-  dart bin/flutter_tizen.dart --flutter-root flutter [command]
+  flutter/bin/dart bin/flutter_tizen.dart help
   ```
 
 - To force the snapshot to be re-generated, remove `bin/cache/flutter-tizen.snapshot`.
 
-- To debug the tool with the VS Code debugger, install the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code) and configure `launch.json` as follows:
-
-  ```json
-  {
-    "name": "flutter-tizen",
-    "request": "launch",
-    "type": "dart",
-    "cwd": "<target project directory>",
-    "program": "<flutter-tizen repo root>/bin/flutter_tizen.dart",
-    "args": ["--flutter-root", "<flutter-tizen repo root>/flutter", "[command]"]
-  }
-  ```
+- To debug the tool with the VS Code debugger,
+  1. Add `flutter-tizen` directory to your workspace.
+  2. Install the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code) for VS Code.
+  3. Configure `launch.json` file as follows:<p>
+     ```json
+     {
+       "version": "0.2.0",
+       "configurations": [
+         {
+           "name": "flutter-tizen",
+           "request": "launch",
+           "type": "dart",
+           "cwd": "${fileWorkspaceFolder}",
+           "program": "${workspaceFolder}/bin/flutter_tizen.dart",
+           "args": ["doctor"]
+         }
+       ]
+     }
+     ```
+  4. Start debugging (F5).

--- a/lib/commands/test.dart
+++ b/lib/commands/test.dart
@@ -1,0 +1,12 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/commands/test.dart';
+
+import '../tizen_plugins.dart';
+
+class TizenTestCommand extends TestCommand with TizenExtension {
+  TizenTestCommand({bool verboseHelp = false})
+      : super(verboseHelp: verboseHelp);
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -31,6 +31,7 @@ import 'commands/drive.dart';
 import 'commands/install.dart';
 import 'commands/packages.dart';
 import 'commands/run.dart';
+import 'commands/test.dart';
 import 'tizen_artifacts.dart';
 import 'tizen_device_discovery.dart';
 import 'tizen_doctor.dart';
@@ -74,6 +75,7 @@ Future<void> main(List<String> args) async {
             TizenInstallCommand(),
             TizenPackagesCommand(),
             TizenRunCommand(verboseHelp: verboseHelp),
+            TizenTestCommand(verboseHelp: verboseHelp),
           ],
       verbose: verbose,
       verboseHelp: verboseHelp,

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter_tools/executable.dart' as flutter;
 import 'package:flutter_tools/runner.dart' as runner;
 import 'package:flutter_tools/src/application_package.dart';
@@ -21,6 +23,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:path/path.dart';
 
 import 'commands/analyze.dart';
 import 'commands/attach.dart';
@@ -46,12 +49,17 @@ Future<void> main(List<String> args) async {
   final bool verbose = args.contains('-v') || args.contains('--verbose');
   final bool help = args.contains('-h') || args.contains('--help');
   final bool verboseHelp = help && verbose;
-  final bool specifiedId = args.contains('-d') || args.contains('--device-id');
+  final bool hasSpecifiedDeviceId =
+      args.contains('-d') || args.contains('--device-id');
+  final bool hasSpecifiedFlutterRoot = args.contains('--flutter-root');
+  final String flutterRoot =
+      normalize(join(Platform.script.toFilePath(), '../../flutter'));
 
   args = <String>[
     '--suppress-analytics', // Suppress flutter analytics by default.
     '--no-version-check',
-    if (!specifiedId) ...<String>['-d', 'tizen'],
+    if (!hasSpecifiedFlutterRoot) ...<String>['--flutter-root', flutterRoot],
+    if (!hasSpecifiedDeviceId) ...<String>['--device-id', 'tizen'],
     ...args,
   ];
 

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:cli';
-
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
@@ -78,20 +76,14 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 }
 
-/// Any [FlutterCommand] that uses [usesPubOption] or invokes [targetFile]
-/// should depend on this mixin to ensure plugins are correctly configured for
-/// Tizen.
+/// Any [FlutterCommand] that invokes [usesPubOption] or [targetFile] should
+/// depend on this mixin to ensure plugins are correctly configured for Tizen.
 ///
 /// See: [FlutterCommand.verifyThenRunCommand] in `flutter_command.dart`
 mixin TizenExtension on FlutterCommand {
-  String entrypoint;
+  String _entrypoint;
 
-  @override
-  String get targetFile {
-    // Caution: Converting async to sync.
-    return entrypoint ??= waitFor<String>(
-        _createEntrypoint(FlutterProject.current(), super.targetFile));
-  }
+  bool get _usesTargetOption => argParser.options.containsKey('target');
 
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
@@ -99,8 +91,15 @@ mixin TizenExtension on FlutterCommand {
       // TODO(swift-kim): Should run pub get first before injecting plugins.
       await injectTizenPlugins(FlutterProject.current());
     }
+    if (_usesTargetOption) {
+      _entrypoint =
+          await _createEntrypoint(FlutterProject.current(), super.targetFile);
+    }
     return await super.verifyThenRunCommand(commandPath);
   }
+
+  @override
+  String get targetFile => _entrypoint ?? super.targetFile;
 }
 
 /// Creates an entrypoint wrapper of [targetFile] and returns its path.
@@ -115,7 +114,6 @@ Future<String> _createEntrypoint(
   if (!hasDartPlugins) {
     return targetFile;
   }
-
   final TizenProject tizenProject = TizenProject.fromFlutter(project);
   if (!tizenProject.existsSync()) {
     return targetFile;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,8 @@ dependencies:
   yaml: any
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mockito: any
   pedantic: any
+  test: any


### PR DESCRIPTION
- Add the `test` command (for unit/command testing) (tests will be added later)
- Add test-related dependencies in pubspec.yaml
- In bin/flutter-tizen, use `flutter pub` instead of `dart pub` to correctly resolve dependencies of flutter_test
- Remove the use of `waitFor` in `TizenExtension.targetFile` as dart:cli is not available when running tests