### PR TITLE
Support plugins that have dependent binaries

### DIFF
--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -68,10 +68,6 @@ class TizenLibrary {
 
   bool get isValid => projectFile.existsSync();
 
-  Directory get headerDir => directory.childDirectory('inc');
-
-  Directory get sourceDir => directory.childDirectory('src');
-
   final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
 
   Map<String, String> _properties;

--- a/templates/plugin/cpp/project_def.prop.tmpl
+++ b/templates/plugin/cpp/project_def.prop.tmpl
@@ -20,7 +20,11 @@ USER_CPPFLAGS_MISC = -c -fmessage-length=0
 USER_LFLAGS =
 
 # Libraries and objects
-USER_LIB_DIRS = lib
+# To provide libraries for your plugin, you must put them in specific
+# directories that match their supporting cpu architecture type.
+# Due to compatibility issue with Tizen CLI, directory names must be armel for arm 
+# and i586 for x86.
+USER_LIB_DIRS = lib/${BUILD_ARCH}
 USER_LIBS =
 USER_OBJS =
 


### PR DESCRIPTION
The tool will check lib/${arch} directory for dependent binaries and copy them to the output tpk.


- [x] using `BUILD_ARCH` variable in `project_def.prop` interpolates to armel, can it be arm?
Directory names in the plugin project must be armel for arm and i586 for x86.

Currently, I don't know why Tizen cli chooses specifically armel for arm and i586 for x86.

~~- [ ] adding new so files in lib directory during plugin development has caching issues which forces plugin developers to run `flutter-tizen clean`.~~ This turned out is not an issue.