### PR TITLE
Load libflutter_engine.so before invoking libflutter_tizen.so

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -221,7 +221,7 @@ abstract class DotnetTpk extends Target {
 
     // For now a constant value is used instead of reading from a file.
     // Keep this value in sync with the latest published nuget version.
-    const String embeddingVersion = '1.2.0';
+    const String embeddingVersion = '1.2.1';
 
     // Run .NET build.
     if (getDotnetCliPath() == null) {

--- a/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -90,6 +90,13 @@ namespace Tizen.Flutter.Embedding
                 switches_count = (uint)switches.Length,
             };
 
+            // This check is not actually required, but we want to make sure that libflutter_engine.so is loaded
+            // before a call to FlutterCreateWindow() is made to avoid library loading issues on TV emulator.
+            if (FlutterEngineRunsAOTCompiledDartCode())
+            {
+                InternalLog.Debug(LogTag, "Running in AOT mode.");
+            }
+
             Handle = FlutterCreateWindow(ref windowProperties, ref engineProperties);
             if (Handle.IsInvalid)
             {

--- a/nuget/Tizen.Flutter.Embedding/Interop.cs
+++ b/nuget/Tizen.Flutter.Embedding/Interop.cs
@@ -100,6 +100,9 @@ namespace Tizen.Flutter.Embedding
                 return DefaultEmbedder.FlutterDesktopGetPluginRegistrar(window, plugin_name);
         }
 
+        [DllImport("flutter_engine.so")]
+        public static extern bool FlutterEngineRunsAOTCompiledDartCode();
+
         #region Default
         private static class DefaultEmbedder
         {

--- a/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Tizen.Flutter.Embedding</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>flutter-tizen</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/flutter-tizen</PackageProjectUrl>


### PR DESCRIPTION
A temporary fix for library loading issue on TV emulator.