### PR TITLE
Impl dotnet tpk cache validation

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/build.dart';
@@ -13,10 +15,14 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/source.dart';
+import 'package:flutter_tools/src/build_system/depfile.dart';
+import 'package:flutter_tools/src/build_system/targets/icon_tree_shaker.dart';
+import 'package:flutter_tools/src/build_system/targets/assets.dart';
 import 'package:flutter_tools/src/build_system/targets/android.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/build_system/file_store.dart';
 
 import 'tizen_artifacts.dart';
 import 'tizen_builder.dart';
@@ -26,22 +32,80 @@ import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
 
 /// Prepares the pre-built flutter bundle.
-class TizenAssetBundle extends AndroidAssetBundle {
+/// Source: [AndroidAssetBundle] in `android.dart`
+class TizenAssetBundle extends Target {
+  TizenAssetBundle(this.project);
+
+  final FlutterProject project;
+
   @override
   String get name => 'tizen_asset_bundle';
 
   @override
+  List<Source> get inputs => const <Source>[
+        Source.pattern('{BUILD_DIR}/app.dill'),
+        ...IconTreeShaker.inputs,
+      ];
+
+  @override
+  List<Source> get outputs => const <Source>[];
+
+  @override
+  List<String> get depfiles => <String>[
+        'flutter_assets.d',
+      ];
+
+  @override
   Future<void> build(Environment environment) async {
-    // Since debug and release build shares the output directory
-    // ({PROJECT_ROOT}/build/tizen/flutter_assets), we need to
-    // clear the directory to prevent dirty files from surviving.
-    final Directory flutterAssetsDir =
-        environment.outputDir.childDirectory('flutter_assets');
-    if (flutterAssetsDir.existsSync()) {
-      flutterAssetsDir.deleteSync(recursive: true);
+    if (environment.defines[kBuildMode] == null) {
+      throw MissingDefineException(kBuildMode, name);
     }
-    await super.build(environment);
+    final BuildMode buildMode =
+        getBuildModeForName(environment.defines[kBuildMode]);
+
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    final Directory outputDirectory = tizenProject.ephemeralDirectory
+        .childDirectory('res')
+        .childDirectory('flutter_assets')
+          ..createSync(recursive: true);
+
+    // Only copy the prebuilt runtimes and kernel blob in debug mode.
+    if (buildMode == BuildMode.debug) {
+      final String vmSnapshotData = environment.artifacts
+          .getArtifactPath(Artifact.vmSnapshotData, mode: BuildMode.debug);
+      final String isolateSnapshotData = environment.artifacts
+          .getArtifactPath(Artifact.isolateSnapshotData, mode: BuildMode.debug);
+      environment.buildDir
+          .childFile('app.dill')
+          .copySync(outputDirectory.childFile('kernel_blob.bin').path);
+      environment.fileSystem
+          .file(vmSnapshotData)
+          .copySync(outputDirectory.childFile('vm_snapshot_data').path);
+      environment.fileSystem
+          .file(isolateSnapshotData)
+          .copySync(outputDirectory.childFile('isolate_snapshot_data').path);
+    }
+
+    final Depfile assetDepfile = await copyAssets(
+      environment,
+      outputDirectory,
+      targetPlatform: TargetPlatform.tester,
+    );
+    final DepfileService depfileService = DepfileService(
+      fileSystem: environment.fileSystem,
+      logger: environment.logger,
+    );
+    depfileService.writeToFile(
+      assetDepfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
   }
+
+  @override
+  List<Target> get dependencies => const <Target>[
+        KernelSnapshot(),
+      ];
 }
 
 /// Compiles Tizen native plugins into shared objects.
@@ -60,11 +124,16 @@ class TizenPlugins extends Target {
   @override
   List<Source> get inputs => const <Source>[
         Source.pattern('{PROJECT_DIR}/.packages'),
+        Source.pattern('{PROJECT_DIR}/.flutter-plugins'),
+        Source.pattern('{PROJECT_DIR}/.flutter-plugins-dependencies'),
       ];
 
   @override
-  List<Source> get outputs => const <Source>[
-        Source.pattern('{PROJECT_DIR}/tizen/flutter/ephemeral'),
+  List<Source> get outputs => const <Source>[];
+
+  @override
+  List<String> get depfiles => <String>[
+        'tizen_plugins.d',
       ];
 
   @override
@@ -72,6 +141,9 @@ class TizenPlugins extends Target {
 
   @override
   Future<void> build(Environment environment) async {
+    final List<File> inputs = <File>[];
+    final List<File> outputs = <File>[];
+
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
 
@@ -81,10 +153,6 @@ class TizenPlugins extends Target {
 
     // Clear the output directory.
     final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    if (ephemeralDir.existsSync()) {
-      ephemeralDir.deleteSync(recursive: true);
-    }
-    ephemeralDir.createSync(recursive: true);
 
     final List<TizenPlugin> nativePlugins =
         await findTizenPlugins(project, nativeOnly: true);
@@ -160,113 +228,74 @@ class TizenPlugins extends Target {
             .childDirectory(arch)
               ..createSync(recursive: true);
         sharedLib.copySync(outputDir.childFile(sharedLib.basename).path);
+        outputs.add(outputDir.childFile(sharedLib.basename));
       }
     }
+
+    final DepfileService depfileService = DepfileService(
+      fileSystem: environment.fileSystem,
+      logger: environment.logger,
+    );
+    depfileService.writeToFile(
+      Depfile(inputs, outputs),
+      environment.buildDir.childFile('tizen_plugins.d'),
+    );
   }
 }
 
-abstract class DotnetTpk extends Target {
-  DotnetTpk(this.project, this.buildInfo);
+// The mixin that handles packaging tpk files
+mixin TizenPackager on Target {
+  PackageTpkDelegate _packageTpkDelegate = _DefaultPackageTpkDelegate();
 
-  final FlutterProject project;
-  final TizenBuildInfo buildInfo;
+  void _setPackageTpkDelegate(PackageTpkDelegate packageTpkDelegate) {
+    _packageTpkDelegate = packageTpkDelegate;
+  }
+
+  Future<File> package(Environment environment) async {
+    return await _packageTpkDelegate.package(environment);
+  }
+}
+
+// The base class that performs tpk packaging.
+abstract class PackageTpkDelegate {
+  Future<File> package(Environment environment);
+}
+
+// The default packaging delegate returns the previously built tpk
+class _DefaultPackageTpkDelegate implements PackageTpkDelegate {
+  _DefaultPackageTpkDelegate();
+
+  @override
+  Future<File> package(Environment environment) {
+    final FlutterProject flutterProject =
+        FlutterProject.fromDirectory(environment.projectDir);
+    final TizenProject tizenProject = TizenProject.fromFlutter(flutterProject);
+    final File tpk =
+        environment.outputDir.childFile(tizenProject.outputTpkName);
+    if (!tpk.existsSync()) {
+      throwToolExit('Failed to locate TPK: ${tpk.path}');
+    }
+    return Future<File>.value(tpk);
+  }
+}
+
+// The packaing delegate for Tizen dotnet project. This delegate should be called after
+// running 'FlutterBuildSystem.build'; after the tpk source directory({PROJECT_DIR}/tizen)
+// is set to the current build mode.
+class DotnetPackageTpkDelegate implements PackageTpkDelegate {
+  DotnetPackageTpkDelegate(this.securityProfile);
+
+  final String securityProfile;
 
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
 
   @override
-  List<Source> get inputs => const <Source>[
-        Source.pattern('{PROJECT_DIR}/tizen'),
-        Source.pattern('{OUTPUT_DIR}/flutter_assets'),
-      ];
-
-  @override
-  List<Source> get outputs => const <Source>[
-        Source.pattern('{OUTPUT_DIR}/*.tpk'),
-      ];
-
-  @override
-  List<Target> get dependencies => <Target>[
-        TizenAssetBundle(),
-        TizenPlugins(project, buildInfo),
-      ];
-
-  @override
-  Future<void> build(Environment environment) async {
-    // Directories that are used as destination directories of copy operations
-    // should be cleared before running the actual build.
-    // Otherwise the directory may contain dirty files which were
-    // created during different build modes. (ex: debug -> release)
-    // (TODO: HakkyuKim): Consider using something like CopyTarget
-    final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    final Directory flutterAssets =
-        ephemeralDir.childDirectory('res').childDirectory('flutter_assets');
-    if (flutterAssets.existsSync()) {
-      flutterAssets.deleteSync(recursive: true);
-    }
-
-    // Output directories of this build should also be cleared to prevent
-    // dirty files from suviving.
-    // (TODO: HakkyuKim) Consider using a subdirectory such as dotnet_output
-    environment.outputDir
-        .listSync()
-        .where((FileSystemEntity entity) =>
-            // flutter_assets is the output directory of [TizenAssetBundle] which this
-            // target depends on. We must not delete this directory.
-            !(entity is Directory && entity.basename == 'flutter_assets'))
-        .where((FileSystemEntity entity) =>
-            // .last_build_id file is maintained by the flutter [_BuildInstance] to
-            // keep track of the latest build mode. We must not delete this file
-            !(entity is File && entity.basename == '.last_build_id'))
-        .forEach((FileSystemEntity entity) {
-      entity.deleteSync(recursive: true);
-    });
-
-    await _build(environment);
-  }
-
-  Future<void> _build(Environment environment) async {
-    final BuildMode buildMode =
-        getBuildModeForName(environment.defines[kBuildMode]);
-
-    // Copy ephemeral files.
+  Future<File> package(Environment environment) async {
+    final FlutterProject flutterProject =
+        FlutterProject.fromDirectory(environment.projectDir);
+    final TizenProject tizenProject = TizenProject.fromFlutter(flutterProject);
     final Directory outputDir = environment.outputDir;
-    final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    final Directory resDir = ephemeralDir.childDirectory('res')
-      ..createSync(recursive: true);
-    globals.fsUtils.copyDirectorySync(
-        outputDir.childDirectory('flutter_assets'),
-        resDir.childDirectory('flutter_assets'));
-
-    for (final String arch in buildInfo.targetArchs) {
-      final Directory libDir = ephemeralDir
-          .childDirectory('lib')
-          .childDirectory(arch)
-            ..createSync(recursive: true);
-
-      final Directory engineDir = tizenArtifacts.getEngineDirectory(
-          getTargetPlatformForArch(arch), buildMode);
-      final File engineBinary = engineDir.childFile('libflutter_engine.so');
-      final File embedding = engineDir.childFile('libflutter_tizen.so');
-      final File icuData =
-          engineDir.parent.childDirectory('common').childFile('icudtl.dat');
-
-      engineBinary.copySync(libDir.childFile(engineBinary.basename).path);
-      embedding.copySync(libDir.childFile(embedding.basename).path);
-      icuData.copySync(resDir.childFile(icuData.basename).path);
-
-      if (tizenProject.apiVersion.startsWith('4')) {
-        final File embedding40 = engineDir.childFile('libflutter_tizen40.so');
-        embedding40.copySync(libDir.childFile(embedding40.basename).path);
-      }
-      if (buildMode.isPrecompiled) {
-        final File aotSharedLib =
-            environment.buildDir.childDirectory(arch).childFile('app.so');
-        aotSharedLib.copySync(libDir.childFile('libapp.so').path);
-      }
-    }
 
     // For now a constant value is used instead of reading from a file.
     // Keep this value in sync with the latest published nuget version.
@@ -308,6 +337,166 @@ abstract class DotnetTpk extends Target {
     // We need to re-generate the TPK by signing with a correct profile.
     // TODO(swift-kim): Apply the profile during .NET build for efficiency.
     // Password descryption by secret-tool will be needed for full automation.
+    environment.logger
+        .printStatus('The $securityProfile profile is used for signing.');
+    result = await _processUtils.run(<String>[
+      tizenSdk.tizenCli.path,
+      'package',
+      '-t',
+      'tpk',
+      '-s',
+      securityProfile,
+      '--',
+      outputDir.childFile(tizenProject.outputTpkName).path,
+    ]);
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to sign the TPK:\n$result');
+    }
+
+    await _persistFileCache(environment);
+    return outputDir.childFile(tizenProject.outputTpkName);
+  }
+
+  Future<void> _persistFileCache(Environment environment) async {
+    final FlutterProject flutterProject =
+        FlutterProject.fromDirectory(environment.projectDir);
+    final TizenProject tizenProject = TizenProject.fromFlutter(flutterProject);
+    final File tpk =
+        environment.outputDir.childFile(tizenProject.outputTpkName);
+
+    final File cacheFile = environment.buildDir.childFile(FileStore.kFileCache);
+    final FileStore fileCache = FileStore(
+      cacheFile: cacheFile,
+      logger: environment.logger,
+    )..initialize();
+
+    // update tpk hash
+    fileCache.currentAssetKeys.addAll(fileCache.previousAssetKeys);
+    await fileCache.diffFileList(<File>[tpk]);
+    fileCache.persist();
+  }
+}
+
+abstract class DotnetTpk extends Target with TizenPackager {
+  DotnetTpk(this.project, this.buildInfo);
+
+  final FlutterProject project;
+  final TizenBuildInfo buildInfo;
+
+  @override
+  List<Source> get inputs => const <Source>[];
+
+  @override
+  List<Source> get outputs => const <Source>[
+        Source.pattern('{OUTPUT_DIR}/*.tpk'),
+      ];
+
+  @override
+  List<Target> get dependencies => <Target>[
+        TizenAssetBundle(project),
+        TizenPlugins(project, buildInfo),
+      ];
+
+  @override
+  List<String> get depfiles => <String>[
+        'dotnet_tpk.d',
+      ];
+
+  @override
+  Future<void> build(Environment environment) async {
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    final List<File> inputs = <File>[];
+    final List<File> outputs = <File>[
+      environment.outputDir.childFile(tizenProject.outputTpkName),
+    ];
+
+    final DepfileService depfileService = DepfileService(
+      fileSystem: environment.fileSystem,
+      logger: environment.logger,
+    );
+    final File flutterAssetsDep =
+        environment.buildDir.childFile('flutter_assets.d');
+    if (flutterAssetsDep.existsSync()) {
+      final Depfile flutterAssets = depfileService.parse(flutterAssetsDep);
+      inputs.addAll(flutterAssets.outputs);
+    }
+    final File tizenPluginsDep =
+        environment.buildDir.childFile('tizen_plugins.d');
+    if (tizenPluginsDep.existsSync()) {
+      final Depfile tizenPlugins = depfileService.parse(flutterAssetsDep);
+      inputs.addAll(tizenPlugins.outputs);
+    }
+
+    final BuildMode buildMode =
+        getBuildModeForName(environment.defines[kBuildMode]);
+
+    // Copy ephemeral files.
+    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
+    final Directory resDir = ephemeralDir.childDirectory('res')
+      ..createSync(recursive: true);
+
+    for (final String arch in buildInfo.targetArchs) {
+      final Directory libDir = ephemeralDir
+          .childDirectory('lib')
+          .childDirectory(arch)
+            ..createSync(recursive: true);
+
+      final Directory engineDir = tizenArtifacts.getEngineDirectory(
+          getTargetPlatformForArch(arch), buildMode);
+      final File engineBinary = engineDir.childFile('libflutter_engine.so');
+      final File embedding = engineDir.childFile('libflutter_tizen.so');
+      final File icuData =
+          engineDir.parent.childDirectory('common').childFile('icudtl.dat');
+      inputs.addAll(<File>[engineBinary, embedding, icuData]);
+
+      engineBinary.copySync(libDir.childFile(engineBinary.basename).path);
+      outputs.add(libDir.childFile(engineBinary.basename));
+      embedding.copySync(libDir.childFile(embedding.basename).path);
+      outputs.add(libDir.childFile(embedding.basename));
+      icuData.copySync(resDir.childFile(icuData.basename).path);
+      outputs.add(resDir.childFile(icuData.basename));
+
+      if (tizenProject.apiVersion.startsWith('4')) {
+        final File embedding40 = engineDir.childFile('libflutter_tizen40.so');
+        embedding40.copySync(libDir.childFile(embedding40.basename).path);
+        inputs.add(embedding40);
+        outputs.add(libDir.childFile(embedding40.basename));
+      }
+      if (buildMode.isPrecompiled) {
+        final File aotSharedLib =
+            environment.buildDir.childDirectory(arch).childFile('app.so');
+        aotSharedLib.copySync(libDir.childFile('libapp.so').path);
+        inputs.add(aotSharedLib);
+        outputs.add(libDir.childFile('libapp.so'));
+      }
+    }
+
+    // add host app files
+    final List<Directory> directories = tizenProject.editableDirectory
+        .listSync()
+        .whereType<Directory>()
+        .where((Directory directory) =>
+            directory.basename != 'obj' &&
+            directory.basename != 'bin' &&
+            directory.basename != 'flutter')
+        .toList();
+
+    inputs.addAll(<File>[
+      // all files in subdirectories of tizen host app root
+      // except obj, bin, and flutter. For example, all
+      // resoruce files in shared directory must be included
+      for (final Directory directory in directories)
+        ...directory.listSync(recursive: true).whereType<File>(),
+      // all files in host app root, such as App.cs, NuGet.Config, etc
+      ...tizenProject.editableDirectory.listSync().whereType<File>(),
+      // generated plugin injection codes
+      ...tizenProject.editableDirectory
+          .childDirectory('flutter')
+          .listSync()
+          .whereType<File>(),
+    ]);
+
     String securityProfile = buildInfo.securityProfile;
     if (securityProfile != null &&
         (tizenSdk.securityProfiles == null ||
@@ -315,22 +504,18 @@ abstract class DotnetTpk extends Target {
       throwToolExit('The security profile $securityProfile does not exist.');
     }
 
+    // add profiles list file as input dependency
+    inputs.add(tizenSdk.securityProfilesFile);
     securityProfile ??= tizenSdk.securityProfiles?.activeProfile?.name;
+
     if (securityProfile != null) {
-      environment.logger
-          .printStatus('The $securityProfile profile is used for signing.');
-      result = await _processUtils.run(<String>[
-        tizenSdk.tizenCli.path,
-        'package',
-        '-t',
-        'tpk',
-        '-s',
-        securityProfile,
-        '--',
-        outputDir.childFile(tizenProject.outputTpkName).path,
-      ]);
-      if (result.exitCode != 0) {
-        throwToolExit('Failed to sign the TPK:\n$result');
+      // add signing profile certificates as input dependencies
+      final SecurityProfile signingProfile =
+          tizenSdk.securityProfiles.getProfile(securityProfile);
+      inputs.add(globals.fs.file(signingProfile.authorCertificate.key));
+      for (final Certificate certificate
+          in signingProfile.distributorCertificates) {
+        inputs.add(globals.fs.file(certificate.key));
       }
     } else {
       globals.printStatus(
@@ -339,6 +524,13 @@ abstract class DotnetTpk extends Target {
         color: TerminalColor.yellow,
       );
     }
+
+    _setPackageTpkDelegate(DotnetPackageTpkDelegate(securityProfile));
+
+    depfileService.writeToFile(
+      Depfile(inputs, outputs),
+      environment.buildDir.childFile('dotnet_tpk.d'),
+    );
   }
 }
 
@@ -453,10 +645,12 @@ class DebugDotnetTpk extends DotnetTpk {
   @override
   List<Source> get outputs => <Source>[
         ...super.outputs,
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
         const Source.pattern(
-            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/vm_snapshot_data'),
+        const Source.pattern(
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/isolate_snapshot_data'),
+        const Source.pattern(
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/kernel_blob.bin'),
       ];
 }
 
@@ -475,7 +669,7 @@ class ReleaseDotnetTpk extends DotnetTpk {
       ];
 }
 
-abstract class NativeTpk extends Target {
+abstract class NativeTpk extends Target with TizenPackager {
   NativeTpk(this.project, this.buildInfo);
 
   final FlutterProject project;
@@ -497,7 +691,7 @@ abstract class NativeTpk extends Target {
 
   @override
   List<Target> get dependencies => <Target>[
-        TizenAssetBundle(),
+        TizenAssetBundle(project),
       ];
 
   @override
@@ -665,10 +859,12 @@ class DebugNativeTpk extends NativeTpk {
   @override
   List<Source> get outputs => <Source>[
         ...super.outputs,
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
         const Source.pattern(
-            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/vm_snapshot_data'),
+        const Source.pattern(
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/isolate_snapshot_data'),
+        const Source.pattern(
+            '{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets/kernel_blob.bin'),
       ];
 }
 

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -388,7 +388,8 @@ abstract class DotnetTpk extends TizenPackage {
       // add signing profile certificates as input dependencies
       final SecurityProfile signingProfile =
           tizenSdk.securityProfiles.getProfile(securityProfile);
-      inputs.add(environment.fileSystem.file(signingProfile.authorCertificate.key));
+      inputs.add(
+          environment.fileSystem.file(signingProfile.authorCertificate.key));
       for (final Certificate certificate
           in signingProfile.distributorCertificates) {
         inputs.add(environment.fileSystem.file(certificate.key));
@@ -477,7 +478,7 @@ abstract class DotnetTpk extends TizenPackage {
     _isTpkCached = true;
   }
 
-  Future<void> _persistTpkCache(Environment environment) async{
+  Future<void> _persistTpkCache(Environment environment) async {
     final FlutterProject flutterProject =
         FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(flutterProject);

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -112,7 +112,7 @@ class TizenBuilder {
       processManager: globals.processManager,
     );
 
-    TizenPackager target;
+    Target target;
     if (tizenProject.isDotnet) {
       target = buildInfo.mode.isJit
           ? DebugDotnetTpk(project, tizenBuildInfo)
@@ -150,7 +150,9 @@ class TizenBuilder {
       // Since Tizen shares the host app directory between different build modes,
       // we must package tpk file after 'FlutterBuildSystem.build' has finished
       // compiling binaries and has removed dirty files from 'PROJECT_ROOT/tizen'.
-      await target.package(environment);
+      if(target is DotnetTpk && !target.isTpkCached){
+        await target.package(environment);
+      }
 
       if (buildInfo.performanceMeasurementFile != null) {
         final File outFile =

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -32,6 +32,10 @@ import 'tizen_build_target.dart';
 import 'tizen_project.dart';
 import 'tizen_tpk.dart';
 
+/// The define to control what Tizen architectures are built for.
+/// This is expected to be a comma-separated list of architectures.
+const String kTizenArchs = 'TizenArchs';
+
 /// See: [AndroidBuildInfo] in `build_info.dart`
 class TizenBuildInfo {
   const TizenBuildInfo(
@@ -88,6 +92,7 @@ class TizenBuilder {
           ? null
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
+        kTizenArchs: tizenBuildInfo.targetArchs.join(','),
         kTargetFile: targetFile,
         kBuildMode: getNameForBuildMode(buildInfo.mode),
         kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android),

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -150,7 +150,7 @@ class TizenBuilder {
       // Since Tizen shares the host app directory between different build modes,
       // we must package tpk file after 'FlutterBuildSystem.build' has finished
       // compiling binaries and has removed dirty files from 'PROJECT_ROOT/tizen'.
-      if(target is DotnetTpk && !target.isTpkCached){
+      if (target is DotnetTpk && !target.isTpkCached) {
         await target.package(environment);
       }
 


### PR DESCRIPTION
This pr implements the functionality of repackaging tpks only when its necessary. Original implementation was https://github.com/flutter-tizen/flutter-tizen/pull/47,
but it couldn't handle packaging between different build modes.

As stated in https://github.com/flutter-tizen/flutter-tizen/pull/51, the `FlutterBuildSystem` cleans dirty files in directories that are shared by different build modes at the last step of `FlutterBuildSystem.build`. Packaging the tpk right after `FlutterBuildSystem.build` is simpler than writing code that find dirty files and delete them.

### Summary of changes

- created `TizenPackager` and `PackageTpkDelegate` constructs to separate packaging from the `Target.build` method
- created `TizenAssetsBundle` class so that flutter_assets files are written directory to `{PROJECT_DIR}/tizen/flutter/ephemeral/res/flutter_assets`
- added proper files as cache sources for `TizenPlugins` and `DotnetTpk`.

### Correctness
The code was tested with a set of test cases in https://github.com/HakkyuKim/flutter-tizen/tree/dotnet-tpk-cache-validation-test.
To run the test, run the following command in the flutter-tizen project root directory.
```
./flutter/bin/cache/dart-sdk/bin/pub run test test/tizen_build_target_test.dart
```

### Limitation
- Validating cache for plugin packages with path dependencies is non-trivial. At the moment, `TizenPlugins` always rebuilds. when there is at least one plugin dependency, flutter always writes timestamp to `.flutter-plugins-dependencies` before building. Adding `.flutter-plugins-dependencies` file to input source will trigger rebuild everytime.
- Currently doesn't support native projects.