### PR TITLE
Reference Tizen.Flutter.Embedding via ProjectReference

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding.csproj
+++ b/embedding/csharp/Tizen.Flutter.Embedding.csproj
@@ -17,10 +17,4 @@
     <NoWarn>NU5048,CS1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>portable</DebugType>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
 </Project>

--- a/lib/commands/clean.dart
+++ b/lib/commands/clean.dart
@@ -33,6 +33,7 @@ class TizenCleanCommand extends CleanCommand {
     if (project.isDotnet) {
       _deleteFile(project.editableDirectory.childDirectory('bin'));
       _deleteFile(project.editableDirectory.childDirectory('obj'));
+      _deleteFile(project.editableDirectory.childFile('Runner.csproj.user'));
     } else {
       _deleteFile(project.editableDirectory.childDirectory('Debug'));
       _deleteFile(project.editableDirectory.childDirectory('Release'));

--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -73,14 +73,11 @@ class TizenCreateCommand extends CreateCommand {
       globals.printStatus('');
     }
 
-    // Actually [super.runCommand] runs [ensureReadyForPlatformSpecificTooling]
-    // based on the target project type. The following code doesn't check the
-    // project type for simplicity. Revisit if this makes any problem.
     if (boolArg('pub')) {
       final FlutterProject project = FlutterProject.fromDirectory(projectDir);
-      await injectTizenPlugins(project);
+      await ensureReadyForTizenTooling(project);
       if (project.hasExampleApp) {
-        await injectTizenPlugins(project.example);
+        await ensureReadyForTizenTooling(project.example);
       }
     }
     return result;

--- a/lib/commands/packages.dart
+++ b/lib/commands/packages.dart
@@ -89,9 +89,9 @@ mixin _PostRunPluginInjection on FlutterCommand {
         return result;
       }
       final FlutterProject rootProject = FlutterProject.fromPath(target);
-      await injectTizenPlugins(rootProject);
+      await ensureReadyForTizenTooling(rootProject);
       if (rootProject.hasExampleApp) {
-        await injectTizenPlugins(rootProject.example);
+        await ensureReadyForTizenTooling(rootProject.example);
       }
     }
 

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -431,6 +431,20 @@ class DotnetTpk {
     // 2021. Keep the value up to date until majority of projects are migrated
     // to use ProjectReference.
     const String embeddingVersion = '1.7.0';
+    final bool migrated = !tizenProject.projectFile
+        .readAsStringSync()
+        .contains(r'$(FlutterEmbeddingVersion)');
+    if (!migrated) {
+      final Function relative = environment.fileSystem.path.relative;
+      environment.logger.printStatus(
+        'The use of PackageReference in ${tizenProject.projectFile.basename} is deprecated. '
+        'To migrate your project, run:\n'
+        '  rm ${relative(tizenProject.projectFile.path)}\n'
+        '  flutter-tizen create ${relative(project.directory.path)}',
+        color: TerminalColor.yellow,
+      );
+      environment.logger.printStatus('');
+    }
 
     // Run the .NET build.
     if (dotnetCli == null) {

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -427,7 +427,9 @@ class DotnetTpk {
           (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
     }
 
-    // Keep this value in sync with the latest published nuget version.
+    // TODO(swift-kim): This property is used by projects created before May
+    // 2021. Keep the value up to date until majority of projects are migrated
+    // to use ProjectReference.
     const String embeddingVersion = '1.7.0';
 
     // Run the .NET build.

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -134,7 +134,7 @@ mixin TizenExtension on FlutterCommand {
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
     if (super.shouldRunPub) {
       // TODO(swift-kim): Should run pub get first before injecting plugins.
-      await injectTizenPlugins(FlutterProject.current());
+      await ensureReadyForTizenTooling(FlutterProject.current());
     }
     if (_usesTargetOption) {
       _entrypoint =
@@ -198,28 +198,41 @@ Future<void> main() async {
 }
 
 const List<String> _knownPlugins = <String>[
+  'audioplayers',
   'battery',
   'connectivity',
   'device_info',
+  'flutter_tts',
   'image_picker',
   'integration_test',
   'package_info',
   'path_provider',
+  'permission_handler',
   'sensors',
   'share',
   'shared_preferences',
   'url_launcher',
+  'video_player',
+  'webview_flutter',
+  'wifi_info_flutter',
 ];
 
-/// This method must be called whenever [injectPlugins] is called.
-/// [injectPlugins] is commonly called by [FlutterProject.regeneratePlatformSpecificTooling].
+/// This function must be called whenever [FlutterProject.regeneratePlatformSpecificTooling]
+/// or [FlutterProject.ensureReadyForPlatformSpecificTooling] is called.
 ///
-/// See: [injectPlugins] in `plugins.dart`
-Future<void> injectTizenPlugins(FlutterProject project) async {
+/// See: [FlutterProject.ensureReadyForPlatformSpecificTooling] in `project.dart`
+Future<void> ensureReadyForTizenTooling(FlutterProject project) async {
   if (!project.directory.existsSync() || project.hasExampleApp) {
     return;
   }
+  final TizenProject tizenProject = TizenProject.fromFlutter(project);
+  await tizenProject.ensureReadyForPlatformSpecificTooling();
 
+  await injectTizenPlugins(project);
+}
+
+/// See: [injectPlugins] in `plugins.dart`
+Future<void> injectTizenPlugins(FlutterProject project) async {
   final TizenProject tizenProject = TizenProject.fromFlutter(project);
   if (tizenProject.existsSync()) {
     final List<TizenPlugin> dartPlugins =

--- a/templates/app/csharp/NuGet.Config
+++ b/templates/app/csharp/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="tizen.myget.org" value="https://tizen.myget.org/F/dotnet/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/templates/app/csharp/Runner.csproj
+++ b/templates/app/csharp/Runner.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.Flutter.Embedding" Version="$(FlutterEmbeddingVersion)*" />
+    <ProjectReference Include="$(FlutterEmbeddingPath)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/template_manifest.json
+++ b/templates/template_manifest.json
@@ -4,7 +4,6 @@
     "files": [
         "templates/app/tizen.tmpl/.gitignore",
         "templates/app/tizen.tmpl/App.cs",
-        "templates/app/tizen.tmpl/NuGet.Config",
         "templates/app/tizen.tmpl/Runner.csproj",
         "templates/app/tizen.tmpl/tizen-manifest.xml.tmpl",
         "templates/app/tizen.tmpl/shared/res/ic_launcher.png",


### PR DESCRIPTION
Reference Tizen.Flutter.Embedding by project reference instead of package reference in `Runner.csproj`.

In this way, developers can easily compile and debug C# code (the runner and Tizen.Flutter.Embedding) using the .NET CLI and IDEs (such as Visual Studio).

Notable changes:
- Implement `ensureReadyForTizenTooling()`
- `TizenProject.ensureReadyForPlatformSpecificTooling()` creates a `Runner.csproj.user` file next to `Runner.csproj` which is managed by Visual Studio and flutter-tizen and not version controlled
- Remove `NuGet.Config`
- Update `_knownPlugins` with newly added plugins

Although this change does not break existing projects, it is recommended to re-generate Tizen projects using `flutter-tizen create`. The use of `PackageReference` and `FlutterEmbeddingVersion` in `Runner.csproj` is now deprecated.