### PR TITLE
Reduce build time by using cache files

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -25,7 +25,7 @@ import 'tizen_project.dart';
 import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
 
-Future<void> writeDepFile(String depFileName, Environment environment,
+Future<void> writeDepfile(String depFileName, Environment environment,
     List<File> inputFiles, List<File> outputFiles) async {
   final DepfileService depfileService = DepfileService(
     fileSystem: environment.fileSystem,
@@ -73,10 +73,10 @@ class TizenPlugins extends Target {
   @override
   Future<void> build(Environment environment) async {
     // input and output files which the target depends on
-    final List<File> inputDepFiles = <File>[];
-    final List<File> outputDepFiles = <File>[];
+    final List<File> inputDepfiles = <File>[];
+    final List<File> outputDepfiles = <File>[];
 
-    inputDepFiles.add(project.directory.childFile('.packages'));
+    inputDepfiles.add(project.directory.childFile('.packages'));
 
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
@@ -166,7 +166,7 @@ class TizenPlugins extends Target {
             .childDirectory(arch)
               ..createSync(recursive: true);
         sharedLib.copySync(outputDir.childFile(sharedLib.basename).path);
-        outputDepFiles.add(sharedLib);
+        outputDepfiles.add(sharedLib);
       }
     }
 
@@ -184,14 +184,14 @@ class TizenPlugins extends Target {
         .map((TizenPlugin plugin) => plugin.name)
         .toList()
         .toString());
-    outputDepFiles.add(pluginList);
+    outputDepfiles.add(pluginList);
 
     // write ephemeral.d file
-    await writeDepFile(
+    await writeDepfile(
       'ephemeral.d',
       environment,
-      inputDepFiles,
-      outputDepFiles,
+      inputDepfiles,
+      outputDepfiles,
     );
   }
 }
@@ -225,8 +225,8 @@ abstract class DotnetTpk extends Target {
   @override
   Future<void> build(Environment environment) async {
     // input and output files which the target depends on
-    final List<File> inputDepFiles = <File>[];
-    final List<File> outputDepFiles = <File>[];
+    final List<File> inputDepfiles = <File>[];
+    final List<File> outputDepfiles = <File>[];
 
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
@@ -241,7 +241,7 @@ abstract class DotnetTpk extends Target {
         outputDir.childDirectory('flutter_assets'),
         resDir.childDirectory('flutter_assets'));
 
-    inputDepFiles.addAll(outputDir
+    inputDepfiles.addAll(outputDir
         .childDirectory('flutter_assets')
         .listSync(recursive: true)
         .whereType<File>()
@@ -264,18 +264,18 @@ abstract class DotnetTpk extends Target {
       embedding.copySync(libDir.childFile(embedding.basename).path);
       icuData.copySync(resDir.childFile(icuData.basename).path);
 
-      inputDepFiles.addAll(<File>[engineBinary, embedding, icuData]);
+      inputDepfiles.addAll(<File>[engineBinary, embedding, icuData]);
 
       if (tizenProject.apiVersion.startsWith('4')) {
         final File embedding40 = engineDir.childFile('libflutter_tizen40.so');
         embedding40.copySync(libDir.childFile(embedding40.basename).path);
-        inputDepFiles.add(embedding40);
+        inputDepfiles.add(embedding40);
       }
       if (buildMode.isPrecompiled) {
         final File aotSharedLib =
             environment.buildDir.childDirectory(arch).childFile('app.so');
         aotSharedLib.copySync(libDir.childFile('libapp.so').path);
-        inputDepFiles.add(aotSharedLib);
+        inputDepfiles.add(aotSharedLib);
       }
     }
 
@@ -347,19 +347,19 @@ abstract class DotnetTpk extends Target {
             directory.basename == 'obj' ||
             directory.basename == 'flutter'))
         .toList();
-    inputDepFiles.addAll(<File>[
+    inputDepfiles.addAll(<File>[
       for (Directory dir in inputDepDirs)
         ...dir.listSync(recursive: true).whereType<File>().toList()
     ]);
 
-    outputDepFiles.add(outputDir.childFile(tizenProject.outputTpkName));
+    outputDepfiles.add(outputDir.childFile(tizenProject.outputTpkName));
 
     // write dotnet_tpk.d file
-    await writeDepFile(
+    await writeDepfile(
       'dotnet_tpk.d',
       environment,
-      inputDepFiles,
-      outputDepFiles,
+      inputDepfiles,
+      outputDepfiles,
     );
   }
 }

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -76,7 +76,7 @@ class TizenBuilder {
 
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final Directory outputDir =
-        project.directory.childDirectory('build').childDirectory('tizen');
+        tizenProject.getBuildModeDirectory(buildInfo.modeName);
 
     final Environment environment = Environment(
       projectDir: project.directory,
@@ -148,6 +148,12 @@ class TizenBuilder {
     }
 
     final File tpkFile = outputDir.childFile(tizenProject.outputTpkName);
+
+    // Update latest tpk build
+    final File latestTpk =
+        tizenProject.latestTpkDirectory.childFile(tizenProject.latestTpkName);
+    tpkFile.copySync(latestTpk.path);
+
     final String tpkSize = getSizeAsMB(tpkFile.lengthSync());
     globals.printStatus(
       '$successMark Built ${relative(tpkFile.path)} ($tpkSize).',

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -77,9 +77,6 @@ class TizenBuilder {
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final Directory outputDir =
         project.directory.childDirectory('build').childDirectory('tizen');
-    if (outputDir.existsSync()) {
-      outputDir.deleteSync(recursive: true);
-    }
 
     final Environment environment = Environment(
       projectDir: project.directory,

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -321,7 +321,10 @@ class TizenDevice extends Device {
       );
       // Package has been built, so we can get the updated application id and
       // activity name from the tpk.
-      package = await TizenTpk.fromProject(project);
+      package = await TizenTpk.fromProject(
+        project,
+        debuggingOptions.buildInfo,
+      );
     }
     if (package == null) {
       throwToolExit('Problem building an application: see above error(s).');

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -53,6 +53,21 @@ class TizenProject extends FlutterProjectPlatform {
     return '${manifest.packageId}-${manifest.version}.tpk';
   }
 
+  String get latestTpkName => 'app.tpk';
+
+  Directory get buildDirectory {
+    return parent.directory
+        .childDirectory('build')
+        .childDirectory('tizen')
+        .childDirectory(isDotnet ? 'dotnet' : 'native');
+  }
+
+  Directory get latestTpkDirectory => buildDirectory;
+
+  Directory getBuildModeDirectory(String modeName) {
+    return buildDirectory.childDirectory(modeName);
+  }
+
   Future<void> ensureReadyForPlatformSpecificTooling() async {}
 }
 

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -59,6 +59,9 @@ class TizenSdk {
     return null;
   }
 
+  File get certificateList =>
+      sdkDataDirectory?.childDirectory('profile')?.childFile('profiles.xml');
+
   Directory get toolsDirectory => directory.childDirectory('tools');
 
   File get emCli => toolsDirectory


### PR DESCRIPTION
This pr leverages the caching functionality of the `FlutterBuildSystem`
to reduce the overall build time by re-building only the modified files.

## Summary

The `FlutterBuildSystem` supports caching intermediate build files
of each target to reduce the overall build time.
In order to use this functionality, we need to specify the files
that each target depends on. If those files are always known during the
dev-lifecycle, they can be listed in `Target.inputs` or `Target.outputs`.
In most cases, however, new dependencies such as plugins or source
code files will be added during development. To handle these cases,
we can either (1) use wildcard patterns in `Source.pattern()`, or (2)
create a `DepFile` that stores the dependencies of a target at runtime
and specify the `DepFile` filename in `Target.depfiles`.

Although (1) is a simpler solution, the implementation of resolving
the wildcard pattern doesn't handle our use cases(See `visitPattern()`
in `source.dart`), such as:
- doesn't support recursive file search
- throws error when intermediate directories are missing in the file path

We need at least one of the above functionalities because our intermediate
files are structured in a multiple depth folder hierarchy.

As such, I've chosen to use solution (2) despite increasing the code
complexity of maintaining depfiles. It is crucial for depFiles to list
all input and output files that participated in `Target.build()`.

## Correctness Check

The following checks are performed for `DotnetTpk` (Debug/Release). 
(`NativeTpk` is left for future work.)
- [x] Skipping all build steps if nothing has changed
- [x] Rebuilding only necessary files when app source changes
- Rebuilding only necessary files when adding or removing plugins
    - [x] Adding new plugin
    - [x] Removing plugin
    - [ ] Plugin version changes
    - [ ] Plugin code changes for path referenced plugins
    - [ ] Plugin not rebuilding when non-plugin packages are added or removed from .packages
- Rebuilding tpk when non-generated files in the host app folder changes
    - [x] Rebuilding when source code changes 
    - [x] Rebuilding tpk when certificate changes
    - [x] Rebuilding tpk when manifest changes

## Result

### Before

| Build Mode | First Build | Second Build |
|---|---|---|
|Debug| 18.1s | 13.0s|
|Release|19.0s|5.4s|

### After

| Build Mode | First Build | Second Build |
|---|---|---|
|Debug| 19.1s | 1.4s|
|Release|19.9s|0.6s|

