### PR TITLE
Fix permission denied error on Windows when building plugins

### DIFF
--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -30,6 +30,7 @@ import 'package:path/path.dart';
 import 'tizen_artifacts.dart';
 import 'tizen_build_target.dart';
 import 'tizen_project.dart';
+import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
 
 /// The define to control what Tizen architectures are built for.
@@ -77,6 +78,12 @@ class TizenBuilder {
     if (!tizenProject.isDotnet && tizenBuildInfo.targetArchs.length > 1) {
       throwToolExit(
           'Tizen native projects cannot be built for multiple target archs.');
+    }
+    if (tizenSdk == null || !tizenSdk.tizenCli.existsSync()) {
+      throwToolExit(
+        'Unable to locate Tizen CLI executable.\n'
+        'Run "flutter-tizen doctor" and install required components.',
+      );
     }
 
     updateManifest(tizenProject, tizenBuildInfo.buildInfo);


### PR DESCRIPTION
- Create a copy of rootstrap manifest instead of creating a symlink
- Also some refactoring

Fixes this error when building Tizen plugins on Windows:
```sh
FileSystemException: Cannot create link, path = 'C:\Apps\tizen-studio\tools\smart-build-interface\plugins\wearable-4.0-device.flutter.xml' (OS Error: A required privilege is not held by the client.
, errno = 1314)
```

Even with this patch still some errors will be thrown when running Tizen native builds on Windows. I'll fix them up soon in a separate patch. → #82