### PR TITLE
Release cache lock after updating tizen cache

### DIFF
--- a/lib/commands/precache.dart
+++ b/lib/commands/precache.dart
@@ -69,6 +69,9 @@ class TizenPrecacheCommand extends PrecacheCommand {
       });
     }
 
+    // Release lock of the cache
+    _cache.releaseLock();
+
     if (includeAllPlatforms || includeDefaults || _includeOtherPlatforms) {
       // If the '--force' option is used, the super.runCommand() will delete
       // the tizen's stamp file. It should be restored.

--- a/lib/commands/precache.dart
+++ b/lib/commands/precache.dart
@@ -69,7 +69,7 @@ class TizenPrecacheCommand extends PrecacheCommand {
       });
     }
 
-    // Release lock of the cache
+    // Release lock of the cache.
     _cache.releaseLock();
 
     if (includeAllPlatforms || includeDefaults || _includeOtherPlatforms) {


### PR DESCRIPTION
fixed #165 

- release the lock of the cache after updating tizen's engine artifacts

