### PR TITLE
Cache plugin sources for build efficiency

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -290,6 +290,12 @@ class TizenPlugins extends Target {
     );
   }
 
+  // Helper method that creates a depfile which lists dependent input files
+  // and the generated output binary from the build() process.
+  // The files collected here should be synced with the files used and created in compiling.
+  //
+  // TODO(HakkyuKim): Refactor so that this method doesn't duplicate codes in
+  // the build() method without mixing the code lines between two method.
   Depfile _createDepfile({
     @required List<TizenPlugin> nativePlugins,
     @required Directory compiledPluginsDir,
@@ -302,15 +308,6 @@ class TizenPlugins extends Target {
     final Directory clientWrapperDir =
         commonDir.childDirectory('client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
-
-    if (!engineDir.existsSync() ||
-        !clientWrapperDir.existsSync() ||
-        !publicDir.existsSync()) {
-      throwToolExit(
-        'The flutter engine artifacts were corrupted or invalid.\n'
-        'Unable to build tizen plugins.',
-      );
-    }
 
     clientWrapperDir
         .listSync(recursive: true)
@@ -331,12 +328,6 @@ class TizenPlugins extends Target {
           getTargetPlatformForArch(arch), buildInfo.buildInfo.mode);
       final File engineBinary =
           engineBinaryDir.childFile('libflutter_tizen.so');
-      if (!engineBinary.existsSync()) {
-        throwToolExit(
-          'The flutter engine artifacts were corrupted or invalid.\n'
-          'Could not find engine binary: ${engineBinary.basename}.',
-        );
-      }
       inputs.add(engineBinary);
 
       final File rootstrap =
@@ -346,13 +337,6 @@ class TizenPlugins extends Target {
 
     for (final TizenPlugin plugin in nativePlugins) {
       final TizenLibrary tizenLibrary = TizenLibrary(plugin.path);
-
-      if (!tizenLibrary.isValid) {
-        throwToolExit(
-          '${plugin.name} is not a valid Tizen plugin project\n'
-          "Check if project_def.prop exists in plugin's tizen directory.",
-        );
-      }
 
       final Directory headerDir = tizenLibrary.headerDir;
       final Directory sourceDir = tizenLibrary.sourceDir;

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -32,6 +32,8 @@ import 'tizen_build_target.dart';
 import 'tizen_project.dart';
 import 'tizen_tpk.dart';
 
+const String kDeviceProfile = 'DeviceProfile';
+
 /// See: [AndroidBuildInfo] in `build_info.dart`
 class TizenBuildInfo {
   const TizenBuildInfo(
@@ -90,6 +92,7 @@ class TizenBuilder {
       defines: <String, String>{
         kTargetFile: targetFile,
         kBuildMode: getNameForBuildMode(buildInfo.mode),
+        kDeviceProfile: tizenBuildInfo.deviceProfile,
         kTargetPlatform: getNameForTargetPlatform(TargetPlatform.android),
         kDartObfuscation: buildInfo.dartObfuscation.toString(),
         kSplitDebugInfo: buildInfo.splitDebugInfoPath,

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -70,7 +70,7 @@ class TizenLibrary {
 
   Directory get headerDir => directory.childDirectory('inc');
 
-  Directory get sourecDir => directory.childDirectory('src');
+  Directory get sourceDir => directory.childDirectory('src');
 
   final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
 

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -68,6 +68,10 @@ class TizenLibrary {
 
   bool get isValid => projectFile.existsSync();
 
+  Directory get headerDir => directory.childDirectory('inc');
+
+  Directory get sourecDir => directory.childDirectory('src');
+
   final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
 
   Map<String, String> _properties;

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -108,7 +108,7 @@ class TizenSdk {
 
   String get defaultGccVersion => '9.2';
 
-  String getFlutterRootstrap({
+  File getFlutterRootstrapFile({
     String profile,
     @required String arch,
   }) {
@@ -128,18 +128,27 @@ class TizenSdk {
         'Make sure your tizen-manifest.xml contains correct information for build.',
       );
     }
+    return rootstrapTarget;
+  }
+
+  String getFlutterRootstrap({
+    String profile,
+    @required String arch,
+  }) {
+    final File rootstrapTarget =
+        getFlutterRootstrapFile(profile: profile, arch: arch);
 
     // Tizen SBI creates a list of rootstraps from this directory.
     final Directory pluginsDir = toolsDirectory
         .childDirectory('smart-build-interface')
         .childDirectory('plugins');
-    final Link rootstrapLink = pluginsDir.childLink('$rootstrapName.xml');
+    final Link rootstrapLink = pluginsDir.childLink(rootstrapTarget.basename);
     if (rootstrapLink.existsSync()) {
       rootstrapLink.deleteSync(recursive: true);
     }
     rootstrapLink.createSync(rootstrapTarget.path, recursive: true);
 
-    return rootstrapName;
+    return rootstrapTarget.basename.replaceFirst('.xml', '');
   }
 }
 


### PR DESCRIPTION
~~:warning: : This pr should be merged after #61~~

This change caches plugin build sources so that plugins are rebuilt only when it needs to.

I've tested for following cases:
- adding new plugin dependency in `pubspec.yaml`
- removing existing plugin dependency in `pubspec.yaml`
- changing existing plugin version in `pubspec.yaml`
- changing the plugin source code when the plugin project is listed as a path dependency in `pubspec.yaml`

The cached sources are:
- inputs: 
  - files in `engine/common/client_wrappers`
  - files in `engine/common/public`
  - `engine/tizen-<arch>-<mode>/libflutter_tizen.so`
  - `rootstrap/wearable-<api-version>-<type>.flutter.xml`
  - files in `tizen/inc`, `tizen/src`, and the `project_def.prop` file

- outputs: the compiled plugin `.so` files