### PR TITLE
Ensure tizen-manifest.xml exists for app project

### DIFF
--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -226,6 +226,9 @@ class TizenBuilder {
     }
     final TizenManifest manifest =
         TizenManifest.parseFromXml(project.manifestFile);
+    if (manifest == null) {
+      return;
+    }
     manifest.version = buildName;
     project.manifestFile.writeAsStringSync(manifest.toString());
   }

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -40,11 +40,10 @@ class TizenProject extends FlutterProjectPlatform {
   File get projectFile => editableDirectory
       .childFile(isDotnet ? 'Runner.csproj' : 'project_def.prop');
 
-  @override
-  bool existsSync() =>
-      editableDirectory.existsSync() && projectFile.existsSync();
-
   File get manifestFile => editableDirectory.childFile('tizen-manifest.xml');
+
+  @override
+  bool existsSync() => projectFile.existsSync() && manifestFile.existsSync();
 
   String get apiVersion => TizenManifest.parseFromXml(manifestFile).apiVersion;
 


### PR DESCRIPTION
Fixes a null reference exception when running the build command in a plugin project directory. The root cause is `_createEntrypoint` not checking the validity of project properly. The correct behavior is printing this error:

```
Target file "lib/main.dart" not found.
```