### PR TITLE
Create tpkroot manually when building native app on Windows

### DIFF
--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -751,7 +751,22 @@ class NativeTpk {
     outputTpk.copySync(outputDir.childFile(tizenProject.outputTpkName).path);
 
     // Extract the contents of the TPK to support code size analysis.
-    globals.os.unzip(outputTpk, outputDir.childDirectory('tpkroot'));
+    final Directory tpkrootDir = outputDir.childDirectory('tpkroot');
+    globals.os.unzip(outputTpk, tpkrootDir);
+
+    // Manually copy files if unzipping failed.
+    // Issue: https://github.com/flutter-tizen/flutter-tizen/issues/121
+    if (!tpkrootDir.existsSync()) {
+      final File runner = buildDir.childFile('runner');
+      final Directory sharedDir = tizenDir.childDirectory('shared');
+      final File tizenManifest = tizenProject.manifestFile;
+      runner.copySync(
+          tpkrootDir.childDirectory('bin').childFile(runner.basename).path);
+      copyDirectory(libDir, tpkrootDir.childDirectory('lib'));
+      copyDirectory(resDir, tpkrootDir.childDirectory('res'));
+      copyDirectory(sharedDir, tpkrootDir.childDirectory('shared'));
+      tizenManifest.copySync(tpkrootDir.childFile(tizenManifest.basename).path);
+    }
   }
 }
 

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -170,7 +170,10 @@ class TizenBuilder {
       color: TerminalColor.green,
     );
 
-    if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
+    final Directory tpkrootDir = tpkDir.childDirectory('tpkroot');
+    if (buildInfo.codeSizeDirectory != null &&
+        sizeAnalyzer != null &&
+        tpkrootDir.existsSync()) {
       final File codeSizeFile = globals.fs
           .directory(buildInfo.codeSizeDirectory)
           .childFile('snapshot.$targetPlatform.json');
@@ -179,7 +182,7 @@ class TizenBuilder {
           .childFile('trace.$targetPlatform.json');
       final Map<String, Object> output = await sizeAnalyzer.analyzeAotSnapshot(
         aotSnapshot: codeSizeFile,
-        outputDirectory: tpkDir.childDirectory('tpkroot'),
+        outputDirectory: tpkrootDir,
         precompilerTrace: precompilerTrace,
         type: 'linux',
       );


### PR DESCRIPTION
Fixes #121.