### PR TITLE
Link libstdc++ statically

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -7,7 +7,7 @@
 #include <system_info.h>
 
 #include <cassert>
-#include <cerrno>
+#include <filesystem>
 #include <fstream>
 
 #include "tizen_log.h"
@@ -177,19 +177,21 @@ void FlutterApp::ParseEngineArgs() {
                         std::string(app_id) + ".rpm");
   free(app_id);
 
-  std::ifstream file(temp_path);
-  if (!file.is_open()) {
+  if (!std::filesystem::exists(temp_path)) {
     return;
   }
-  std::string line;
-  while (file && !file.eof() && std::getline(file, line)) {
-    TizenLog::Info("Enabled: %s", line.c_str());
-    engine_args.push_back(line.c_str());
+  std::ifstream file(temp_path);
+  file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+  try {
+    std::string line;
+    while (!file.eof() && std::getline(file, line)) {
+      TizenLog::Info("Enabled: %s", line.c_str());
+      engine_args.push_back(line.c_str());
+    }
+    std::filesystem::remove(temp_path);
+  } catch (const std::exception &ex) {
+    TizenLog::Warn("Error while processing a file: %s", ex.what());
   }
   file.close();
-
-  // Note: std::filesystem is not available on Tizen 5.5 or older.
-  if (remove(temp_path.c_str()) != 0) {
-    TizenLog::Warn("Error removing file: %s", strerror(errno));
-  }
 }

--- a/rootstraps/wearable-4.0-arm.flutter.xml
+++ b/rootstraps/wearable-4.0-arm.flutter.xml
@@ -2,7 +2,7 @@
 <extension point="rootstrapDefinition">
   <rootstrap id="wearable-4.0-arm.flutter" name="Tizen Device 4.0" version="Wearable 4.0" architecture="armel" path="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/wearable-4.0-device.core" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/info/wearable-4.0-device.core.dev.xml" />
-    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="-static-libstdc++" />
     <property key="COMPILER_MISCELLANEOUS_OPTION" value="" />
     <toolchain name="gcc" version="9.2" />
     <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-4.0/common/efl-tool/efl-tools/bin/edje_cc" />

--- a/rootstraps/wearable-4.0-x86.flutter.xml
+++ b/rootstraps/wearable-4.0-x86.flutter.xml
@@ -2,7 +2,7 @@
 <extension point="rootstrapDefinition">
   <rootstrap id="wearable-4.0-x86.flutter" name="Tizen Emulator 4.0" version="Wearable 4.0" architecture="i586" path="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/wearable-4.0-emulator.core" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-4.0/wearable/rootstraps/info/wearable-4.0-emulator.core.dev.xml" />
-    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="-static-libstdc++" />
     <property key="COMPILER_MISCELLANEOUS_OPTION" value="" />
     <toolchain name="gcc" version="9.2" />
     <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-4.0/common/efl-tool/efl-tools/bin/edje_cc" />

--- a/rootstraps/wearable-5.5-arm.flutter.xml
+++ b/rootstraps/wearable-5.5-arm.flutter.xml
@@ -2,7 +2,7 @@
 <extension point="rootstrapDefinition">
   <rootstrap id="wearable-5.5-arm.flutter" name="Tizen Device 5.5" version="Wearable 5.5" architecture="armel" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-device.core" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-device.core.dev.xml" />
-    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="-static-libstdc++" />
     <property key="COMPILER_MISCELLANEOUS_OPTION" value="" />
     <toolchain name="gcc" version="9.2" />
     <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />

--- a/rootstraps/wearable-5.5-x86.flutter.xml
+++ b/rootstraps/wearable-5.5-x86.flutter.xml
@@ -2,7 +2,7 @@
 <extension point="rootstrapDefinition">
   <rootstrap id="wearable-5.5-x86.flutter" name="Tizen Emulator 5.5" version="Wearable 5.5" architecture="i586" path="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/wearable-5.5-emulator.core" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="#{SBI_HOME}/../../platforms/tizen-5.5/wearable/rootstraps/info/wearable-5.5-emulator.core.dev.xml" />
-    <property key="LINKER_MISCELLANEOUS_OPTION" value="" />
+    <property key="LINKER_MISCELLANEOUS_OPTION" value="-static-libstdc++" />
     <property key="COMPILER_MISCELLANEOUS_OPTION" value="" />
     <toolchain name="gcc" version="9.2" />
     <tool name="EDJE_CC" version="" path="#{SBI_HOME}/../../platforms/tizen-5.5/common/efl-tool/efl-tools/bin/edje_cc" />


### PR DESCRIPTION
Link libstdc++ statically when building apps or plugins for Tizen 4.0 and 5.5, to remove dependency on GLIBCXX_3.4.26 and use C++17 features without limitations.

Fixes #71.

Notes:
- Is it safe to statically  link libstdc++ (especially for our case)? - Yes, I couldn't find any reason not to.
- This change slightly increases the tpk and storage size of an app (by 0.4 MB and 1 MB respectively).
- The change is not applied when targeting Tizen 6.0+, because libstdc++.so on Tizen 6.0+ is already compatible with C++17.
- The change is not applied when targeting arm64, because there's only Tizen 6.0+ runtime for arm64.
