### PR TITLE
Set requiredArtifacts to drive, test commmands

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -26,7 +26,8 @@ class TizenBuildCommand extends BuildCommand {
   }
 }
 
-class BuildTpkCommand extends BuildSubCommand with TizenExtension {
+class BuildTpkCommand extends BuildSubCommand
+    with TizenExtension, TizenRequiredArtifacts {
   /// See: [BuildApkCommand] in `build_apk.dart`
   BuildTpkCommand({bool verboseHelp = false}) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
@@ -53,13 +54,6 @@ class BuildTpkCommand extends BuildSubCommand with TizenExtension {
 
   @override
   final String name = 'tpk';
-
-  @override
-  Future<Set<DevelopmentArtifact>> get requiredArtifacts async =>
-      <DevelopmentArtifact>{
-        DevelopmentArtifact.androidGenSnapshot,
-        TizenDevelopmentArtifact.tizen,
-      };
 
   @override
   final String description = 'Build a Tizen TPK file from your app.';

--- a/lib/commands/drive.dart
+++ b/lib/commands/drive.dart
@@ -7,9 +7,11 @@
 import 'package:flutter_tools/src/commands/drive.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
+import '../tizen_cache.dart';
 import '../tizen_plugins.dart';
 
-class TizenDriveCommand extends DriveCommand with TizenExtension {
+class TizenDriveCommand extends DriveCommand
+    with TizenExtension, TizenRequiredArtifacts {
   TizenDriveCommand({bool verboseHelp = false})
       : super(
           verboseHelp: verboseHelp,

--- a/lib/commands/run.dart
+++ b/lib/commands/run.dart
@@ -4,19 +4,12 @@
 
 // @dart = 2.8
 
-import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/run.dart';
 
 import '../tizen_cache.dart';
 import '../tizen_plugins.dart';
 
-class TizenRunCommand extends RunCommand with TizenExtension {
+class TizenRunCommand extends RunCommand
+    with TizenExtension, TizenRequiredArtifacts {
   TizenRunCommand({bool verboseHelp = false}) : super(verboseHelp: verboseHelp);
-
-  @override
-  Future<Set<DevelopmentArtifact>> get requiredArtifacts async =>
-      <DevelopmentArtifact>{
-        DevelopmentArtifact.androidGenSnapshot,
-        TizenDevelopmentArtifact.tizen,
-      };
 }

--- a/lib/commands/test.dart
+++ b/lib/commands/test.dart
@@ -6,9 +6,11 @@
 
 import 'package:flutter_tools/src/commands/test.dart';
 
+import '../tizen_cache.dart';
 import '../tizen_plugins.dart';
 
-class TizenTestCommand extends TestCommand with TizenExtension {
+class TizenTestCommand extends TestCommand
+    with TizenExtension, TizenRequiredArtifacts {
   TizenTestCommand({bool verboseHelp = false})
       : super(verboseHelp: verboseHelp);
 }

--- a/lib/tizen_cache.dart
+++ b/lib/tizen_cache.dart
@@ -16,7 +16,17 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/flutter_cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:http/http.dart' as http;
+
+mixin TizenRequiredArtifacts on FlutterCommand {
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async =>
+      <DevelopmentArtifact>{
+        DevelopmentArtifact.androidGenSnapshot,
+        TizenDevelopmentArtifact.tizen,
+      };
+}
 
 /// See: [DevelopmentArtifact] in `cache.dart`
 class TizenDevelopmentArtifact implements DevelopmentArtifact {


### PR DESCRIPTION
fix #169

- Add a mixin `TizenRequiredArtifacts` to override `requiredArtifacts`  of `FlutterCommand`.
- Apply the mixin to `build`, `run`, `drive`, `test` commands
