### PR TITLE
Allow plugins to link against static libraries

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -275,7 +275,6 @@ class NativeTpk {
     final List<String> extraOptions = <String>[
       '-lflutter_tizen_${buildInfo.deviceProfile}',
       '-L"${libDir.path.toPosixPath()}"',
-      '-std=c++17',
       '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
       '-I"${publicDir.path.toPosixPath()}"',
       ...userIncludes.map((String f) => '-I"${f.toPosixPath()}"'),

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -208,7 +208,7 @@ class TizenSdk {
   <rootstrap id="$flutterRootstrapId" name="flutter" version="flutter" architecture="$buildArch" path="${rootstrap.rootDirectory.path}" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="${configFile.path}"/>
     <property key="LINKER_MISCELLANEOUS_OPTION" value="${linkerFlags.join(' ')}"/>
-    <property key="COMPILER_MISCELLANEOUS_OPTION" value=""/>
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17"/>
     <toolchain name="gcc" version="$defaultGccVersion"/>
   </rootstrap>
 </extension>

--- a/templates/plugin/cpp/project_def.prop.tmpl
+++ b/templates/plugin/cpp/project_def.prop.tmpl
@@ -6,7 +6,7 @@ type = sharedLib
 profile = common-4.0
 
 # Source files
-USER_SRCS += src/{{projectName}}_plugin.cc
+USER_SRCS += src/*.cc
 
 # User defines
 USER_DEFS =


### PR DESCRIPTION
- Support linking user static libraries. (Currently only shared libraries are supported).
- Move the `-std=c++17` option to the rootstrap definition.
- Update `project_def.prop` of the plugin template to use a wildcard (`src/*.cc`).