### PR TITLE
Clear tpkroot directory before dotnet build

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -448,6 +448,12 @@ class DotnetTpk {
     // Keep this value in sync with the latest published nuget version.
     const String embeddingVersion = '1.3.0';
 
+    // Clear tpkroot directory
+    final Directory tpkRootDir = outputDir.childDirectory('tpkroot');
+    if (tpkRootDir.existsSync()) {
+      tpkRootDir.deleteSync(recursive: true);
+    }
+
     // Run .NET build.
     if (dotnetCli == null) {
       throwToolExit(


### PR DESCRIPTION
Solves issue #74.

It seems that dotnet cli or the build script that is run by the cli doesn't remove empty directories when updating `tpkroot`. I cannot think of a way to fix this without changing the behavior of the dotnet build, a quick solution is deleting `tpkroot` before running dotnet build.
 