### PR TITLE
Define a profile name switch for plugin builds

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -46,6 +46,9 @@ Not all commands in the [`flutter`](https://flutter.dev/docs/reference/flutter-c
   # Build a TPK without installing on a device.
   flutter-tizen build tpk
 
+  # Build for a TV device.
+  flutter-tizen build tpk --device-profile tv
+
   # Build for an emulator.
   flutter-tizen build tpk --debug --target-arch x86
   ```

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -43,7 +43,15 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
       splitCommas: true,
       defaultsTo: <String>['arm'],
       allowed: <String>['arm', 'aarch64', 'x86'],
-      help: 'The target architectures to compile the application for',
+      help: 'Target architectures to compile the application for',
+    );
+    argParser.addOption(
+      'device-profile',
+      defaultsTo: 'common',
+      allowed: <String>['common', 'wearable', 'tv'],
+      help: 'The type of Tizen device the application will operate on. It is '
+          'recommended to choose a right profile for your target device rather '
+          'than just "common". Otherwise, some plugins may fail to load.',
     );
     argParser.addOption(
       'security-profile',
@@ -82,6 +90,7 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
     final TizenBuildInfo tizenBuildInfo = TizenBuildInfo(
       buildInfo,
       targetArchs: stringsArg('target-arch'),
+      deviceProfile: stringArg('device-profile'),
       securityProfile: stringArg('security-profile'),
     );
     validateBuild(tizenBuildInfo);

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -35,11 +35,13 @@ class TizenBuildInfo {
   const TizenBuildInfo(
     this.buildInfo, {
     @required this.targetArchs,
+    this.deviceProfile,
     this.securityProfile,
   });
 
   final BuildInfo buildInfo;
   final List<String> targetArchs;
+  final String deviceProfile;
   final String securityProfile;
 }
 

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -306,8 +306,11 @@ class TizenDevice extends Device {
       await TizenBuilder.buildTpk(
         project: project,
         targetFile: mainPath,
-        tizenBuildInfo: TizenBuildInfo(debuggingOptions.buildInfo,
-            targetArchs: <String>[architecture]),
+        tizenBuildInfo: TizenBuildInfo(
+          debuggingOptions.buildInfo,
+          targetArchs: <String>[architecture],
+          deviceProfile: getCapability('profile_name'),
+        ),
       );
       // Package has been built, so we can get the updated application id and
       // activity name from the tpk.

--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -13,12 +13,12 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
-import 'package:flutter_tizen/tizen_sdk.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:xml/xml.dart';
 
 import 'tizen_doctor.dart';
+import 'tizen_sdk.dart';
 
 /// A class to get available Tizen emulators.
 class TizenEmulatorManager extends EmulatorManager {

--- a/lib/tizen_tpk.dart
+++ b/lib/tizen_tpk.dart
@@ -163,12 +163,12 @@ class TizenManifest {
   /// The target API version number.
   String get apiVersion => _manifest.getAttribute('api-version');
 
-  /// The fully qualified target profile name (e.g. `wearable-5.5`)
-  String get profile {
-    final XmlElement parent = _manifest.findElements('profile').first;
-    final String name = parent.getAttribute('name');
-    return '$name-$apiVersion';
-  }
+  /// The profile name representing a device type.
+  String get profileName =>
+      _manifest.findElements('profile').first.getAttribute('name');
+
+  /// The fully qualified profile string. (e.g. `wearable-5.5`)
+  String get profile => '$profileName-$apiVersion';
 
   /// The unique application id used for launching and terminating applications.
   String get applicationId {


### PR DESCRIPTION
- Detect a profile name from a target device and build plugins with a corresponding switch (-DTV_PROFILE or -DWEARABLE_PROFILE) set
- Add a --device-profile option to the "build tpk" command

This patch adds support for plugins like permission_handler which depend on `capi-privacy-privilege-manager` which is not available on TV.

Related to https://github.com/flutter-tizen/plugins/pull/33.
