### PR TITLE
add linker option "-Wl,-E" to remove regression

### DIFF
--- a/templates/app/cpp/project_def.prop
+++ b/templates/app/cpp/project_def.prop
@@ -17,7 +17,7 @@ USER_CPP_UNDEFS =
 # Compiler/linker flags
 USER_CFLAGS_MISC =
 USER_CPPFLAGS_MISC = -c -fmessage-length=0
-USER_LFLAGS =
+USER_LFLAGS = -Wl,-E
 
 # Libraries and objects
 USER_LIB_DIRS = lib


### PR DESCRIPTION
When the toolchain is changed, the linker option "-Wl,-E" is omitted.
Due to this, performance degradation occurred by launching the app using exec() in the candidate process.

Add "-Wl,-E" to linker option of cpp template so that main() symbol are added to the dynamic symbol table,
and can be used in candidate process.

| Applying  "-Wl,-E" linker option   |   Startup Time  |
|:-:|:-:|
| X                                 |  1162 ms              |
| O |  811 ms |


#57