### PR TITLE
Fix flutter-tizen driver bat file on windows

### DIFF
--- a/bin/flutter-tizen.bat
+++ b/bin/flutter-tizen.bat
@@ -10,13 +10,13 @@ where /q python3 || (
     ECHO Error: Unable to find python3 in your PATH.
     EXIT /B 1
 )
-python3 -V >NUL 2>NUL
-IF errorlevel 9009 (
+
+CALL python3 -V >NUL 2>NUL || (
     ECHO Run "python3" to install python and try again.
     EXIT /B 1
 )
 
 REM Run the flutter-tizen python script.
 SET FLUTTER_TIZEN_ROOT=%~dp0..
-python3 "%FLUTTER_TIZEN_ROOT%\bin\flutter-tizen" %*
+CALL python3 "%FLUTTER_TIZEN_ROOT%\bin\flutter-tizen" %*
 EXIT /B !ERRORLEVEL!


### PR DESCRIPTION
This pr fixes a bug when `flutter-tizen` runs `python3.bat` instead of `python3.exe`.

On Windows, running a command `program` in cmd can run either `program.exe` or `program.bat`. If both files exist in the same path, `exe` has precedence.

When the `flutter-tizen.bat` script executes on a system and the command `python3` runs `python3.bat`, the control flow will not return back to `flutter-tizen.bat`. To fix this, the `CALL` command should be used. ([MS Docs Reference](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/call))

In summary, it seems that `exe` runs in the current batch process and `bat` runs on a child batch process, but doesn't return to the parent if the `CALL` command is not used.

To handle both extension files, `CALL` command should always be used for calling `python3`.