### PR TITLE
Enable HW acceleration for native projects by default

### DIFF
--- a/templates/app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/app/cpp/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{androidIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{androidIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true">
+    <ui-application appid="{{androidIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
     </ui-application>


### PR DESCRIPTION
Inspired by @wscho77's comment in https://github.com/flutter-tizen/flutter-tizen/pull/62#issuecomment-804634261, I measured the effect of setting the `hw-acceleration` attribute in tizen-manifext.xml of a simple counter sample app:

#### Native
```sh
# Galaxy Watch (PLATFORM_DayR800XX_20200611.001)
Application                              STIME     PSS     RSS
com.example.native_no_hw_accel            1621   24638   49368
com.example.native_hw_accel               1576   26611   53068

# TW3 (tizen-6.0-unified_20201216.3_wearable-wayland-armv7l-tw3)
Application                              STIME     PSS     RSS
com.example.native_no_hw_accel             880   26134   40690
com.example.native_hw_accel                846   28654   44938

# RPi4-arm64 (tizen-6.0-unified_20210331.1_iot-headed-3parts-aarch64-rpi)
Application                              STIME     PSS     RSS
com.example.native_no_hw_accel             585   36259   50355
com.example.native_hw_accel                485   37841   53086

# Wearable 5.5 emulator (tizen-5.5-unified-wearable-hotfix_20201103.1_wearable-emulator-circle)
Application                              STIME     PSS     RSS
com.example.native_no_hw_accel            1126  106389  130252
com.example.native_hw_accel               1048  110856  141084
```

There's about 40 ms of launching time improvement on watches (with slightly increased memory footprints), and 100 ms on RPi4.

#### .NET (direct-launch=yes)
```sh
# TW3
Application                              STIME     PSS     RSS
com.example.dotnet_no_hw_accel            1367   43104   62368
com.example.dotnet_hw_accel               1390   43140   62237

# RPi4-arm64
Application                              STIME     PSS     RSS
com.example.dotnet_no_hw_accel             826   43652   61882
com.example.dotnet_hw_accel                822   43660   61874
```

There's no benefit in case of .NET type apps, maybe because hw acceleration is already enabled somewhere by default.

#### Appendix

The result of running `flutter-tizen run --profile --trace-startup` on RPi4:

```sh
Application                              STIME     PSS     RSS
com.example.native_no_hw_accel             616   44899   60362
{
  "engineEnterTimestampMicros": 9477330240,
  "timeToFrameworkInitMicros": 86877,
  "timeToFirstFrameRasterizedMicros": 418726,
  "timeToFirstFrameMicros": 201308,
  "timeAfterFrameworkInitMicros": 114431
}
com.example.native_hw_accel                505   46349   63078
{
  "engineEnterTimestampMicros": 9442871073,
  "timeToFrameworkInitMicros": 86525,
  "timeToFirstFrameRasterizedMicros": 414774,
  "timeToFirstFrameMicros": 203931,
  "timeAfterFrameworkInitMicros": 117406
}
```

There's almost no difference (see `timeToFirstFrameRasterizedMicros`).