### PR TITLE
Fix the following bugs

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -27,21 +27,60 @@ import 'tizen_tpk.dart';
 
 /// Prepares the pre-built flutter bundle.
 class TizenAssetBundle extends AndroidAssetBundle {
+  TizenAssetBundle(this.project, this.buildInfo);
+
+  final FlutterProject project;
+  final TizenBuildInfo buildInfo;
+
   @override
   String get name => 'tizen_asset_bundle';
 
   @override
-  Future<void> build(Environment environment) async {
-    // Since debug and release build shares the output directory
-    // ({PROJECT_ROOT}/build/tizen/flutter_assets), we need to
-    // clear the directory to prevent dirty files from surviving.
-    final Directory flutterAssetsDir =
-        environment.outputDir.childDirectory('flutter_assets');
-    if (flutterAssetsDir.existsSync()) {
-      flutterAssetsDir.deleteSync(recursive: true);
-    }
-    await super.build(environment);
-  }
+  List<Target> get dependencies => <Target>[
+        ...super.dependencies,
+        TizenPlugins(project, buildInfo),
+      ];
+}
+
+/// Source: [DebugAndroidApplication] in `android.dart`
+class DebugTizenAssetBundle extends TizenAssetBundle {
+  DebugTizenAssetBundle(FlutterProject project, TizenBuildInfo buildInfo)
+      : super(project, buildInfo);
+
+  @override
+  String get name => 'debug_tizen_asset_bundle';
+
+  @override
+  List<Source> get inputs => <Source>[
+        ...super.inputs,
+        const Source.artifact(Artifact.vmSnapshotData, mode: BuildMode.debug),
+        const Source.artifact(Artifact.isolateSnapshotData,
+            mode: BuildMode.debug),
+      ];
+
+  @override
+  List<Source> get outputs => <Source>[
+        ...super.outputs,
+        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
+        const Source.pattern(
+            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
+        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
+      ];
+}
+
+/// See: [ReleaseAndroidApplication] in `android.dart`
+class ReleaseTizenAssetBundle extends TizenAssetBundle {
+  ReleaseTizenAssetBundle(FlutterProject project, TizenBuildInfo buildInfo)
+      : super(project, buildInfo);
+
+  @override
+  String get name => 'release_tizen_asset_bundle';
+
+  @override
+  List<Target> get dependencies => <Target>[
+        TizenAotElf(buildInfo.targetArchs),
+        ...super.dependencies,
+      ];
 }
 
 /// Compiles Tizen native plugins into shared objects.
@@ -165,7 +204,7 @@ class TizenPlugins extends Target {
   }
 }
 
