### PR TITLE
Warn if a Tizen plugin is available

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -73,7 +73,7 @@ class TizenPlugins extends Target {
     ephemeralDir.createSync(recursive: true);
 
     final List<TizenPlugin> nativePlugins =
-        await findTizenPlugins(project, filterNative: true);
+        await findTizenPlugins(project, nativeOnly: true);
 
     for (final TizenPlugin plugin in nativePlugins) {
       final Directory pluginDir = environment.fileSystem.directory(plugin.path);
@@ -493,9 +493,10 @@ abstract class NativeTpk extends Target {
     final List<String> userIncludes = <String>[];
     final List<String> userSources = <String>[];
 
-    final List<TizenPlugin> plugins =
-        await findTizenPlugins(project, filterNative: true);
-    for (final TizenPlugin plugin in plugins) {
+    final List<TizenPlugin> nativePlugins =
+        await findTizenPlugins(project, nativeOnly: true);
+
+    for (final TizenPlugin plugin in nativePlugins) {
       final TizenNativeProject pluginProject = TizenNativeProject(plugin.path);
       // TODO(swift-kim): Currently only checks for USER_INC_DIRS and USER_SRCS.
       // More properties (such as USER_LIBS) should be parsed to fully support

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -5,6 +5,7 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/dart/package_map.dart';
@@ -146,6 +147,20 @@ Future<void> main() async {
   return entrypoint.path;
 }
 
+const List<String> _knownPlugins = <String>[
+  'battery',
+  'connectivity',
+  'device_info',
+  'image_picker',
+  'integration_test',
+  'package_info',
+  'path_provider',
+  'sensors',
+  'share',
+  'shared_preferences',
+  'url_launcher',
+];
+
 /// This method has the same role as [ensureReadyForPlatformSpecificTooling].
 ///
 /// See:
@@ -168,6 +183,18 @@ Future<void> injectTizenPlugins(FlutterProject project) async {
         tizenProject.managedDirectory, nativePlugins);
     await _writeCsharpPluginRegistrant(
         tizenProject.managedDirectory, nativePlugins);
+  }
+
+  final List<String> plugins =
+      (await findPlugins(project)).map((Plugin p) => p.name).toList();
+  for (final String plugin in plugins) {
+    final String tizenPlugin = '${plugin}_tizen';
+    if (_knownPlugins.contains(plugin) && !plugins.contains(tizenPlugin)) {
+      globals.printStatus(
+        '$tizenPlugin is available on pub.dev. Did you forget to add to pubspec.yaml?',
+        color: TerminalColor.yellow,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
- Print the following message if `foobar_tizen` plugin (non-endorsed) is available but only `foobar` is added as a dependency.

  ```
  package_info_tizen is available on pub.dev. Did you forget to add to pubspec.yaml?
  path_provider_tizen is available on pub.dev. Did you forget to add to pubspec.yaml?
  ```
  The plugin list is hard-coded and needs update if a new plugin is added to [flutter-tizen/plugins](https://github.com/flutter-tizen/plugins).

- Small refactoring (rename optional parameters of `findTizenPlugins`)

Suggested by @bbrto21 🎉