### PR TITLE
Install TPK twice when uninstalling and re-installing (TV emulator)

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -251,10 +251,10 @@ class TizenDevice extends Device {
   /// Source: [AndroidDevice.uninstallApp] in `android_device.dart`
   @override
   Future<bool> uninstallApp(TizenTpk app, {String userIdentifier}) async {
-    try {
-      await runSdbAsync(<String>['uninstall', app.id]);
-    } on Exception catch (error) {
-      _logger.printError('sdb uninstall failed: $error');
+    final RunResult result =
+        await runSdbAsync(<String>['uninstall', app.id], checked: false);
+    if (result.exitCode != 0 || !result.stdout.contains('val[ok]')) {
+      _logger.printError('sdb uninstall failed:\n$result');
       return false;
     }
     return true;

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -251,11 +252,13 @@ class TizenDevice extends Device {
       return false;
     }
 
-    final double deviceVersion = double.tryParse(platformVersion) ?? 0;
-    final double apiVersion = double.tryParse(app.manifest?.apiVersion) ?? 0;
-    if (apiVersion > deviceVersion) {
+    final Version deviceVersion = Version.parse(platformVersion);
+    final Version apiVersion = Version.parse(app.manifest?.apiVersion);
+    if (deviceVersion != null &&
+        apiVersion != null &&
+        apiVersion > deviceVersion) {
       _logger.printStatus(
-        'Warning: The package API version (${app.manifest?.apiVersion}) is greater than the device API version ($platformVersion).\n'
+        'Warning: The package API version ($apiVersion) is greater than the device API version ($deviceVersion).\n'
         'Check "tizen-manifest.xml" of your Tizen project to fix this problem.',
         color: TerminalColor.yellow,
       );


### PR DESCRIPTION
Currently an app is installed only once on TV emulator when uninstalling and installing (e.g. due to certificate change) an already installed app. This may lead to the notorious library loading error (https://github.com/flutter-tizen/flutter-tizen/issues/50).

- Make sure the app is installed twice.
- Apply https://github.com/flutter/flutter/pull/67936 (change the functions order and un-nest if blocks).
- Check the uninstallation result.
- Use `Version` when comparing the package API version and the device API version.
