### PR TITLE
Unsupport building TPK for multiple archs

### DIFF
--- a/embedding/csharp/FlutterApplication.cs
+++ b/embedding/csharp/FlutterApplication.cs
@@ -6,9 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using Tizen.Applications;
-using Tizen.System;
 using static Tizen.Flutter.Embedding.Interop;
 
 namespace Tizen.Flutter.Embedding
@@ -51,15 +49,7 @@ namespace Tizen.Flutter.Embedding
             string resPath = Current.DirectoryInfo.Resource;
             string assetsPath = $"{resPath}/flutter_assets";
             string icuDataPath = $"{resPath}/icudtl.dat";
-            string arch = RuntimeInformation.ProcessArchitecture switch
-            {
-                Architecture.X86 => "x86",
-                Architecture.X64 => "x64",
-                Architecture.Arm => "arm",
-                Architecture.Arm64 => "aarch64",
-                _ => "",
-            };
-            string aotLibPath = $"{resPath}/../lib/{arch}/libapp.so";
+            string aotLibPath = $"{resPath}/../lib/libapp.so";
 
             // Read engine arguments passed from the tool.
             ParseEngineArgs();

--- a/embedding/csharp/Tizen.Flutter.Embedding.csproj
+++ b/embedding/csharp/Tizen.Flutter.Embedding.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Tizen.Flutter.Embedding</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <Authors>flutter-tizen</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/flutter-tizen</PackageProjectUrl>

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -28,12 +28,11 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
   BuildTpkCommand({bool verboseHelp = false}) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesBuildNameOption();
-    argParser.addMultiOption(
+    argParser.addOption(
       'target-arch',
-      splitCommas: true,
-      defaultsTo: <String>['arm'],
+      defaultsTo: 'arm',
       allowed: <String>['arm', 'arm64', 'x86'],
-      help: 'Target architectures to compile the application for',
+      help: 'Target architecture for which the the app is compiled',
     );
     argParser.addOption(
       'device-profile',
@@ -57,13 +56,8 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
 
   /// See: [android.validateBuild] in `build_validation.dart`
   void validateBuild(TizenBuildInfo tizenBuildInfo) {
-    if (tizenBuildInfo.buildInfo.codeSizeDirectory != null &&
-        tizenBuildInfo.targetArchs.length > 1) {
-      throwToolExit(
-          'Cannot perform code size analysis when building for multiple ABIs.');
-    }
     if (tizenBuildInfo.buildInfo.mode.isPrecompiled &&
-        tizenBuildInfo.targetArchs.contains('x86')) {
+        tizenBuildInfo.targetArch == 'x86') {
       throwToolExit('x86 ABI does not support AOT compilation.');
     }
   }
@@ -83,7 +77,7 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
     final BuildInfo buildInfo = await getBuildInfo();
     final TizenBuildInfo tizenBuildInfo = TizenBuildInfo(
       buildInfo,
-      targetArchs: stringsArg('target-arch'),
+      targetArch: stringArg('target-arch'),
       deviceProfile: deviceProfile,
       securityProfile: stringArg('security-profile'),
     );

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -433,7 +433,7 @@ class DotnetTpk {
     }
 
     // Keep this value in sync with the latest published nuget version.
-    const String embeddingVersion = '1.6.0';
+    const String embeddingVersion = '1.7.0';
 
     // Clear tpkroot directory
     final Directory tpkRootDir = outputDir.childDirectory('tpkroot');

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -313,7 +313,7 @@ class TizenDevice extends Device {
         targetFile: mainPath,
         tizenBuildInfo: TizenBuildInfo(
           debuggingOptions.buildInfo,
-          targetArchs: <String>[architecture],
+          targetArch: architecture,
           deviceProfile: getCapability('profile_name'),
         ),
       );


### PR DESCRIPTION
This change is preparation for fixing the plugin destruction bug (#90) by reducing discrepancy between the native and .NET TPK structures. I want to apply the same plugin architecture for both native and .NET build targets.

The code diff looks a little bit messy due to indentation changes but there are no other changes than those related to "targetArch". The exception is `TizenAotElf` - we no longer need the custom `build()` method if targeting only a single arch.