### PR TITLE
Compile native plugins into a single shared object

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -103,9 +103,8 @@ abstract class TizenAssetBundle extends Target {
 
 /// Source: [DebugAndroidApplication] in `android.dart`
 class DebugTizenApplication extends TizenAssetBundle {
-  DebugTizenApplication(this.project, this.buildInfo);
+  DebugTizenApplication(this.buildInfo);
 
-  final FlutterProject project;
   final TizenBuildInfo buildInfo;
 
   @override
@@ -131,16 +130,14 @@ class DebugTizenApplication extends TizenAssetBundle {
   @override
   List<Target> get dependencies => <Target>[
         ...super.dependencies,
-        if (TizenProject.fromFlutter(project).isDotnet)
-          TizenPlugins(project, buildInfo),
+        TizenPlugins(buildInfo),
       ];
 }
 
 /// See: [ReleaseAndroidApplication] in `android.dart`
 class ReleaseTizenApplication extends TizenAssetBundle {
-  ReleaseTizenApplication(this.project, this.buildInfo);
+  ReleaseTizenApplication(this.buildInfo);
 
-  final FlutterProject project;
   final TizenBuildInfo buildInfo;
 
   @override
@@ -150,16 +147,14 @@ class ReleaseTizenApplication extends TizenAssetBundle {
   List<Target> get dependencies => <Target>[
         ...super.dependencies,
         TizenAotElf(),
-        if (TizenProject.fromFlutter(project).isDotnet)
-          TizenPlugins(project, buildInfo),
+        TizenPlugins(buildInfo),
       ];
 }
 
 /// Compiles Tizen native plugins into shared objects.
 class TizenPlugins extends Target {
-  TizenPlugins(this.project, this.buildInfo);
+  TizenPlugins(this.buildInfo);
 
-  final FlutterProject project;
   final TizenBuildInfo buildInfo;
 
   final ProcessUtils _processUtils = ProcessUtils(
@@ -186,231 +181,207 @@ class TizenPlugins extends Target {
 
   @override
   Future<void> build(Environment environment) async {
-    final BuildMode buildMode =
-        getBuildModeForName(environment.defines[kBuildMode]);
-
-    final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    final String profile =
-        TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
-
-    // Clear the output directory.
-    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    if (ephemeralDir.existsSync()) {
-      ephemeralDir.deleteSync(recursive: true);
-    }
-    ephemeralDir.createSync(recursive: true);
-
-    final List<TizenPlugin> nativePlugins =
-        await findTizenPlugins(project, nativeOnly: true);
-
-    for (final TizenPlugin plugin in nativePlugins) {
-      final Directory pluginDir = environment.fileSystem.directory(plugin.path);
-      final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
-      final Directory buildDir = pluginDir.childDirectory(buildConfig);
-
-      final Directory engineDir =
-          tizenArtifacts.getEngineDirectory(buildInfo.targetArch, buildMode);
-      final Directory commonDir = engineDir.parent.childDirectory('common');
-      final Directory clientWrapperDir =
-          commonDir.childDirectory('cpp_client_wrapper');
-
-      if (!engineDir.existsSync() || !clientWrapperDir.existsSync()) {
-        throwToolExit(
-          'The flutter engine artifacts were corrupted or invalid.\n'
-          'Unable to build ${plugin.name} plugin.',
-        );
-      }
-      final Map<String, String> variables = <String, String>{
-        'PATH': getDefaultPathVariable(),
-        'USER_SRCS': getUnixPath(clientWrapperDir.childFile('*.cc').path)
-      };
-      final List<String> extraOptions = <String>[
-        '-lflutter_tizen_${buildInfo.deviceProfile}',
-        '-L${getUnixPath(engineDir.path)}',
-        '-std=c++17',
-        '-I${getUnixPath(clientWrapperDir.childDirectory('include').path)}',
-        '-I${getUnixPath(commonDir.childDirectory('public').path)}',
-        '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
-      ];
-
-      assert(tizenSdk != null);
-      final Rootstrap rootstrap = tizenSdk.getFlutterRootstrap(
-          profile: profile, arch: buildInfo.targetArch);
-
-      if (buildDir.existsSync()) {
-        buildDir.deleteSync(recursive: true);
-      }
-      final RunResult result = await _processUtils.run(<String>[
-        tizenSdk.tizenCli.path,
-        'build-native',
-        '-a',
-        getTizenCliArch(buildInfo.targetArch),
-        '-C',
-        buildConfig,
-        '-c',
-        tizenSdk.defaultNativeCompiler,
-        '-r',
-        rootstrap.id,
-        '-e',
-        extraOptions.join(' '),
-        '--',
-        pluginDir.path,
-      ], environment: variables);
-      if (result.exitCode != 0) {
-        throwToolExit('Failed to build ${plugin.name} plugin:\n$result');
-      }
-
-      final File sharedLib =
-          buildDir.childFile('lib' + (plugin.toMap()['sofile'] as String));
-      if (!sharedLib.existsSync()) {
-        throwToolExit(
-          'Built ${plugin.name} but the file ${sharedLib.path} is not found:\n'
-          '${result.stdout}',
-        );
-      }
-      final Directory outputDir = ephemeralDir.childDirectory('lib')
-        ..createSync(recursive: true);
-      sharedLib.copySync(outputDir.childFile(sharedLib.basename).path);
-
-      // Copy binaries that the plugin depends on.
-      final Directory pluginLibDir = pluginDir
-          .childDirectory('lib')
-          .childDirectory(getTizenBuildArch(buildInfo.targetArch));
-      if (pluginLibDir.existsSync()) {
-        globals.fsUtils.copyDirectorySync(pluginLibDir, outputDir);
-      }
-    }
-
-    final Depfile pluginDepfile = await _createDepfile(environment);
+    final List<File> inputs = <File>[];
+    final List<File> outputs = <File>[];
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,
       logger: environment.logger,
     );
-    depfileService.writeToFile(
-      pluginDepfile,
-      environment.buildDir.childFile('tizen_plugins.d'),
-    );
-  }
 
-  // Helper method that creates a depfile which lists dependent input files
-  // and the generated output binary from the build() process.
-  // The files collected here should be synced with the files used and created in compiling.
-  //
-  // TODO(HakkyuKim): Refactor so that this method doesn't duplicate codes in
-  // the build() method without mixing the code lines between two method.
-  Future<Depfile> _createDepfile(Environment environment) async {
-    final List<File> inputs = <File>[];
-    final List<File> outputs = <File>[];
-
-    final Directory commonDir =
-        tizenArtifacts.getArtifactDirectory('engine').childDirectory('common');
-    final Directory clientWrapperDir =
-        commonDir.childDirectory('cpp_client_wrapper');
-    final Directory publicDir = commonDir.childDirectory('public');
-
-    clientWrapperDir
-        .listSync(recursive: true)
-        .whereType<File>()
-        .forEach((File file) => inputs.add(file));
-    publicDir
-        .listSync(recursive: true)
-        .whereType<File>()
-        .forEach((File file) => inputs.add(file));
-
+    final FlutterProject project =
+        FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    // Create a dummy project in the build directory.
+    final Directory rootDir = environment.buildDir
+        .childDirectory('flutter_plugins')
+          ..createSync(recursive: true);
     final String profile =
         TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
     inputs.add(tizenProject.manifestFile);
 
-    final Directory engineDir = tizenArtifacts.getEngineDirectory(
-        buildInfo.targetArch, buildInfo.buildInfo.mode);
+    rootDir.childFile('project_def.prop').writeAsStringSync('''
+APPNAME = flutter_plugins
+type = sharedLib
+profile = $profile
+
+USER_CPP_DEFS = TIZEN_DEPRECATION DEPRECATION_WARNING FLUTTER_PLUGIN_IMPL
+USER_CPPFLAGS_MISC = -c -fmessage-length=0
+USER_LIB_DIRS = lib
+''');
+
+    // Check if there's anything to build.
+    final List<TizenPlugin> nativePlugins =
+        await findTizenPlugins(project, nativeOnly: true);
+    if (nativePlugins.isEmpty) {
+      rootDir.deleteSync(recursive: true);
+
+      depfileService.writeToFile(
+        Depfile(inputs, outputs),
+        environment.buildDir.childFile('tizen_plugins.d'),
+      );
+      return;
+    }
+
+    // Prepare for build.
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    final Directory buildDir = rootDir.childDirectory(buildConfig);
+    final Directory libDir = rootDir.childDirectory('lib')
+      ..createSync(recursive: true);
+
+    final List<String> userIncludes = <String>[];
+    final List<String> userSources = <String>[];
+    final List<String> userLibs = <String>[];
+
+    for (final TizenPlugin plugin in nativePlugins) {
+      inputs.add(plugin.projectFile);
+
+      // TODO(swift-kim): Currently only checks for USER_INC_DIRS, USER_SRCS,
+      // and USER_LIBS. More properties may be parsed in the future.
+      userIncludes.addAll(plugin.getPropertyAsAbsolutePaths('USER_INC_DIRS'));
+      userSources.addAll(plugin.getPropertyAsAbsolutePaths('USER_SRCS'));
+
+      final Directory headerDir = plugin.directory.childDirectory('inc');
+      if (headerDir.existsSync()) {
+        headerDir.listSync(recursive: true).whereType<File>().map(inputs.add);
+      }
+      final Directory sourceDir = plugin.directory.childDirectory('src');
+      if (sourceDir.existsSync()) {
+        sourceDir.listSync(recursive: true).whereType<File>().map(inputs.add);
+      }
+
+      for (final String libName in plugin.getProperty('USER_LIBS').split(' ')) {
+        final File libFile = plugin.directory
+            .childDirectory('lib')
+            .childDirectory(getTizenBuildArch(buildInfo.targetArch))
+            .childFile('lib$libName.so');
+        if (libFile.existsSync()) {
+          userLibs.add(libName);
+          libFile.copySync(libDir.childFile(libFile.basename).path);
+
+          inputs.add(libFile);
+          outputs.add(libDir.childFile(libFile.basename));
+        }
+      }
+    }
+
+    final Directory engineDir =
+        tizenArtifacts.getEngineDirectory(buildInfo.targetArch, buildMode);
     final File embedder =
         engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
     inputs.add(embedder);
 
+    final Directory commonDir = engineDir.parent.childDirectory('common');
+    final Directory clientWrapperDir =
+        commonDir.childDirectory('cpp_client_wrapper');
+    final Directory publicDir = commonDir.childDirectory('public');
+    clientWrapperDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .map(inputs.add);
+    publicDir.listSync(recursive: true).whereType<File>().map(inputs.add);
+
+    userSources.add(clientWrapperDir.childFile('*.cc').path);
+
+    final Map<String, String> variables = <String, String>{
+      'PATH': getDefaultPathVariable(),
+      'USER_SRCS': userSources.map(getUnixPath).join(' '),
+    };
+    final List<String> extraOptions = <String>[
+      '-lflutter_tizen_${buildInfo.deviceProfile}',
+      '-L${getUnixPath(engineDir.path)}',
+      '-std=c++17',
+      '-I${getUnixPath(clientWrapperDir.childDirectory('include').path)}',
+      '-I${getUnixPath(publicDir.path)}',
+      ...userIncludes.map(getUnixPath).map((String p) => '-I' + p),
+      ...userLibs.map((String lib) => '-l' + lib),
+      '-L${getUnixPath(libDir.path)}',
+      '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+    ];
+
+    assert(tizenSdk != null);
     final Rootstrap rootstrap = tizenSdk.getFlutterRootstrap(
         profile: profile, arch: buildInfo.targetArch);
     inputs.add(rootstrap.manifestFile);
 
-    final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-
-    final List<TizenPlugin> nativePlugins =
-        await findTizenPlugins(project, nativeOnly: true);
-
-    for (final TizenPlugin plugin in nativePlugins) {
-      final Directory pluginDir = environment.fileSystem.directory(plugin.path);
-      final Directory headerDir = pluginDir.childDirectory('inc');
-      final Directory sourceDir = pluginDir.childDirectory('src');
-
-      inputs.add(pluginDir.childFile('project_def.prop'));
-      if (headerDir.existsSync()) {
-        headerDir
-            .listSync(recursive: true)
-            .whereType<File>()
-            .forEach((File file) => inputs.add(file));
-      }
-      if (sourceDir.existsSync()) {
-        sourceDir
-            .listSync(recursive: true)
-            .whereType<File>()
-            .forEach((File file) => inputs.add(file));
-      }
-
-      final File sharedLib = ephemeralDir
-          .childDirectory('lib')
-          .childFile('lib' + (plugin.toMap()['sofile'] as String));
-      outputs.add(sharedLib);
-
-      final Directory pluginLibDir = pluginDir
-          .childDirectory('lib')
-          .childDirectory(getTizenBuildArch(buildInfo.targetArch));
-      if (pluginLibDir.existsSync()) {
-        final List<File> pluginLibFiles =
-            pluginLibDir.listSync(recursive: true).whereType<File>().toList();
-        for (final File file in pluginLibFiles) {
-          inputs.add(file);
-          final String relativePath =
-              file.path.replaceFirst('${pluginLibDir.path}/', '');
-          final String outputPath = environment.fileSystem.path.join(
-            ephemeralDir.childDirectory('lib').path,
-            relativePath,
-          );
-          outputs.add(environment.fileSystem.file(outputPath));
-        }
-      }
+    // Run the native build.
+    if (buildDir.existsSync()) {
+      buildDir.deleteSync(recursive: true);
     }
-    return Depfile(inputs, outputs);
+    final RunResult result = await _processUtils.run(<String>[
+      tizenSdk.tizenCli.path,
+      'build-native',
+      '-a',
+      getTizenCliArch(buildInfo.targetArch),
+      '-C',
+      buildConfig,
+      '-c',
+      tizenSdk.defaultNativeCompiler,
+      '-r',
+      rootstrap.id,
+      '-e',
+      extraOptions.join(' '),
+      '--',
+      rootDir.path,
+    ], environment: variables);
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to build Flutter plugins:\n$result');
+    }
+
+    final File outputLib = buildDir.childFile('libflutter_plugins.so');
+    if (!outputLib.existsSync()) {
+      throwToolExit(
+        'Build succeeded but the file ${outputLib.path} is not found:\n'
+        '${result.stdout}',
+      );
+    }
+    outputs.add(outputLib);
+
+    depfileService.writeToFile(
+      Depfile(inputs, outputs),
+      environment.buildDir.childFile('tizen_plugins.d'),
+    );
   }
 }
 
 class DotnetTpk {
-  DotnetTpk(this.project, this.buildInfo);
+  DotnetTpk(this.buildInfo);
 
-  final FlutterProject project;
   final TizenBuildInfo buildInfo;
 
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
 
   Future<void> build(Environment environment) async {
-    final BuildMode buildMode =
-        getBuildModeForName(environment.defines[kBuildMode]);
-
-    final Directory outputDir = environment.outputDir;
+    final FlutterProject project =
+        FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    // Clean up the intermediate and output directories.
     final Directory ephemeralDir = tizenProject.ephemeralDirectory;
-    final Directory resDir = ephemeralDir.childDirectory('res');
-    final Directory flutterAssetsDir = resDir.childDirectory('flutter_assets');
-
-    if (flutterAssetsDir.existsSync()) {
-      flutterAssetsDir.deleteSync(recursive: true);
+    if (ephemeralDir.existsSync()) {
+      ephemeralDir.deleteSync(recursive: true);
     }
-    globals.fsUtils.copyDirectorySync(
-        outputDir.childDirectory('flutter_assets'), flutterAssetsDir);
-
+    final Directory resDir = ephemeralDir.childDirectory('res')
+      ..createSync(recursive: true);
     final Directory libDir = ephemeralDir.childDirectory('lib')
       ..createSync(recursive: true);
 
+    final Directory outputDir = environment.outputDir.childDirectory('tpk');
+    if (outputDir.existsSync()) {
+      outputDir.deleteSync(recursive: true);
+    }
+    outputDir.createSync(recursive: true);
+
+    // Copy necessary files.
+    final Directory flutterAssetsDir = resDir.childDirectory('flutter_assets');
+    globals.fsUtils.copyDirectorySync(
+      environment.outputDir.childDirectory('flutter_assets'),
+      flutterAssetsDir,
+    );
+
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
     final Directory engineDir =
         tizenArtifacts.getEngineDirectory(buildInfo.targetArch, buildMode);
     final File engineBinary = engineDir.childFile('libflutter_engine.so');
@@ -423,7 +394,7 @@ class DotnetTpk {
 
     engineBinary.copySync(libDir.childFile(engineBinary.basename).path);
     // The embedder so name is statically defined in C# code and cannot be
-    // provided at runtime, so the file name must be fixed.
+    // provided at runtime, so the file name must be a constant.
     embedder.copySync(libDir.childFile('libflutter_tizen.so').path);
     icuData.copySync(resDir.childFile(icuData.basename).path);
 
@@ -432,16 +403,25 @@ class DotnetTpk {
       aotSharedLib.copySync(libDir.childFile('libapp.so').path);
     }
 
+    final Directory pluginsDir =
+        environment.buildDir.childDirectory('flutter_plugins');
+    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    final File pluginsLib = pluginsDir
+        .childDirectory(buildConfig)
+        .childFile('libflutter_plugins.so');
+    if (pluginsLib.existsSync()) {
+      pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
+    }
+    final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
+    if (pluginsUserLibDir.existsSync()) {
+      pluginsUserLibDir.listSync().whereType<File>().forEach(
+          (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
+    }
+
     // Keep this value in sync with the latest published nuget version.
     const String embeddingVersion = '1.7.0';
 
-    // Clear tpkroot directory
-    final Directory tpkRootDir = outputDir.childDirectory('tpkroot');
-    if (tpkRootDir.existsSync()) {
-      tpkRootDir.deleteSync(recursive: true);
-    }
-
-    // Run .NET build.
+    // Run the .NET build.
     if (dotnetCli == null) {
       throwToolExit(
         'Unable to locate .NET CLI executable.\n'
@@ -462,15 +442,14 @@ class DotnetTpk {
       throwToolExit('Failed to build .NET application:\n$result');
     }
 
-    if (!outputDir.childFile(tizenProject.outputTpkName).existsSync()) {
+    final File outputTpk = outputDir.childFile(tizenProject.outputTpkName);
+    if (!outputTpk.existsSync()) {
       throwToolExit(
           'Build succeeded but the expected TPK not found:\n${result.stdout}');
     }
 
     // build-task-tizen signs the output TPK with a dummy profile by default.
     // We need to re-generate the TPK by signing with a correct profile.
-    // TODO(swift-kim): Apply the profile during .NET build for efficiency.
-    // Password descryption by secret-tool will be needed for full automation.
     String securityProfile = buildInfo.securityProfile;
     assert(tizenSdk != null);
 
@@ -493,7 +472,7 @@ class DotnetTpk {
         '-s',
         securityProfile,
         '--',
-        outputDir.childFile(tizenProject.outputTpkName).path,
+        outputTpk.path,
       ]);
       if (result.exitCode != 0) {
         throwToolExit('Failed to sign the TPK:\n$result');
@@ -540,38 +519,44 @@ class TizenAotElf extends AotElfBase {
 }
 
 class NativeTpk {
-  NativeTpk(this.project, this.buildInfo);
+  NativeTpk(this.buildInfo);
 
-  final FlutterProject project;
   final TizenBuildInfo buildInfo;
 
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
 
   Future<void> build(Environment environment) async {
-    final BuildMode buildMode =
-        getBuildModeForName(environment.defines[kBuildMode]);
-
+    final FlutterProject project =
+        FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    final String profile =
-        TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
 
-    // Copy ephemeral files.
-    // TODO(swift-kim): Use ephemeral directory instead of editable directory.
-    final Directory outputDir = environment.outputDir;
+    // Clean up the intermediate and output directories.
+    // TODO(swift-kim): Make use of the ephemeral directory instead of the
+    // editable directory.
     final Directory tizenDir = tizenProject.editableDirectory;
     final Directory resDir = tizenDir.childDirectory('res')
       ..createSync(recursive: true);
-    if (resDir.childDirectory('flutter_assets').existsSync()) {
-      resDir.childDirectory('flutter_assets').deleteSync(recursive: true);
-    }
-    globals.fsUtils.copyDirectorySync(
-        outputDir.childDirectory('flutter_assets'),
-        resDir.childDirectory('flutter_assets'));
-
     final Directory libDir = tizenDir.childDirectory('lib')
       ..createSync(recursive: true);
 
+    final Directory outputDir = environment.outputDir.childDirectory('tpk');
+    if (outputDir.existsSync()) {
+      outputDir.deleteSync(recursive: true);
+    }
+    outputDir.createSync(recursive: true);
+
+    // Copy necessary files.
+    final Directory flutterAssetsDir = resDir.childDirectory('flutter_assets');
+    if (flutterAssetsDir.existsSync()) {
+      flutterAssetsDir.deleteSync(recursive: true);
+    }
+    globals.fsUtils.copyDirectorySync(
+      environment.outputDir.childDirectory('flutter_assets'),
+      flutterAssetsDir,
+    );
+
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
     final Directory engineDir =
         tizenArtifacts.getEngineDirectory(buildInfo.targetArch, buildMode);
     final File engineBinary = engineDir.childFile('libflutter_engine.so');
@@ -594,8 +579,26 @@ class NativeTpk {
       aotSharedLib.copySync(libDir.childFile('libapp.so').path);
     }
 
-    // Prepare for build.
+    final Directory pluginsDir =
+        environment.buildDir.childDirectory('flutter_plugins');
     final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    final File pluginsLib = pluginsDir
+        .childDirectory(buildConfig)
+        .childFile('libflutter_plugins.so');
+    if (libDir.childFile(pluginsLib.basename).existsSync()) {
+      libDir.childFile(pluginsLib.basename).deleteSync(recursive: true);
+    }
+    if (pluginsLib.existsSync()) {
+      pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
+    }
+    final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
+    // TODO: these files cannot be cleaned up!
+    if (pluginsUserLibDir.existsSync()) {
+      pluginsUserLibDir.listSync().whereType<File>().forEach(
+          (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
+    }
+
+    // Prepare for build.
     final Directory buildDir = tizenDir.childDirectory(buildConfig);
     final Directory embeddingDir = environment.fileSystem
         .directory(Cache.flutterRoot)
@@ -609,40 +612,20 @@ class NativeTpk {
     final List<String> userSources = <String>[
       embeddingDir.childFile('*.cc').path,
     ];
-    final List<String> userLibs = <String>[];
 
     final List<TizenPlugin> nativePlugins =
         await findTizenPlugins(project, nativeOnly: true);
-
     for (final TizenPlugin plugin in nativePlugins) {
-      final TizenLibrary library = TizenLibrary(plugin.path);
-      // TODO(swift-kim): Currently only checks for USER_INC_DIRS, USER_SRCS,
-      // and USER_LIBS. More properties should be parsed to fully support
-      // plugin builds.
-      userIncludes.addAll(library.getPropertyAsAbsolutePaths('USER_INC_DIRS'));
-      userSources.addAll(library.getPropertyAsAbsolutePaths('USER_SRCS'));
-
-      for (final String userLib
-          in library.getProperty('USER_LIBS').split(' ')) {
-        final File libFile = library.directory
-            .childDirectory('lib')
-            .childDirectory(getTizenBuildArch(buildInfo.targetArch))
-            .childFile('lib$userLib.so');
-        if (libFile.existsSync()) {
-          libFile.copySync(libDir.childFile(libFile.basename).path);
-          userLibs.add(userLib);
-        }
-      }
+      userIncludes.add(plugin.directory.childDirectory('inc').path);
     }
 
     final Directory commonDir = engineDir.parent.childDirectory('common');
     final Directory clientWrapperDir =
         commonDir.childDirectory('cpp_client_wrapper');
+    final Directory publicDir = commonDir.childDirectory('public');
+
     userSources.add(clientWrapperDir.childFile('*.cc').path);
 
-    if (!engineDir.existsSync() || !clientWrapperDir.existsSync()) {
-      throwToolExit('The flutter engine artifacts were corrupted or invalid.');
-    }
     final Map<String, String> variables = <String, String>{
       'PATH': getDefaultPathVariable(),
       'USER_SRCS': userSources.map(getUnixPath).join(' '),
@@ -652,18 +635,21 @@ class NativeTpk {
       '-L${getUnixPath(libDir.path)}',
       '-std=c++17',
       '-I${getUnixPath(clientWrapperDir.childDirectory('include').path)}',
-      '-I${getUnixPath(commonDir.childDirectory('public').path)}',
+      '-I${getUnixPath(publicDir.path)}',
       ...userIncludes.map(getUnixPath).map((String p) => '-I' + p),
-      ...userLibs.map((String lib) => '-l' + lib),
+      if (pluginsLib.existsSync()) '-lflutter_plugins',
+      '-L${getUnixPath(libDir.path)}',
       '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
       '-Wl,-unresolved-symbols=ignore-in-shared-libs',
     ];
 
     assert(tizenSdk != null);
+    final String profile =
+        TizenManifest.parseFromXml(tizenProject.manifestFile)?.profile;
     final Rootstrap rootstrap = tizenSdk.getFlutterRootstrap(
         profile: profile, arch: buildInfo.targetArch);
 
-    // Run native build.
+    // Run the native build.
     if (buildDir.existsSync()) {
       buildDir.deleteSync(recursive: true);
     }
@@ -684,17 +670,28 @@ class NativeTpk {
       tizenDir.path,
     ], environment: variables);
     if (result.exitCode != 0) {
-      throwToolExit('Failed to compile native application:\n$result');
+      throwToolExit('Failed to build native application:\n$result');
+    }
+
+    String securityProfile = buildInfo.securityProfile;
+    if (securityProfile != null) {
+      if (tizenSdk.securityProfiles == null ||
+          !tizenSdk.securityProfiles.names.contains(securityProfile)) {
+        throwToolExit('The profile $securityProfile does not exist.');
+      }
+    }
+    securityProfile ??= tizenSdk.securityProfiles?.active?.name;
+
+    if (securityProfile != null) {
+      environment.logger
+          .printStatus('The $securityProfile profile is used for signing.');
     }
     result = await _processUtils.run(<String>[
       tizenSdk.tizenCli.path,
       'package',
       '-t',
       'tpk',
-      if (buildInfo.securityProfile?.isNotEmpty ?? false) ...<String>[
-        '-s',
-        buildInfo.securityProfile,
-      ],
+      if (securityProfile != null) ...<String>['-s', securityProfile],
       '--',
       buildDir.path,
     ]);
@@ -705,16 +702,18 @@ class NativeTpk {
     final String tpkArch = buildInfo.targetArch
         .replaceFirst('arm64', 'aarch64')
         .replaceFirst('x86', 'i586');
-    final String nativeTpkName =
-        tizenProject.outputTpkName.replaceFirst('.tpk', '-$tpkArch.tpk');
-    if (buildDir.childFile(nativeTpkName).existsSync()) {
-      buildDir
-          .childFile(nativeTpkName)
-          .renameSync(outputDir.childFile(tizenProject.outputTpkName).path);
-    } else {
+    final File outputTpk = buildDir.childFile(
+        tizenProject.outputTpkName.replaceFirst('.tpk', '-$tpkArch.tpk'));
+    if (!outputTpk.existsSync()) {
       throwToolExit(
           'Build succeeded but the expected TPK not found:\n${result.stdout}');
     }
+
+    // Copy and rename the file.
+    outputTpk.copySync(outputDir.childFile(tizenProject.outputTpkName).path);
+
+    // Extract the file to support code size analysis.
+    globals.os.unzip(outputTpk, outputDir.childDirectory('tpkroot'));
   }
 }
 

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -88,7 +88,7 @@ abstract class TizenAssetBundle extends Target {
     final Depfile assetDepfile = await copyAssets(
       environment,
       outputDirectory,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: null, // corresponds to flutter-tester
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -81,9 +81,10 @@ class TizenBuilder {
 
     updateManifest(tizenProject, tizenBuildInfo.buildInfo);
 
-    final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final Directory outputDir =
         project.directory.childDirectory('build').childDirectory('tizen');
+    final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
+    final String buildModeName = getNameForBuildMode(buildInfo.mode);
     // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(
         getTargetPlatformForArch(tizenBuildInfo.targetArch));
@@ -99,7 +100,7 @@ class TizenBuilder {
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
         kTargetFile: targetFile,
-        kBuildMode: getNameForBuildMode(buildInfo.mode),
+        kBuildMode: buildModeName,
         kTargetPlatform: targetPlatform,
         kDartObfuscation: buildInfo.dartObfuscation.toString(),
         kSplitDebugInfo: buildInfo.splitDebugInfoPath,
@@ -124,10 +125,9 @@ class TizenBuilder {
     );
 
     final Target target = buildInfo.isDebug
-        ? DebugTizenApplication(project, tizenBuildInfo)
-        : ReleaseTizenApplication(project, tizenBuildInfo);
+        ? DebugTizenApplication(tizenBuildInfo)
+        : ReleaseTizenApplication(tizenBuildInfo);
 
-    final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(
         'Building a Tizen application in $buildModeName mode...');
     try {
@@ -142,9 +142,9 @@ class TizenBuilder {
       }
 
       if (tizenProject.isDotnet) {
-        await DotnetTpk(project, tizenBuildInfo).build(environment);
+        await DotnetTpk(tizenBuildInfo).build(environment);
       } else {
-        await NativeTpk(project, tizenBuildInfo).build(environment);
+        await NativeTpk(tizenBuildInfo).build(environment);
       }
 
       if (buildInfo.performanceMeasurementFile != null) {
@@ -156,7 +156,8 @@ class TizenBuilder {
       status.stop();
     }
 
-    final File tpkFile = outputDir.childFile(tizenProject.outputTpkName);
+    final Directory tpkDir = outputDir.childDirectory('tpk');
+    final File tpkFile = tpkDir.childFile(tizenProject.outputTpkName);
     final String tpkSize = getSizeAsMB(tpkFile.lengthSync());
     globals.printStatus(
       '$successMark Built ${relative(tpkFile.path)} ($tpkSize).',
@@ -172,7 +173,7 @@ class TizenBuilder {
           .childFile('trace.$targetPlatform.json');
       final Map<String, Object> output = await sizeAnalyzer.analyzeAotSnapshot(
         aotSnapshot: codeSizeFile,
-        outputDirectory: outputDir.childDirectory('tpkroot'),
+        outputDirectory: tpkDir.childDirectory('tpkroot'),
         precompilerTrace: precompilerTrace,
         type: 'linux',
       );

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -141,6 +141,8 @@ class TizenBuilder {
         throwToolExit('The build failed.');
       }
 
+      // These pseudo targets cannot be skipped and should be invoked whenever
+      // the build is run.
       if (tizenProject.isDotnet) {
         await DotnetTpk(tizenBuildInfo).build(environment);
       } else {

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -34,7 +34,7 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
     @required this.directory,
     this.pluginClass,
     this.dartPluginClass,
-    @required this.fileName,
+    this.fileName,
   }) : assert(pluginClass != null || dartPluginClass != null);
 
   factory TizenPlugin.fromYaml(String name, Directory directory, YamlMap yaml) {

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -29,19 +29,19 @@ import 'tizen_project.dart';
 ///
 /// Source: [LinuxPlugin] in `platform_plugins.dart`
 class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
-  const TizenPlugin({
+  TizenPlugin({
     @required this.name,
-    @required this.path,
+    @required this.directory,
     this.pluginClass,
     this.dartPluginClass,
     @required this.fileName,
   }) : assert(pluginClass != null || dartPluginClass != null);
 
-  factory TizenPlugin.fromYaml(String name, String path, YamlMap yaml) {
+  factory TizenPlugin.fromYaml(String name, Directory directory, YamlMap yaml) {
     assert(validate(yaml));
     return TizenPlugin(
       name: name,
-      path: path,
+      directory: directory,
       pluginClass: yaml[kPluginClass] as String,
       dartPluginClass: yaml[kDartPluginClass] as String,
       fileName: yaml['fileName'] as String,
@@ -58,7 +58,7 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
   static const String kConfigKey = 'tizen';
 
   final String name;
-  final String path;
+  final Directory directory;
   final String pluginClass;
   final String dartPluginClass;
   final String fileName;
@@ -73,9 +73,51 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
       if (pluginClass != null) 'class': pluginClass,
       if (dartPluginClass != null) 'dartPluginClass': dartPluginClass,
       'file': fileName,
-      if (pluginClass != null)
-        'sofile': fileName.toLowerCase().replaceFirst('.h', '.so'),
     };
+  }
+
+  File get projectFile => directory.childFile('project_def.prop');
+
+  final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
+
+  Map<String, String> _properties;
+
+  String getProperty(String key) {
+    if (_properties == null) {
+      if (!projectFile.existsSync()) {
+        return null;
+      }
+      _properties = <String, String>{};
+
+      for (final String line in projectFile.readAsLinesSync()) {
+        final Match match = _propertyFormat.firstMatch(line);
+        if (match == null) {
+          continue;
+        }
+        final String key = match.group(1);
+        final String value = match.group(2).trim();
+        _properties[key] = value;
+      }
+    }
+    return _properties.containsKey(key) ? _properties[key] : null;
+  }
+
+  List<String> getPropertyAsAbsolutePaths(String key) {
+    final String property = getProperty(key);
+    if (property == null) {
+      return <String>[];
+    }
+
+    final List<String> paths = <String>[];
+    for (final String element in property.split(' ')) {
+      if (globals.fs.path.isAbsolute(element)) {
+        paths.add(element);
+      } else {
+        paths.add(globals.fs.path
+            .normalize(globals.fs.path.join(directory.path, element)));
+      }
+    }
+    return paths;
   }
 }
 
@@ -264,7 +306,7 @@ TizenPlugin _pluginFromPackage(String name, Uri packageRoot) {
   }
   return TizenPlugin.fromYaml(
     name,
-    packageDir.childDirectory('tizen').path,
+    packageDir.childDirectory('tizen'),
     platformsYaml[TizenPlugin.kConfigKey] as YamlMap,
   );
 }
@@ -364,7 +406,7 @@ namespace Runner
     internal class GeneratedPluginRegistrant
     {
       {{#plugins}}
-        [DllImport("{{sofile}}")]
+        [DllImport("flutter_plugins.so")]
         public static extern void {{class}}RegisterWithRegistrar(IntPtr registrar);
       {{/plugins}}
 

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -6,7 +6,6 @@
 import 'dart:io';
 
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
 import 'tizen_plugins.dart';
@@ -53,59 +52,4 @@ class TizenProject extends FlutterProjectPlatform {
   }
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {}
-}
-
-/// Used for parsing native plugin's `project_def.prop`.
-class TizenLibrary {
-  TizenLibrary(this.path);
-
-  final String path;
-
-  Directory get directory => globals.fs.directory(path).absolute;
-
-  File get projectFile => directory.childFile('project_def.prop');
-
-  bool get isValid => projectFile.existsSync();
-
-  final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
-
-  Map<String, String> _properties;
-
-  String getProperty(String key) {
-    if (_properties == null) {
-      if (!isValid) {
-        return null;
-      }
-      _properties = <String, String>{};
-
-      for (final String line in projectFile.readAsLinesSync()) {
-        final Match match = _propertyFormat.firstMatch(line);
-        if (match == null) {
-          continue;
-        }
-        final String key = match.group(1);
-        final String value = match.group(2).trim();
-        _properties[key] = value;
-      }
-    }
-    return _properties.containsKey(key) ? _properties[key] : null;
-  }
-
-  List<String> getPropertyAsAbsolutePaths(String key) {
-    final String property = getProperty(key);
-    if (property == null) {
-      return <String>[];
-    }
-
-    final List<String> paths = <String>[];
-    for (final String element in property.split(' ')) {
-      if (globals.fs.path.isAbsolute(element)) {
-        paths.add(element);
-      } else {
-        paths.add(globals.fs.path
-            .normalize(globals.fs.path.join(directory.path, element)));
-      }
-    }
-    return paths;
-  }
 }

--- a/lib/tizen_tpk.dart
+++ b/lib/tizen_tpk.dart
@@ -50,9 +50,9 @@ class TizenTpk extends ApplicationPackage {
   })  : assert(file != null),
         super(id: manifest?.packageId);
 
-  static Future<TizenTpk> fromTpk(File tpk) async {
+  static Future<TizenTpk> fromTpk(File tpkFile) async {
     final Directory tempDir = globals.fs.systemTempDirectory.createTempSync();
-    globals.os.unzip(tpk, tempDir);
+    globals.os.unzip(tpkFile, tempDir);
 
     // We have to manually restore permissions for files zipped by
     // build-task-tizen on Unix.
@@ -70,7 +70,7 @@ class TizenTpk extends ApplicationPackage {
     final File signatureFile = tempDir.childFile('author-signature.xml');
 
     return TizenTpk(
-      file: tpk,
+      file: tpkFile,
       manifest: TizenManifest.parseFromXml(manifestFile),
       signature: Signature.parseFromXml(signatureFile),
     );
@@ -85,6 +85,7 @@ class TizenTpk extends ApplicationPackage {
     final File tpkFile = flutterProject.directory
         .childDirectory('build')
         .childDirectory('tizen')
+        .childDirectory('tpk')
         .childFile(project.outputTpkName);
     if (tpkFile.existsSync()) {
       return await TizenTpk.fromTpk(tpkFile);

--- a/templates/plugin/cpp/src/log.h.tmpl
+++ b/templates/plugin/cpp/src/log.h.tmpl
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "{{pluginClass}}"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/templates/plugin/cpp/src/projectName_plugin.cc.tmpl
+++ b/templates/plugin/cpp/src/projectName_plugin.cc.tmpl
@@ -14,6 +14,8 @@
 
 #include "log.h"
 
+namespace {
+
 class {{pluginClass}} : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
@@ -58,6 +60,8 @@ class {{pluginClass}} : public flutter::Plugin {
     }
   }
 };
+
+}  // namespace
 
 void {{pluginClass}}RegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {


### PR DESCRIPTION
[Before]
- (Native) Plugins are compiled as part of the runner executable.
- (.NET) Plugins are built separately into each .so and loaded by the runner (managed DLL) via P/Invoke. This results in the error stated by #90, because each plugin creates its own `PluginRegistrarManager` instance and tries to register its destruction handler to the embedder.

[After]
- Plugins are compiled into a single file `libflutter_plugins.so` regardless of the app type.

Changelog:
- Re-write the `TizenPlugins` build target
- Update `DotnetTpk.build()` and `NativeTpk.build()` accordingly and clean up
- Remove the `TizenLibrary` class and merge it with `TizenPlugin`
- Change the TPK output directory (from `build/tizen` to `build/tizen/tpk`)
- Wrap the plguin class in the plugin template with an unnamed namespace to prevent potential naming conflicts
- Replace `__FILE__` with `__MODULE__` in `templates/plugin/cpp/src/log.h.tmpl`

Fixes #90.