### PR TITLE
[Bug fix] Cache tizen_manifest.xml file for plugin build

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -322,6 +322,7 @@ class TizenPlugins extends Target {
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
     final String profile =
         TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
+    inputs.add(tizenProject.manifestFile);
 
     for (final String arch in buildInfo.targetArchs) {
       final Directory engineBinaryDir = tizenArtifacts.getEngineDirectory(


### PR DESCRIPTION
Plugin build depends on `profile` and `api-version` values set in the `tizen-manifest.xml` file.