### PR TITLE
Simplify the __MODULE__ macro definition

### DIFF
--- a/templates/plugin/cpp/src/log.h.tmpl
+++ b/templates/plugin/cpp/src/log.h.tmpl
@@ -9,8 +9,7 @@
 #define LOG_TAG "{{pluginClass}}"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \


### PR DESCRIPTION
As suggested in https://github.com/flutter-tizen/plugins/pull/111#pullrequestreview-667883789.