-abstract class DotnetTpk extends Target {
+class DotnetTpk {
   DotnetTpk(this.project, this.buildInfo);
 
   final FlutterProject project;
@@ -174,71 +213,21 @@ abstract class DotnetTpk extends Target {
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
 
-  @override
-  List<Source> get inputs => const <Source>[
-        Source.pattern('{PROJECT_DIR}/tizen'),
-        Source.pattern('{OUTPUT_DIR}/flutter_assets'),
-      ];
-
-  @override
-  List<Source> get outputs => const <Source>[
-        Source.pattern('{OUTPUT_DIR}/*.tpk'),
-      ];
-
-  @override
-  List<Target> get dependencies => <Target>[
-        TizenAssetBundle(),
-        TizenPlugins(project, buildInfo),
-      ];
-
-  @override
   Future<void> build(Environment environment) async {
-    // Directories that are used as destination directories of copy operations
-    // should be cleared before running the actual build.
-    // Otherwise the directory may contain dirty files which were
-    // created during different build modes. (ex: debug -> release)
-    // (TODO: HakkyuKim): Consider using something like CopyTarget
-    final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    final Directory flutterAssets =
-        ephemeralDir.childDirectory('res').childDirectory('flutter_assets');
-    if (flutterAssets.existsSync()) {
-      flutterAssets.deleteSync(recursive: true);
-    }
-
-    // Output directories of this build should also be cleared to prevent
-    // dirty files from suviving.
-    // (TODO: HakkyuKim) Consider using a subdirectory such as dotnet_output
-    environment.outputDir
-        .listSync()
-        .where((FileSystemEntity entity) =>
-            // flutter_assets is the output directory of [TizenAssetBundle] which this
-            // target depends on. We must not delete this directory.
-            !(entity is Directory && entity.basename == 'flutter_assets'))
-        .where((FileSystemEntity entity) =>
-            // .last_build_id file is maintained by the flutter [_BuildInstance] to
-            // keep track of the latest build mode. We must not delete this file
-            !(entity is File && entity.basename == '.last_build_id'))
-        .forEach((FileSystemEntity entity) {
-      entity.deleteSync(recursive: true);
-    });
-
-    await _build(environment);
-  }
-
-  Future<void> _build(Environment environment) async {
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
 
-    // Copy ephemeral files.
     final Directory outputDir = environment.outputDir;
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
     final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    final Directory resDir = ephemeralDir.childDirectory('res')
-      ..createSync(recursive: true);
+    final Directory resDir = ephemeralDir.childDirectory('res');
+    final Directory flutterAssetsDir = resDir.childDirectory('flutter_assets');
+
+    if (flutterAssetsDir.existsSync()) {
+      flutterAssetsDir.deleteSync(recursive: true);
+    }
     globals.fsUtils.copyDirectorySync(
-        outputDir.childDirectory('flutter_assets'),
-        resDir.childDirectory('flutter_assets'));
+        outputDir.childDirectory('flutter_assets'), flutterAssetsDir);
 
     for (final String arch in buildInfo.targetArchs) {
       final Directory libDir = ephemeralDir
@@ -435,48 +424,7 @@ class TizenAotElf extends Target {
   }
 }
 
-/// Source: [DebugAndroidApplication] in `android.dart`
-class DebugDotnetTpk extends DotnetTpk {
-  DebugDotnetTpk(FlutterProject project, TizenBuildInfo buildInfo)
-      : super(project, buildInfo);
-
-  @override
-  String get name => 'debug_dotnet_tpk';
-
-  @override
-  List<Source> get inputs => <Source>[
-        ...super.inputs,
-        const Source.artifact(Artifact.vmSnapshotData, mode: BuildMode.debug),
-        const Source.artifact(Artifact.isolateSnapshotData,
-            mode: BuildMode.debug),
-      ];
-
-  @override
-  List<Source> get outputs => <Source>[
-        ...super.outputs,
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
-        const Source.pattern(
-            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
-      ];
-}
-
-/// See: [ReleaseAndroidApplication] in `android.dart`
-class ReleaseDotnetTpk extends DotnetTpk {
-  ReleaseDotnetTpk(FlutterProject project, TizenBuildInfo buildInfo)
-      : super(project, buildInfo);
-
-  @override
-  String get name => 'release_dotnet_tpk';
-
-  @override
-  List<Target> get dependencies => <Target>[
-        TizenAotElf(buildInfo.targetArchs),
-        ...super.dependencies,
-      ];
-}
-
-abstract class NativeTpk extends Target {
+class NativeTpk {
   NativeTpk(this.project, this.buildInfo);
 
   final FlutterProject project;
@@ -485,23 +433,6 @@ abstract class NativeTpk extends Target {
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
 
-  @override
-  List<Source> get inputs => const <Source>[
-        Source.pattern('{PROJECT_DIR}/tizen'),
-        Source.pattern('{OUTPUT_DIR}/flutter_assets'),
-      ];
-
-  @override
-  List<Source> get outputs => const <Source>[
-        Source.pattern('{OUTPUT_DIR}/*.tpk'),
-      ];
-
-  @override
-  List<Target> get dependencies => <Target>[
-        TizenAssetBundle(),
-      ];
-
-  @override
   Future<void> build(Environment environment) async {
     final BuildMode buildMode =
         getBuildModeForName(environment.defines[kBuildMode]);
@@ -645,43 +576,4 @@ abstract class NativeTpk extends Target {
           'Build succeeded but the expected TPK not found:\n${result.stdout}');
     }
   }
-}
-
-class DebugNativeTpk extends NativeTpk {
-  DebugNativeTpk(FlutterProject project, TizenBuildInfo buildInfo)
-      : super(project, buildInfo);
-
-  @override
-  String get name => 'debug_native_tpk';
-
-  @override
-  List<Source> get inputs => <Source>[
-        ...super.inputs,
-        const Source.artifact(Artifact.vmSnapshotData, mode: BuildMode.debug),
-        const Source.artifact(Artifact.isolateSnapshotData,
-            mode: BuildMode.debug),
-      ];
-
-  @override
-  List<Source> get outputs => <Source>[
-        ...super.outputs,
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
-        const Source.pattern(
-            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
-      ];
-}
-
-class ReleaseNativeTpk extends NativeTpk {
-  ReleaseNativeTpk(FlutterProject project, TizenBuildInfo buildInfo)
-      : super(project, buildInfo);
-
-  @override
-  String get name => 'release_native_tpk';
-
-  @override
-  List<Target> get dependencies => <Target>[
-        TizenAotElf(buildInfo.targetArchs),
-        ...super.dependencies,
-      ];
 }

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -26,7 +26,7 @@ import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
 
 /// Prepares the pre-built flutter bundle.
-class TizenAssetBundle extends AndroidAssetBundle {
+abstract class TizenAssetBundle extends AndroidAssetBundle {
   TizenAssetBundle(this.project, this.buildInfo);
 
   final FlutterProject project;
@@ -34,21 +34,15 @@ class TizenAssetBundle extends AndroidAssetBundle {
 
   @override
   String get name => 'tizen_asset_bundle';
-
-  @override
-  List<Target> get dependencies => <Target>[
-        ...super.dependencies,
-        TizenPlugins(project, buildInfo),
-      ];
 }
 
 /// Source: [DebugAndroidApplication] in `android.dart`
-class DebugTizenAssetBundle extends TizenAssetBundle {
-  DebugTizenAssetBundle(FlutterProject project, TizenBuildInfo buildInfo)
+class DebugTizenApplication extends TizenAssetBundle {
+  DebugTizenApplication(FlutterProject project, TizenBuildInfo buildInfo)
       : super(project, buildInfo);
 
   @override
-  String get name => 'debug_tizen_asset_bundle';
+  String get name => 'debug_tizen_application';
 
   @override
   List<Source> get inputs => <Source>[
@@ -66,20 +60,29 @@ class DebugTizenAssetBundle extends TizenAssetBundle {
             '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
         const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
       ];
-}
-
-/// See: [ReleaseAndroidApplication] in `android.dart`
-class ReleaseTizenAssetBundle extends TizenAssetBundle {
-  ReleaseTizenAssetBundle(FlutterProject project, TizenBuildInfo buildInfo)
-      : super(project, buildInfo);
-
-  @override
-  String get name => 'release_tizen_asset_bundle';
 
   @override
   List<Target> get dependencies => <Target>[
-        TizenAotElf(buildInfo.targetArchs),
         ...super.dependencies,
+        if (TizenProject.fromFlutter(project).isDotnet)
+          TizenPlugins(project, buildInfo),
+      ];
+}
+
+/// See: [ReleaseAndroidApplication] in `android.dart`
+class ReleaseTizenApplication extends TizenAssetBundle {
+  ReleaseTizenApplication(FlutterProject project, TizenBuildInfo buildInfo)
+      : super(project, buildInfo);
+
+  @override
+  String get name => 'release_tizen_application';
+
+  @override
+  List<Target> get dependencies => <Target>[
+        ...super.dependencies,
+        TizenAotElf(buildInfo.targetArchs),
+        if (TizenProject.fromFlutter(project).isDotnet)
+          TizenPlugins(project, buildInfo),
       ];
 }
 

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -118,8 +118,8 @@ class TizenBuilder {
     );
 
     final Target target = buildInfo.isDebug
-        ? DebugTizenAssetBundle(project, tizenBuildInfo)
-        : ReleaseTizenAssetBundle(project, tizenBuildInfo);
+        ? DebugTizenApplication(project, tizenBuildInfo)
+        : ReleaseTizenApplication(project, tizenBuildInfo);
 
     final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -32,6 +32,10 @@ import 'tizen_build_target.dart';
 import 'tizen_project.dart';
 import 'tizen_tpk.dart';
 
+/// The define to control what Tizen architectures are built for.
+/// This is expected to be a comma-separated list of architectures.
+const String kTizenArchs = 'TizenArchs';
+
 /// See: [AndroidBuildInfo] in `build_info.dart`
 class TizenBuildInfo {
   const TizenBuildInfo(
@@ -88,6 +92,7 @@ class TizenBuilder {
           ? null
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
+        kTizenArchs: tizenBuildInfo.targetArchs.join(','),
         kTargetFile: targetFile,
         kBuildMode: getNameForBuildMode(buildInfo.mode),
         kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android),
@@ -112,16 +117,9 @@ class TizenBuilder {
       processManager: globals.processManager,
     );
 
-    Target target;
-    if (tizenProject.isDotnet) {
-      target = buildInfo.isDebug
-          ? DebugDotnetTpk(project, tizenBuildInfo)
-          : ReleaseDotnetTpk(project, tizenBuildInfo);
-    } else {
-      target = buildInfo.isDebug
-          ? DebugNativeTpk(project, tizenBuildInfo)
-          : ReleaseNativeTpk(project, tizenBuildInfo);
-    }
+    final Target target = buildInfo.isDebug
+        ? DebugTizenAssetBundle(project, tizenBuildInfo)
+        : ReleaseTizenAssetBundle(project, tizenBuildInfo);
 
     final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(
@@ -135,6 +133,12 @@ class TizenBuilder {
           globals.printError(measurement.exception.toString());
         }
         throwToolExit('The build failed.');
+      }
+
+      if (tizenProject.isDotnet) {
+        await DotnetTpk(project, tizenBuildInfo).build(environment);
+      } else {
+        await NativeTpk(project, tizenBuildInfo).build(environment);
       }
 
       if (buildInfo.performanceMeasurementFile != null) {


### PR DESCRIPTION
## Current bugs

Altering different build modes doesn't generate expected tpks

- debug -> release : output tpk contains debug binaries because `{OUTPUT_DIR}/flutter_assets` directory still contains them when `DotnetTpk.build()` or `NativeTpk.build()` is called.
- release -> debug: output tpk doesn't contain debug binaries because `TizenAssetBundle.build()` is not reinvoked due to caching. Debug binaries must be specified in `TizenAssetBundle.outputs`, see `DebugAndroidApplication` in `android.dart`.
- x86 -> arm, arm -> x86: arch string is not provided to `Enviroment` in `TizenBuilder.buildTpk()`.

## Changes

- create DebugTizenAssetBundle and ReleaseTizenAssetBundle.
Both targets must inherit AssetBundle. (See Debug
AndroidApplication and AotAndroidAssetBundle in android.dart)

- Package tpk after FlutterBuildSystem syncs output directory

- pass arch string to Environment instantiation to
force different hash values in .dart_tool for different
arch types. (See kIosArches in common.dart)