### PR TITLE
Retain dotnet output

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -28,6 +28,19 @@ import 'tizen_tpk.dart';
 class TizenAssetBundle extends AndroidAssetBundle {
   @override
   String get name => 'tizen_asset_bundle';
+
+  @override
+  Future<void> build(Environment environment) async {
+    // Since debug and release build shares the output folder
+    // ({PROJECT_ROOT}/build/tizen/flutter_assets), we need to
+    // initialize the folder to prevent dirty files from surviving.
+    final Directory flutterAssetsDir =
+        environment.outputDir.childDirectory('flutter_assets');
+    if (flutterAssetsDir.existsSync()) {
+      flutterAssetsDir.deleteSync(recursive: true);
+    }
+    await super.build(environment);
+  }
 }
 
 /// Compiles Tizen native plugins into shared objects.
@@ -179,6 +192,40 @@ abstract class DotnetTpk extends Target {
 
   @override
   Future<void> build(Environment environment) async {
+    // Folders that are used as detinations folders of copy operations
+    // should be reinitialized before running the actual build.
+    // Otherwise the folder may contain dirty files which were
+    // created during different build modes. (ex: debug -> release)
+    // (TODO: HakkyuKim): Consider using something like CopyTarget
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
+    final Directory flutterAssets =
+        ephemeralDir.childDirectory('res').childDirectory('flutter_assets');
+    if (flutterAssets.existsSync()) {
+      flutterAssets.deleteSync(recursive: true);
+    }
+
+    // Output folders of this build should also be initialized to prevent
+    // dirty files from suviving.
+    // (TODO: HakkyuKim) Consider using a subdirectory such as dotnet_output
+    environment.outputDir
+        .listSync()
+        .where((FileSystemEntity entity) =>
+            // flutter_assets is the output directory of [TizenAssetBundle] which this
+            // target depends on. We must not delete this folder.
+            !(entity is Directory && entity.basename == 'flutter_assets'))
+        .where((FileSystemEntity entity) =>
+            // .last_build_id file is maintained by the flutter [_BuildInstance] to
+            // keep track of the latest build mode. We must not delete this file
+            !(entity is File && entity.basename == '.last_build_id'))
+        .forEach((FileSystemEntity entity) {
+      entity.deleteSync(recursive: true);
+    });
+
+    await _build(environment);
+  }
+
+  Future<void> _build(Environment environment) async {
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
 

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -31,9 +31,9 @@ class TizenAssetBundle extends AndroidAssetBundle {
 
   @override
   Future<void> build(Environment environment) async {
-    // Since debug and release build shares the output folder
+    // Since debug and release build shares the output directory
     // ({PROJECT_ROOT}/build/tizen/flutter_assets), we need to
-    // initialize the folder to prevent dirty files from surviving.
+    // clear the directory to prevent dirty files from surviving.
     final Directory flutterAssetsDir =
         environment.outputDir.childDirectory('flutter_assets');
     if (flutterAssetsDir.existsSync()) {
@@ -192,9 +192,9 @@ abstract class DotnetTpk extends Target {
 
   @override
   Future<void> build(Environment environment) async {
-    // Folders that are used as detinations folders of copy operations
-    // should be reinitialized before running the actual build.
-    // Otherwise the folder may contain dirty files which were
+    // Directories that are used as destination directories of copy operations
+    // should be cleared before running the actual build.
+    // Otherwise the directory may contain dirty files which were
     // created during different build modes. (ex: debug -> release)
     // (TODO: HakkyuKim): Consider using something like CopyTarget
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
@@ -205,14 +205,14 @@ abstract class DotnetTpk extends Target {
       flutterAssets.deleteSync(recursive: true);
     }
 
-    // Output folders of this build should also be initialized to prevent
+    // Output directories of this build should also be cleared to prevent
     // dirty files from suviving.
     // (TODO: HakkyuKim) Consider using a subdirectory such as dotnet_output
     environment.outputDir
         .listSync()
         .where((FileSystemEntity entity) =>
             // flutter_assets is the output directory of [TizenAssetBundle] which this
-            // target depends on. We must not delete this folder.
+            // target depends on. We must not delete this directory.
             !(entity is Directory && entity.basename == 'flutter_assets'))
         .where((FileSystemEntity entity) =>
             // .last_build_id file is maintained by the flutter [_BuildInstance] to

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -77,9 +77,6 @@ class TizenBuilder {
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final Directory outputDir =
         project.directory.childDirectory('build').childDirectory('tizen');
-    if (outputDir.existsSync()) {
-      outputDir.deleteSync(recursive: true);
-    }
 
     final Environment environment = Environment(
       projectDir: project.directory,


### PR DESCRIPTION
This is a sub-pr that will allow small future diffs in pr #47 (Reduce Build time using cache files)

 

## The problem

To use the cache build system of `FlutterBuildSystem`, we must retain the output files of `Target` during multiple build commands. However, due to a packaging bug, the current implementation deletes the output folder({PROJECT_ROOT}/build/tizen) in `TizenBuilder.buildTpk`.

 

https://github.com/flutter-tizen/flutter-tizen/blob/942b24847a205da7e9a76c264dfdb861c02cede2/lib/tizen_builder.dart#L80-L82

 

After deleting the output folder, `TizenBuilder.buildTpk` calls `FlutterBuildSystem.build` which is where the cache files are looked up to determine if a `Target` requires a rebuild. 

 

https://github.com/flutter-tizen/flutter-tizen/blob/942b24847a205da7e9a76c264dfdb861c02cede2/lib/tizen_builder.dart#L134-L135

 

Because of this, the current build system can't leverage the cache system correctly.

 

## The packaging bug

 

If `flutter-tizen build tpk --release` is run right after `flutter-tizen build tpk --debug`, the release package will contain three files(vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin) that should only be in a debug package. After including those three unwanting files, those three files were erased from the output directory as if the system was correcting itself(See below for details).

 

### Why did those three file get included?

 

During the execution of `flutter-tizen build tpk --debug`, `TizenAssetBundle.build` method generates several files in `build/tizen/flutter_assets` folder, including vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin. After generating these files, `DotnetTpk.build` method copies all files in the `build/tizen/flutter_assets` folder to `tizen/flutter/ephemeral/res/flutter_assets` folder.

 

https://github.com/flutter-tizen/flutter-tizen/blob/942b24847a205da7e9a76c264dfdb861c02cede2/lib/tizen_build_target.dart#L189-L193

 

Now, suppose we run `flutter-tizen build tpk --release`. The process is same but the data is different, `TizenAssetBundle.build` method generates several files in `build/tizen/flutter_assets` folder, ***but not vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin***. Because we haven't erased the contents of `build/tizen/flutter_assets` before, files with same name will be overwritten, and files that were not touched will just stay there. After this step, `DotnetTpk.build` method copies all files in the `build/tizen/flutter_assets` folder to `tizen/flutter/ephemeral/res/flutter_assets` folder. Here is where the bug happens, the three files that were part of the debug build will be copied to the `tizen/flutter/ephemeral/res/flutter_assets` folder.

 

### Why did the folder correct itself?

 

Before completing `flutter-tizen build tpk --release`, `build/tizen/flutter_assets` folder  contains vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin, as it should, bases on the explanation above. But just before finishing the command, the three files in the `build/tizen/flutter_assets` folder disappears(as if the folder is correcting itself). This is because of the `trackSharedBuildDirectory` method in `build_system.dart`.

 

https://github.com/flutter/flutter/blob/c4fe3461e782a610f89cb9f65f830030ddf2a545/packages/flutter_tools/lib/src/build_system/build_system.dart#L697-L701

 

This method reads `output.json` file of the last build---the `output.json` contains all output files generated during the build. Then, for each file in `output.json`, check if the file was generated in the current build(checks against `buildInstance.outputFiles`, where all generated output files are logged during the build). If it wasn't, the method deletes that file from the system it it exists. 

 

In our case, the last build was **debug**, so `output.json` contains vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin. The current build was **release**, so `buildInstance.outputFiles` will not contain those three files. Therefore vm_snapshot_data, isolate_snapshot_data, and kernel_blob.bin will be erased from the system.

 

https://github.com/flutter/flutter/blob/c4fe3461e782a610f89cb9f65f830030ddf2a545/packages/flutter_tools/lib/src/build_system/build_system.dart#L731-L736

 

#### Log test to check correctess

Code reference: https://github.com/flutter/flutter/blob/c4fe3461e782a610f89cb9f65f830030ddf2a545/packages/flutter_tools/lib/src/build_system/build_system.dart#L731-L736
 

![Screenshot from 2021-03-02 04-53-23](https://user-images.githubusercontent.com/43136596/109551658-2da0b000-7b14-11eb-8134-3331c912b1f3.png)

 

![Screenshot from 2021-03-02 04-58-34](https://user-images.githubusercontent.com/43136596/109551665-31343700-7b14-11eb-9865-87b2857e5163.png)

 

 

## What are the changes?

To leverage the cache build system, initialization of the output folder should be performed in `Target.build`, so that `FlutterBuildSystem` is able to first check the cache files. Technically, all output folders (destination folders for file creation/update/copy) must not leave dirty files that were created in the previous builds. One solution that ensures this is initializing the folder to the "original state" before any operation. Note that the "original state" doesn't necessary mean an empty folder, `Target`s can share an output folder in the build pipeline, for example, if a dependent `Target` has created a file A in some other `Target`'s output folder, the "original state" of that `Target`'s output folder is a folder that only contains file A.

 

## Results

Release packaging works correctly without removing the output folder before cache look-ups. This pr doesn't yet leverage the cache build system. It is an intermediate change to help track code diff. 