### PR TITLE
Remove the use of FlutterRotateWindow

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -222,7 +222,7 @@ abstract class DotnetTpk extends Target {
 
     // For now a constant value is used instead of reading from a file.
     // Keep this value in sync with the latest published nuget version.
-    const String embeddingVersion = '1.2.1';
+    const String embeddingVersion = '1.2.2';
 
     // Run .NET build.
     if (getDotnetCliPath() == null) {

--- a/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/nuget/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -157,16 +157,6 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
-        protected override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
-        {
-            base.OnDeviceOrientationChanged(e);
-
-            if (!Handle.IsInvalid)
-            {
-                FlutterRotateWindow(Handle, (int)e.DeviceOrientation);
-            }
-        }
-
         protected override void OnLocaleChanged(LocaleChangedEventArgs e)
         {
             base.OnLocaleChanged(e);

--- a/nuget/Tizen.Flutter.Embedding/Interop.cs
+++ b/nuget/Tizen.Flutter.Embedding/Interop.cs
@@ -83,14 +83,6 @@ namespace Tizen.Flutter.Embedding
                 DefaultEmbedder.FlutterNotifyAppIsPaused(window);
         }
 
-        public static void FlutterRotateWindow(FlutterWindowControllerHandle window, int degree)
-        {
-            if (IsTizen40)
-                Tizen40Embedder.FlutterRotateWindow(window, degree);
-            else
-                DefaultEmbedder.FlutterRotateWindow(window, degree);
-        }
-
         public static IntPtr FlutterDesktopGetPluginRegistrar(
             FlutterWindowControllerHandle window, string plugin_name)
         {
@@ -134,10 +126,6 @@ namespace Tizen.Flutter.Embedding
                 FlutterWindowControllerHandle window);
 
             [DllImport(SharedLibrary)]
-            public static extern void FlutterRotateWindow(
-                FlutterWindowControllerHandle window, int degree);
-
-            [DllImport(SharedLibrary)]
             public static extern IntPtr FlutterDesktopGetPluginRegistrar(
                 FlutterWindowControllerHandle window, string plugin_name);
         }
@@ -172,10 +160,6 @@ namespace Tizen.Flutter.Embedding
             [DllImport(SharedLibrary)]
             public static extern void FlutterNotifyAppIsPaused(
                 FlutterWindowControllerHandle window);
-
-            [DllImport(SharedLibrary)]
-            public static extern void FlutterRotateWindow(
-                FlutterWindowControllerHandle window, int degree);
 
             [DllImport(SharedLibrary)]
             public static extern IntPtr FlutterDesktopGetPluginRegistrar(

--- a/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/nuget/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Tizen.Flutter.Embedding</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>flutter-tizen</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/flutter-tizen</PackageProjectUrl>


### PR DESCRIPTION
`FlutterRotateWindow` is deprecated and does nothing in the current version of the engine.