### PR TITLE
Various refactoring

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -139,7 +139,13 @@ Future<void> main(List<String> args) async {
             osUtils: globals.os,
           ),
       TemplateRenderer: () => const MustacheTemplateRenderer(),
-      ApplicationPackageFactory: () => TizenApplicationPackageFactory(),
+      ApplicationPackageFactory: () => TizenApplicationPackageFactory(
+            androidSdk: globals.androidSdk,
+            processManager: globals.processManager,
+            logger: globals.logger,
+            userMessages: globals.userMessages,
+            fileSystem: globals.fs,
+          ),
       DeviceManager: () => TizenDeviceManager(
             fileSystem: globals.fs,
             logger: globals.logger,

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -140,7 +140,12 @@ Future<void> main(List<String> args) async {
           ),
       TemplateRenderer: () => const MustacheTemplateRenderer(),
       ApplicationPackageFactory: () => TizenApplicationPackageFactory(),
-      DeviceManager: () => TizenDeviceManager(),
+      DeviceManager: () => TizenDeviceManager(
+            fileSystem: globals.fs,
+            logger: globals.logger,
+            platform: globals.platform,
+            processManager: globals.processManager,
+          ),
       DoctorValidatorsProvider: () => TizenDoctorValidatorsProvider(),
       TizenSdk: () => TizenSdk.locateSdk(),
       TizenWorkflow: () => TizenWorkflow(

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -152,7 +152,10 @@ Future<void> main(List<String> args) async {
             tizenSdk: tizenSdk,
             operatingSystemUtils: globals.os,
           ),
-      TizenValidator: () => TizenValidator(),
+      TizenValidator: () => TizenValidator(
+            logger: globals.logger,
+            processManager: globals.processManager,
+          ),
       EmulatorManager: () => TizenEmulatorManager(
             tizenSdk: tizenSdk,
             tizenWorkflow: tizenWorkflow,

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -501,11 +501,11 @@ class DotnetTpk {
 
     if (securityProfile != null) {
       if (tizenSdk.securityProfiles == null ||
-          !tizenSdk.securityProfiles.names.contains(securityProfile)) {
+          !tizenSdk.securityProfiles.contains(securityProfile)) {
         throwToolExit('The profile $securityProfile does not exist.');
       }
     }
-    securityProfile ??= tizenSdk.securityProfiles?.active?.name;
+    securityProfile ??= tizenSdk.securityProfiles?.active;
 
     if (securityProfile != null) {
       environment.logger
@@ -713,11 +713,11 @@ class NativeTpk {
     String securityProfile = buildInfo.securityProfile;
     if (securityProfile != null) {
       if (tizenSdk.securityProfiles == null ||
-          !tizenSdk.securityProfiles.names.contains(securityProfile)) {
+          !tizenSdk.securityProfiles.contains(securityProfile)) {
         throwToolExit('The profile $securityProfile does not exist.');
       }
     }
-    securityProfile ??= tizenSdk.securityProfiles?.active?.name;
+    securityProfile ??= tizenSdk.securityProfiles?.active;
 
     if (securityProfile != null) {
       environment.logger

--- a/lib/tizen_build_target.dart
+++ b/lib/tizen_build_target.dart
@@ -264,7 +264,7 @@ USER_LIB_DIRS = lib
             .forEach(inputs.add);
       }
 
-      for (final String libName in plugin.getProperty('USER_LIBS').split(' ')) {
+      for (final String libName in plugin.getProperty('USER_LIBS')) {
         final File libFile = plugin.directory
             .childDirectory('lib')
             .childDirectory(getTizenBuildArch(buildInfo.targetArch))

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -257,7 +257,7 @@ class TizenDevice extends Device {
     }
 
     final Version deviceVersion = Version.parse(_platformVersion);
-    final Version apiVersion = Version.parse(app.manifest?.apiVersion);
+    final Version apiVersion = Version.parse(app.manifest.apiVersion);
     if (deviceVersion != null &&
         apiVersion != null &&
         apiVersion > deviceVersion) {
@@ -336,7 +336,7 @@ class TizenDevice extends Device {
       );
       // Package has been built, so we can get the updated application id and
       // activity name from the tpk.
-      package = await TizenTpk.fromTizenProject(project);
+      package = await TizenTpk.fromProject(project);
     }
     if (package == null) {
       throwToolExit('Problem building an application: see above error(s).');

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -39,12 +39,14 @@ class TizenDevice extends Device {
     String id, {
     String modelId,
     @required Logger logger,
-    @required TizenSdk tizenSdk,
     @required ProcessManager processManager,
+    @required TizenSdk tizenSdk,
+    @required FileSystem fileSystem,
   })  : _modelId = modelId,
         _logger = logger,
-        _tizenSdk = tizenSdk,
         _processManager = processManager,
+        _tizenSdk = tizenSdk,
+        _fileSystem = fileSystem,
         _processUtils =
             ProcessUtils(logger: logger, processManager: processManager),
         super(id,
@@ -54,8 +56,9 @@ class TizenDevice extends Device {
 
   final String _modelId;
   final Logger _logger;
-  final TizenSdk _tizenSdk;
   final ProcessManager _processManager;
+  final TizenSdk _tizenSdk;
+  final FileSystem _fileSystem;
   final ProcessUtils _processUtils;
 
   Map<String, String> _capabilities;
@@ -182,7 +185,7 @@ class TizenDevice extends Device {
       '/opt/usr/globalapps',
     ];
     for (final String root in rootCandidates) {
-      final File signatureFile = globals.fs.systemTempDirectory
+      final File signatureFile = _fileSystem.systemTempDirectory
           .createTempSync()
           .childFile('author-signature.xml');
       final RunResult result = await runSdbAsync(
@@ -446,7 +449,7 @@ class TizenDevice extends Device {
     String filename,
   ) async {
     final File localFile =
-        globals.fs.systemTempDirectory.createTempSync().childFile(filename);
+        _fileSystem.systemTempDirectory.createTempSync().childFile(filename);
     localFile.writeAsStringSync(arguments.join('\n'));
     final String remotePath = '/home/owner/share/tmp/sdk_tools/$filename';
     final RunResult result =

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -40,7 +40,7 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
     this.fileName,
   }) : assert(pluginClass != null || dartPluginClass != null);
 
-  factory TizenPlugin.fromYaml(String name, Directory directory, YamlMap yaml) {
+  static TizenPlugin fromYaml(String name, Directory directory, YamlMap yaml) {
     assert(validate(yaml));
     return TizenPlugin(
       name: name,
@@ -83,14 +83,14 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
 
   final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
 
-  Map<String, String> _properties;
+  Map<String, List<String>> _properties;
 
-  String getProperty(String key) {
+  List<String> getProperty(String key) {
     if (_properties == null) {
       if (!projectFile.existsSync()) {
-        return null;
+        return <String>[];
       }
-      _properties = <String, String>{};
+      _properties = <String, List<String>>{};
 
       for (final String line in projectFile.readAsLinesSync()) {
         final Match match = _propertyFormat.firstMatch(line);
@@ -99,20 +99,15 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
         }
         final String key = match.group(1);
         final String value = match.group(2).trim();
-        _properties[key] = value;
+        _properties[key] = value.split(' ');
       }
     }
-    return _properties.containsKey(key) ? _properties[key] : null;
+    return _properties.containsKey(key) ? _properties[key] : <String>[];
   }
 
   List<String> getPropertyAsAbsolutePaths(String key) {
-    final String property = getProperty(key);
-    if (property == null) {
-      return <String>[];
-    }
-
     final List<String> paths = <String>[];
-    for (final String element in property.split(' ')) {
+    for (final String element in getProperty(key)) {
       if (globals.fs.path.isAbsolute(element)) {
         paths.add(element);
       } else {

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -22,7 +22,7 @@ class TizenSdk {
   TizenSdk._(this.directory);
 
   /// See: [AndroidSdk.locateAndroidSdk] in `android_sdk.dart`
-  factory TizenSdk.locateSdk() {
+  static TizenSdk locateSdk() {
     Directory tizenHomeDir;
     final Map<String, String> environment = globals.platform.environment;
     final File sdb = globals.os.which('sdb');
@@ -58,14 +58,18 @@ class TizenSdk {
   Directory get sdkDataDirectory {
     final File sdkInfo = directory.childFile('sdk.info');
     if (!sdkInfo.existsSync()) {
-      return null;
+      throwToolExit(
+        'The sdk.info file could not be found. Tizen Studio is out of date or corrupted.',
+      );
     }
     // ignore: invalid_use_of_visible_for_testing_member
     final Map<String, String> info = parseIniLines(sdkInfo.readAsLinesSync());
     if (info.containsKey('TIZEN_SDK_DATA_PATH')) {
       return globals.fs.directory(info['TIZEN_SDK_DATA_PATH']);
     }
-    return null;
+    throwToolExit(
+      'The SDK data directory could not be found. Tizen Studio is out of date or corrupted.',
+    );
   }
 
   /// The SDK version number in the "x.y[.z]" format, or null if not found.
@@ -102,11 +106,11 @@ class TizenSdk {
           ? 'package-manager-cli.exe'
           : 'package-manager-cli.bin');
 
-  File get securityProfilesFile =>
-      sdkDataDirectory.childDirectory('profile').childFile('profiles.xml');
-
-  SecurityProfiles get securityProfiles =>
-      SecurityProfiles.parseFromXml(securityProfilesFile);
+  SecurityProfiles get securityProfiles {
+    final File manifest =
+        sdkDataDirectory.childDirectory('profile').childFile('profiles.xml');
+    return SecurityProfiles.parseFromXml(manifest);
+  }
 
   String get defaultNativeCompiler => 'llvm-10.0';
 


### PR DESCRIPTION
- Reduce the use of `globals` for improved testability.
- Clean-ups for https://github.com/flutter-tizen/flutter-tizen/issues/172.
- Convert factory constructors into static methods.
- Remove unused classes `Certificate` and `SecurityProfile`.