### PR TITLE
Minor updates for 1.22.6

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -133,6 +133,15 @@ Not all commands in the [`flutter`](https://flutter.dev/docs/reference/flutter-c
   flutter-tizen format foo.dart
   ```
 
+- ### `gen-l10n`
+
+  Generate localizations for the Flutter project. Identical to `flutter gen-l10n`.
+
+  ```sh
+  # Note: Create a template arb file "app_en.arb" in "lib/l10n" before running this.
+  flutter-tizen gen-l10n
+  ```
+
 - ### `install`
 
   Install TPK on a Tizen device.

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/commands/emulators.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/commands/format.dart';
+import 'package:flutter_tools/src/commands/generate_localizations.dart';
 import 'package:flutter_tools/src/commands/logs.dart';
 import 'package:flutter_tools/src/commands/screenshot.dart';
 import 'package:flutter_tools/src/commands/symbolize.dart';
@@ -81,6 +82,7 @@ Future<void> main(List<String> args) async {
       DoctorCommand(verbose: verbose),
       EmulatorsCommand(),
       FormatCommand(),
+      GenerateLocalizationsCommand(fileSystem: globals.fs),
       LogsCommand(),
       ScreenshotCommand(),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -106,9 +106,9 @@ class TizenPlugins extends Target {
           '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
         ];
 
-        if (getTizenCliPath() == null) {
+        if (tizenSdk == null || !tizenSdk.tizenCli.existsSync()) {
           throwToolExit(
-            'Unable to locate Tizen SDK.\n'
+            'Unable to locate Tizen CLI executable.\n'
             'Run "flutter-tizen doctor" and install required components.',
           );
         }
@@ -116,7 +116,7 @@ class TizenPlugins extends Target {
           buildDir.deleteSync(recursive: true);
         }
         final RunResult result = await _processUtils.run(<String>[
-          getTizenCliPath(),
+          tizenSdk.tizenCli.path,
           'build-native',
           '-a',
           arch,
@@ -225,11 +225,14 @@ abstract class DotnetTpk extends Target {
     const String embeddingVersion = '1.2.1';
 
     // Run .NET build.
-    if (getDotnetCliPath() == null) {
-      throwToolExit('Unable to locate .NET CLI.');
+    if (dotnetCli == null) {
+      throwToolExit(
+        'Unable to locate .NET CLI executable.\n'
+        'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',
+      );
     }
     RunResult result = await _processUtils.run(<String>[
-      getDotnetCliPath(),
+      dotnetCli.path,
       'build',
       '-c',
       'Release',
@@ -247,9 +250,9 @@ abstract class DotnetTpk extends Target {
           'Build succeeded but the expected TPK not found:\n${result.stdout}');
     }
 
-    if (getTizenCliPath() == null) {
+    if (tizenSdk == null || !tizenSdk.tizenCli.existsSync()) {
       throwToolExit(
-        'Unable to locate Tizen SDK.\n'
+        'Unable to locate Tizen CLI executable.\n'
         'Run "flutter-tizen doctor" and install required components.',
       );
     }
@@ -261,7 +264,7 @@ abstract class DotnetTpk extends Target {
       environment.logger.printStatus('The active profile is used for signing.');
     }
     result = await _processUtils.run(<String>[
-      getTizenCliPath(),
+      tizenSdk.tizenCli.path,
       'package',
       '-t',
       'tpk',
@@ -524,9 +527,9 @@ abstract class NativeTpk extends Target {
     ];
 
     // Run native build.
-    if (getTizenCliPath() == null) {
+    if (tizenSdk == null || !tizenSdk.tizenCli.existsSync()) {
       throwToolExit(
-        'Unable to locate Tizen SDK.\n'
+        'Unable to locate Tizen CLI executable.\n'
         'Run "flutter-tizen doctor" and install required components.',
       );
     }
@@ -534,7 +537,7 @@ abstract class NativeTpk extends Target {
       buildDir.deleteSync(recursive: true);
     }
     RunResult result = await _processUtils.run(<String>[
-      getTizenCliPath(),
+      tizenSdk.tizenCli.path,
       'build-native',
       '-a',
       targetArch,
@@ -553,7 +556,7 @@ abstract class NativeTpk extends Target {
       throwToolExit('Failed to compile native application:\n$result');
     }
     result = await _processUtils.run(<String>[
-      getTizenCliPath(),
+      tizenSdk.tizenCli.path,
       'package',
       '-t',
       'tpk',

--- a/lib/tizen_device_discovery.dart
+++ b/lib/tizen_device_discovery.dart
@@ -88,15 +88,14 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
 
   @override
   Future<List<Device>> pollingGetDevices({Duration timeout}) async {
-    final String sdbPath = getSdbPath();
-    if (sdbPath == null) {
+    if (tizenSdk == null) {
       return <TizenDevice>[];
     }
 
     String stdout;
     try {
       final RunResult result = await _processUtils
-          .run(<String>[sdbPath, 'devices'], throwOnError: true);
+          .run(<String>[tizenSdk.sdb.path, 'devices'], throwOnError: true);
       stdout = result.stdout.trim();
     } on ProcessException catch (ex) {
       throwToolExit('sdb failed to list connected devices:\n$ex');
@@ -126,9 +125,10 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
 
       devices.add(TizenDevice(
         deviceId,
-        logger: _logger ?? globals.logger,
-        processManager: _processManager ?? globals.processManager,
         modelId: deviceModel,
+        logger: _logger ?? globals.logger,
+        tizenSdk: tizenSdk,
+        processManager: _processManager ?? globals.processManager,
       ));
     }
     return devices;
@@ -136,13 +136,12 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async {
-    final String sdbPath = getSdbPath();
-    if (sdbPath == null) {
+    if (tizenSdk == null) {
       return <String>[];
     }
 
     final RunResult result =
-        await _processUtils.run(<String>[sdbPath, 'devices']);
+        await _processUtils.run(<String>[tizenSdk.sdb.path, 'devices']);
     if (result.exitCode != 0) {
       return <String>[];
     }

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -77,7 +77,7 @@ class TizenValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    if (getSdbPath() == null) {
+    if (tizenSdk == null) {
       messages.add(const ValidationMessage.error(
         'Unable to locate Tizen SDK.\n'
         'Install Tizen Studio from: https://developer.tizen.org/development/tizen-studio/download\n'
@@ -90,7 +90,7 @@ class TizenValidator extends DoctorValidator {
       return ValidationResult(ValidationType.partial, messages);
     }
 
-    if (getDotnetCliPath() == null) {
+    if (dotnetCli == null) {
       messages.add(const ValidationMessage.error(
         '.NET CLI is required for building Tizen applications.\n'
         'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -13,17 +13,7 @@ import 'package:meta/meta.dart';
 
 TizenSdk get tizenSdk => context.get<TizenSdk>();
 
-String getSdbPath() {
-  return tizenSdk?.sdb?.path;
-}
-
-String getTizenCliPath() {
-  return tizenSdk?.tizenCli?.path;
-}
-
-String getDotnetCliPath() {
-  return globals.os.which('dotnet')?.path;
-}
+File get dotnetCli => globals.os.which('dotnet');
 
 class TizenSdk {
   TizenSdk._(this.directory);


### PR DESCRIPTION
Tracking code changes in the upstream framework between 1.22.0-12.1.pre and 1.22.6.

Changed:
- Improve locating Tizen CLI executable
  - Remove `getXxxPath()` for consistency with android implementation (`getAdbPath()` has been removed from flutter_tools)
  - Generate an error if Tizen CLI package is not installed
- Add the `gen-l10n` command