### PR TITLE
Handle corrupted Runner.csproj.user properly

### DIFF
--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -73,7 +73,7 @@ class TizenProject extends FlutterProjectPlatform {
       document = XmlDocument.parse(userFile.readAsStringSync().trim());
     } on XmlException {
       globals.printStatus('Overwriting ${userFile.basename}...');
-      userFile.writeAsStringSync(initialXmlContent);
+      document = XmlDocument.parse(initialXmlContent);
     }
 
     final File embeddingProjectFile = globals.fs


### PR DESCRIPTION
Fixes a null reference error when `Runner.csproj.user` file is corrupted (which is expected to be a very rare case). My previous implementation was incorrect.

Before:
```
Overwriting Runner.csproj.user...

NoSuchMethodError: The getter 'children' was called on null.
Receiver: null
Tried calling: children
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:54:5)
#1      XmlDescendantsIterator.push (package:xml/src/xml/navigation/descendants.dart:31:23)
#2      new XmlDescendantsIterator (package:xml/src/xml/navigation/descendants.dart:27:5)
#3      XmlDescendantsIterable.iterator (package:xml/src/xml/navigation/descendants.dart:18:37)
#4      WhereTypeIterable.iterator (dart:_internal/iterable.dart:860:64)
#5      WhereIterable.iterator (dart:_internal/iterable.dart:423:62)
#6      Iterable.isEmpty (dart:core/iterable.dart:396:24)
#7      TizenProject.ensureReadyForPlatformSpecificTooling (package:flutter_tizen/tizen_project.dart:87:18)
#8      ensureReadyForTizenTooling (package:flutter_tizen/tizen_plugins.dart:240:22)
...
```

After:
```
Overwriting Runner.csproj.user...

Building without sound null safety
For more information see https://dart.dev/null-safety/unsound-null-safety

Building a Tizen application in release mode...                  2,015ms
✓ Built build/tizen/tpk/com.example.dotnet_app-1.0.0.tpk (6.2MB).
```