### PR TITLE
Fix create command for C# application

### DIFF
--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -142,7 +142,7 @@ class TizenCreateCommand extends CreateCommand {
         if (dest.existsSync()) {
           dest.deleteSync(recursive: true);
         }
-        if (projectType.basename == 'app') {
+        if (projectType.basename == 'app' && language == 'cpp') {
           final Directory application =
               source.childDirectory(isTizenService ? 'service-app' : 'ui-app');
           if (!application.existsSync()) {


### PR DESCRIPTION
Creating C# application caused failure because of not existing app
directory.

Signed-off-by: Rafal Walczyna <r.walczyna@samsung.com>