### PR TITLE
Improve the doctor -v output

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -30,7 +30,6 @@ import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
-import 'package:flutter_tools/src/version.dart';
 import 'package:path/path.dart';
 
 import 'commands/analyze.dart';
@@ -76,7 +75,7 @@ Future<void> main(List<String> args) async {
     ...args,
   ];
 
-  Cache.flutterRoot = join(_rootPath, 'flutter');
+  Cache.flutterRoot = join(rootPath, 'flutter');
 
   await runner.run(
     args,
@@ -129,7 +128,6 @@ Future<void> main(List<String> args) async {
             logger: globals.logger,
             fileSystem: globals.fs,
           ),
-      FlutterVersion: () => _FlutterVersion(),
       if (verbose && !muteCommandLogging)
         Logger: () => VerboseLogger(StdoutLogger(
               stdio: globals.stdio,
@@ -142,43 +140,10 @@ Future<void> main(List<String> args) async {
 }
 
 /// See: [Cache.defaultFlutterRoot] in `cache.dart`
-String get _rootPath {
+String get rootPath {
   final String scriptPath = Platform.script.toFilePath();
   return normalize(join(
     scriptPath,
     scriptPath.endsWith('.snapshot') ? '../../..' : '../..',
   ));
-}
-
-class _FlutterVersion extends FlutterVersion {
-  _FlutterVersion() : super(workingDirectory: _rootPath);
-
-  @override
-  String get frameworkVersion => 'for Tizen';
-
-  /// See: [Cache.getVersionFor] in `cache.dart`
-  String _getVersionFor(String artifactName) {
-    final File versionFile = globals.fs
-        .directory(_rootPath)
-        .childDirectory('bin')
-        .childDirectory('internal')
-        .childFile('$artifactName.version');
-    return versionFile.existsSync()
-        ? versionFile.readAsStringSync().trim()
-        : null;
-  }
-
-  @override
-  String get engineRevision => _getVersionFor('engine');
-
-  /// See: [_runGit] in `version.dart`
-  String _runGit(String command) => globals.processUtils
-      .runSync(command.split(' '), workingDirectory: _rootPath)
-      .stdout
-      .trim();
-
-  /// See: [FlutterVersion.frameworkCommitDate] in `version.dart`
-  @override
-  String get frameworkCommitDate => _runGit(
-      'git -c log.showSignature=false log -n 1 --pretty=format:%ad --date=iso');
 }

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -4,12 +4,12 @@
 
 // @dart = 2.8
 
-import 'package:flutter_tools/src/android/android_studio_validator.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/doctor_validator.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:meta/meta.dart';
 
 import 'tizen_sdk.dart';
@@ -23,15 +23,11 @@ class TizenDoctorValidatorsProvider extends DoctorValidatorsProvider {
   List<DoctorValidator> get validators {
     final List<DoctorValidator> validators =
         DoctorValidatorsProvider.defaultInstance.validators;
-    for (final DoctorValidator validator in validators) {
-      // Append before any IDE validators.
-      if (validator is AndroidStudioValidator ||
-          validator is NoAndroidStudioValidator) {
-        validators.insert(validators.indexOf(validator), tizenValidator);
-        break;
-      }
-    }
-    return validators;
+    return <DoctorValidator>[
+      validators.first,
+      tizenValidator,
+      ...validators.sublist(1)
+    ];
   }
 
   @override
@@ -112,16 +108,22 @@ class TizenValidator extends DoctorValidator {
       return ValidationResult(ValidationType.partial, messages);
     }
 
-    if (dotnetCli == null) {
+    if (globals.processManager.canRun(dotnetCli.path)) {
+      // TODO(swift-kim): Extract numbers only and compare with the minimum SDK
+      // version using Version.parse().
+      final String dotnetVersion = globals.processUtils
+          .runSync(<String>[dotnetCli.path, '--version'])
+          .stdout
+          .trim();
+      messages.add(ValidationMessage(
+        '.NET SDK $dotnetVersion at ${dotnetCli.path}',
+      ));
+    } else {
       messages.add(const ValidationMessage.error(
-        '.NET CLI is required for building Tizen applications.\n'
+        'Unable to find the .NET CLI executable in your PATH.\n'
         'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',
       ));
       return ValidationResult(ValidationType.missing, messages);
-    } else {
-      messages.add(ValidationMessage(
-        '.NET CLI executable at ${dotnetCli.path}',
-      ));
     }
 
     return ValidationResult(ValidationType.installed, messages);

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -108,7 +108,7 @@ class TizenValidator extends DoctorValidator {
       return ValidationResult(ValidationType.partial, messages);
     }
 
-    if (globals.processManager.canRun(dotnetCli.path)) {
+    if (dotnetCli != null && globals.processManager.canRun(dotnetCli.path)) {
       // TODO(swift-kim): Extract numbers only and compare with the minimum SDK
       // version using Version.parse().
       final String dotnetVersion = globals.processUtils


### PR DESCRIPTION
- Displays Tizen tool and engine revisions.
- Displays the .NET SDK version currently in use.

```
$ flutter-tizen doctor -v
[✓] Flutter (Channel unknown, 2.2.1, on Linux, locale C.UTF-8)
    • Flutter version 2.2.1 at /home/swift/Git/flutter-tizen/flutter
    • Framework revision 02c026b03c (5 weeks ago), 2021-05-27 12:24:44 -0700
    • Engine revision 0fdb562ac8
    • Dart version 2.13.1

[✓] Tizen toolchain - develop for Tizen devices
    • Framework revision 4756304f13 (2 minutes ago), 2021-07-01 17:25:16 +0900
    • Engine revision a67e79d07d
    • Tizen Studio 4.1 at /home/swift/tizen-studio
    • .NET SDK 5.0.300 at /usr/bin/dotnet
```