### PR TITLE
Additional commands and build options

### DIFF
--- a/bin/flutter-tizen
+++ b/bin/flutter-tizen
@@ -177,7 +177,7 @@ def main():
 
     # Run the snapshot.
     command = [dartPath, '--disable-dart-dev', '--packages=' + packagesPath,
-               snapshotPath, '--flutter-root', flutterDir]
+               snapshotPath]
     command.extend(sys.argv[1:])
     try:
         process = subprocess.run(command)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -175,6 +175,24 @@ Not all commands in the [`flutter`](https://flutter.dev/docs/reference/flutter-c
   flutter-tizen run -d emulator-26101
   ```
 
+- ### `screenshot`
+
+  Take a screenshot from a connected device.
+
+  ```sh
+  flutter-tizen screenshot --type rasterizer --observatory-uri http://127.0.0.1:43000/Swm0bjIe0ks=
+  ```
+
+  You have to specify both `--type` and `--observatory-uri` values because the default (`device`) screenshot type is not supported by Tizen devices. The observatory URI value can be found in the device log output (`flutter-tizen run` or `flutter-tizen logs`) after you start an app in debug or profile mode.
+
+- ### `symbolize`
+
+  Symbolize a stack trace from a Flutter app which has been built with the `--split-debug-info` option.
+
+  ```sh
+  flutter-tizen symbolize --debug-info app.android-arm.symbols --input stack_trace.err
+  ```
+
 - ### `test`
 
   Run tests in this package.

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -19,25 +19,14 @@ class TizenBuildCommand extends BuildCommand {
   TizenBuildCommand({bool verboseHelp = false})
       : super(verboseHelp: verboseHelp) {
     addSubcommand(BuildTpkCommand(verboseHelp: verboseHelp));
-    // BuildAotCommand is deprecated, so we don't override it for Tizen.
   }
 }
 
 class BuildTpkCommand extends BuildSubCommand with TizenExtension {
   /// See: [BuildApkCommand] in `build_apk.dart`
   BuildTpkCommand({bool verboseHelp = false}) {
-    addTreeShakeIconsFlag();
-    usesTargetOption();
-    addBuildModeFlags(verboseHelp: verboseHelp);
-    usesPubOption();
+    addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesBuildNameOption();
-    addSplitDebugInfoOption();
-    addDartObfuscationOption();
-    usesDartDefineOption();
-    usesExtraFrontendOptions();
-    addNullSafetyModeOptions(hide: !verboseHelp);
-    usesTrackWidgetCreation(verboseHelp: verboseHelp);
-    usesAnalyzeSizeFlag();
     argParser.addMultiOption(
       'target-arch',
       splitCommas: true,
@@ -48,8 +37,8 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
     argParser.addOption(
       'security-profile',
       abbr: 's',
-      help: 'The security profile name to sign the TPK with (the active '
-          'profile is used if not specified)',
+      help: 'The security profile name to sign the TPK with (defaults to the '
+          'current active profile)',
     );
   }
 

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/commands/emulators.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/commands/format.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
+import 'package:flutter_tools/src/commands/screenshot.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
@@ -73,6 +74,7 @@ Future<void> main(List<String> args) async {
             EmulatorsCommand(),
             FormatCommand(),
             LogsCommand(),
+            ScreenshotCommand(),
             // Commands extended for Tizen.
             TizenAnalyzeCommand(verboseHelp: verboseHelp),
             TizenAttachCommand(verboseHelp: verboseHelp),

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/commands/format.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
 import 'package:flutter_tools/src/commands/screenshot.dart';
+import 'package:flutter_tools/src/commands/symbolize.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
@@ -82,6 +83,7 @@ Future<void> main(List<String> args) async {
       FormatCommand(),
       LogsCommand(),
       ScreenshotCommand(),
+      SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       // Commands extended for Tizen.
       TizenAnalyzeCommand(verboseHelp: verboseHelp),
       TizenAttachCommand(verboseHelp: verboseHelp),
@@ -120,7 +122,7 @@ Future<void> main(List<String> args) async {
               stdio: globals.stdio,
               terminal: globals.terminal,
               outputPreferences: globals.outputPreferences,
-            ))
+            )),
     },
   );
 }

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -62,14 +62,11 @@ Future<void> main(List<String> args) async {
 
   final bool hasSpecifiedDeviceId =
       args.contains('-d') || args.contains('--device-id');
-  final bool hasSpecifiedFlutterRoot = args.contains('--flutter-root');
-  final String flutterRoot =
-      normalize(join(Platform.script.toFilePath(), '../../flutter'));
 
   args = <String>[
     '--suppress-analytics', // Suppress flutter analytics by default.
     '--no-version-check',
-    if (!hasSpecifiedFlutterRoot) ...<String>['--flutter-root', flutterRoot],
+    '--flutter-root', flutterRoot,
     if (!hasSpecifiedDeviceId) ...<String>['--device-id', 'tizen'],
     ...args,
   ];
@@ -126,4 +123,13 @@ Future<void> main(List<String> args) async {
             ))
     },
   );
+}
+
+String get flutterRoot {
+  final String scriptPath = Platform.script.toFilePath();
+  final String rootPath = normalize(join(
+    scriptPath,
+    scriptPath.endsWith('.snapshot') ? '../../..' : '../..',
+  ));
+  return join(rootPath, 'flutter');
 }


### PR DESCRIPTION
- Add `screenshot` and `symbolize` commands
- Support more build options for `build tpk` command
  - `--performance-measurement-file`
  - `--bundle-sksl-path`
  - `--enable-experiment`
- Update docs accordingly
- Fix `-v` option not working as expected (`-h -v` and `doctor -v`)
