### PR TITLE
Fix doctor crash when validating Tizen Studio version

### DIFF
--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -89,16 +89,14 @@ class TizenValidator extends DoctorValidator {
       return ValidationResult(ValidationType.missing, messages);
     }
 
-    if (tizenSdk.sdkVersion == null) {
+    final double sdkVersion = double.tryParse(tizenSdk.sdkVersion ?? '');
+    if (sdkVersion == null) {
       messages.add(const ValidationMessage.error(
         'Unknown Tizen Studio version.\n'
-        'The version file is corrupted. Consider updating or reinstalling Tizen Studio.',
+        'The version file is missing or corrupted. Consider updating or reinstalling Tizen Studio.',
       ));
       return ValidationResult(ValidationType.missing, messages);
-    }
-
-    final double sdkVersion = double.tryParse(tizenSdk.sdkVersion);
-    if (sdkVersion == null || sdkVersion < 4.0) {
+    } else if (sdkVersion < 4.0) {
       messages.add(ValidationMessage.error(
         'A newer version of Tizen Studio is required. To update, run:\n'
         '${tizenSdk.packageManagerCli.path} update',

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -89,17 +89,26 @@ class TizenValidator extends DoctorValidator {
       return ValidationResult(ValidationType.missing, messages);
     }
 
-    final double sdkVersion = double.tryParse(tizenSdk.sdkVersion) ?? 0;
-    if (sdkVersion < 4.0) {
+    if (tizenSdk.sdkVersion == null) {
+      messages.add(const ValidationMessage.error(
+        'Unknown Tizen Studio version.\n'
+        'The version file is corrupted. Consider updating or reinstalling Tizen Studio.',
+      ));
+      return ValidationResult(ValidationType.missing, messages);
+    }
+
+    final double sdkVersion = double.tryParse(tizenSdk.sdkVersion);
+    if (sdkVersion == null || sdkVersion < 4.0) {
       messages.add(ValidationMessage.error(
         'A newer version of Tizen Studio is required. To update, run:\n'
         '${tizenSdk.packageManagerCli.path} update',
       ));
       return ValidationResult(ValidationType.missing, messages);
+    } else {
+      messages.add(ValidationMessage(
+        'Tizen Studio $sdkVersion at ${tizenSdk.directory.path}',
+      ));
     }
-
-    messages.add(ValidationMessage(
-        'Tizen Studio ${tizenSdk.sdkVersion} at ${tizenSdk.directory.path}'));
 
     if (!_validatePackages(messages)) {
       return ValidationResult(ValidationType.partial, messages);
@@ -111,9 +120,11 @@ class TizenValidator extends DoctorValidator {
         'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',
       ));
       return ValidationResult(ValidationType.missing, messages);
+    } else {
+      messages.add(ValidationMessage(
+        '.NET CLI executable at ${dotnetCli.path}',
+      ));
     }
-
-    messages.add(ValidationMessage('.NET CLI executable at ${dotnetCli.path}'));
 
     return ValidationResult(ValidationType.installed, messages);
   }

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -69,6 +69,7 @@ class TizenSdk {
     return null;
   }
 
+  /// The SDK version number in the "x.y" format, or null if unavailable.
   String get sdkVersion {
     final File versionFile = directory.childFile('sdk.version');
     if (!versionFile.existsSync()) {


### PR DESCRIPTION
Fixes the doctor command crash when the `sdk.version` file is corrupted.

This fixes the error in #142, but doesn't really help fixing the root cause of the error.
