### PR TITLE
Improve device detection

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -496,7 +496,15 @@ class TizenDevice extends Device {
       );
 
   @override
-  bool isSupported() => true;
+  bool isSupported() {
+    final double deviceVersion = double.tryParse(platformVersion) ?? 0;
+    if (!_emulatorArchs.contains(getCapability('cpu_arch')) &&
+        usesSecureProtocol &&
+        deviceVersion < 6.0) {
+      return false;
+    }
+    return deviceVersion >= 4.0;
+  }
 
   @override
   bool get supportsScreenshot => false;


### PR DESCRIPTION
- Decide the `isSupported` value based on the device's API version
- Do not add a device when sdb gives false information (#30)
- More diagnostic messages (e.g. unauthorized, offline)

Fixes #30.