### PR TITLE
Implement precache command for tizen

### DIFF
--- a/lib/commands/precache.dart
+++ b/lib/commands/precache.dart
@@ -40,11 +40,10 @@ class TizenPrecacheCommand extends PrecacheCommand {
   final Cache _cache;
   final Platform _platform;
 
-  bool get _includeOtherPlatforms {
-    return boolArg('android') ||
-        DevelopmentArtifact.values.any((DevelopmentArtifact artifact) =>
-            boolArg(artifact.name) && argResults.wasParsed(artifact.name));
-  }
+  bool get _includeOtherPlatforms =>
+      boolArg('android') ||
+      DevelopmentArtifact.values.any((DevelopmentArtifact artifact) =>
+          boolArg(artifact.name) && argResults.wasParsed(artifact.name));
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/lib/commands/precache.dart
+++ b/lib/commands/precache.dart
@@ -31,10 +31,12 @@ class TizenPrecacheCommand extends PrecacheCommand {
           logger: logger,
           featureFlags: featureFlags,
         ) {
-    argParser.addFlag('tizen',
-        negatable: true,
-        defaultsTo: false,
-        help: 'Precache artifacts for Tizen development.');
+    argParser.addFlag(
+      'tizen',
+      negatable: true,
+      defaultsTo: false,
+      help: 'Precache artifacts for Tizen development.',
+    );
   }
 
   final Cache _cache;
@@ -62,8 +64,9 @@ class TizenPrecacheCommand extends PrecacheCommand {
       if (boolArg('force')) {
         _cache.setStampFor(tizenStampName, '');
       }
-      await _cache
-          .updateAll(<DevelopmentArtifact>{TizenDevelopmentArtifact.tizen});
+      await _cache.updateAll(<DevelopmentArtifact>{
+        TizenDevelopmentArtifact.tizen,
+      });
     }
 
     if (includeAllPlatforms || includeDefaults || _includeOtherPlatforms) {

--- a/lib/commands/precache.dart
+++ b/lib/commands/precache.dart
@@ -1,0 +1,83 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:meta/meta.dart';
+
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/commands/precache.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+
+import '../tizen_cache.dart';
+
+class TizenPrecacheCommand extends PrecacheCommand {
+  TizenPrecacheCommand({
+    bool verboseHelp = false,
+    @required Cache cache,
+    @required Platform platform,
+    @required Logger logger,
+    @required FeatureFlags featureFlags,
+  })  : _cache = cache,
+        _platform = platform,
+        super(
+          verboseHelp: verboseHelp,
+          cache: cache,
+          platform: platform,
+          logger: logger,
+          featureFlags: featureFlags,
+        ) {
+    argParser.addFlag('tizen',
+        negatable: true,
+        defaultsTo: false,
+        help: 'Precache artifacts for Tizen development.');
+  }
+
+  final Cache _cache;
+  final Platform _platform;
+
+  bool get _includeOtherPlatforms {
+    return boolArg('android') ||
+        DevelopmentArtifact.values.any((DevelopmentArtifact artifact) =>
+            boolArg(artifact.name) && argResults.wasParsed(artifact.name));
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final bool includeAllPlatforms = boolArg('all-platforms');
+    final bool includeTizen = boolArg('tizen');
+    final bool includeDefaults = !includeTizen && !_includeOtherPlatforms;
+
+    const String tizenStampName = 'tizen-sdk';
+
+    // Re-lock the cache.
+    if (_platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true') {
+      await _cache.lock();
+    }
+
+    if (includeAllPlatforms || includeDefaults || includeTizen) {
+      if (boolArg('force')) {
+        _cache.setStampFor(tizenStampName, '');
+      }
+      await _cache
+          .updateAll(<DevelopmentArtifact>{TizenDevelopmentArtifact.tizen});
+    }
+
+    if (includeAllPlatforms || includeDefaults || _includeOtherPlatforms) {
+      // If the '--force' option is used, the super.runCommand() will delete
+      // the tizen's stamp file. It should be restored.
+      final String tizenStamp = _cache.getStampFor(tizenStampName);
+      final FlutterCommandResult result = await super.runCommand();
+      if (tizenStamp != null) {
+        _cache.setStampFor(tizenStampName, tizenStamp);
+      }
+      return result;
+    }
+
+    return FlutterCommandResult.success();
+  }
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -27,6 +27,7 @@ import 'package:flutter_tools/src/commands/symbolize.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/emulator.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
@@ -40,6 +41,7 @@ import 'commands/clean.dart';
 import 'commands/create.dart';
 import 'commands/drive.dart';
 import 'commands/packages.dart';
+import 'commands/precache.dart';
 import 'commands/run.dart';
 import 'commands/test.dart';
 import 'tizen_cache.dart';
@@ -103,6 +105,13 @@ Future<void> main(List<String> args) async {
       TizenCreateCommand(verboseHelp: verboseHelp),
       TizenDriveCommand(verboseHelp: verboseHelp),
       TizenPackagesCommand(),
+      TizenPrecacheCommand(
+        verboseHelp: verboseHelp,
+        cache: globals.cache,
+        logger: globals.logger,
+        platform: globals.platform,
+        featureFlags: featureFlags,
+      ),
       TizenRunCommand(verboseHelp: verboseHelp),
       TizenTestCommand(verboseHelp: verboseHelp),
     ],


### PR DESCRIPTION
context: #156

Use the 'precache` command to download the tizen engine artifacts as follows:

```bash
flutter-tizen precache  # default artifacts including tizen
flutter-tizen precache --tizen  # explicit artifacts
flutter-tizen precache -a   # all artifacts
```
