### PR TITLE
Rework the native plugin builder

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -248,6 +248,9 @@ class NativeTpk {
     }
 
     // Prepare for build.
+    final Directory clientWrapperDir =
+        commonDir.childDirectory('cpp_client_wrapper');
+    final Directory publicDir = commonDir.childDirectory('public');
     final Directory embeddingDir = environment.fileSystem
         .directory(Cache.flutterRoot)
         .parent
@@ -259,28 +262,8 @@ class NativeTpk {
       pluginsDir.childDirectory('include').path,
     ];
     final List<String> userSources = <String>[
+      clientWrapperDir.childFile('*.cc').path,
       embeddingDir.childFile('*.cc').path,
-    ];
-
-    final Directory clientWrapperDir =
-        commonDir.childDirectory('cpp_client_wrapper');
-    final Directory publicDir = commonDir.childDirectory('public');
-
-    userSources.add(clientWrapperDir.childFile('*.cc').path);
-
-    final Map<String, String> variables = <String, String>{
-      'PATH': getDefaultPathVariable(),
-      'USER_SRCS': userSources.map((String f) => f.toPosixPath()).join(' '),
-    };
-    final List<String> extraOptions = <String>[
-      '-lflutter_tizen_${buildInfo.deviceProfile}',
-      '-L"${libDir.path.toPosixPath()}"',
-      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
-      '-I"${publicDir.path.toPosixPath()}"',
-      ...userIncludes.map((String f) => '-I"${f.toPosixPath()}"'),
-      if (pluginsLib.existsSync()) '-lflutter_plugins',
-      '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
-      '-Wl,-unresolved-symbols=ignore-in-shared-libs',
     ];
 
     assert(tizenSdk != null);
@@ -299,22 +282,28 @@ class NativeTpk {
     }
 
     // Run the native build.
-    RunResult result = await _processUtils.run(<String>[
-      tizenSdk.tizenCli.path,
-      'build-native',
-      '-a',
-      getTizenCliArch(buildInfo.targetArch),
-      '-C',
-      buildConfig,
-      '-c',
-      tizenSdk.defaultNativeCompiler,
-      '-r',
-      rootstrap.id,
-      '-e',
-      extraOptions.join(' '),
-      '--',
+    RunResult result = await tizenSdk.buildNative(
       tizenDir.path,
-    ], environment: variables);
+      configuration: buildConfig,
+      arch: getTizenCliArch(buildInfo.targetArch),
+      predefines: <String>[
+        '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+      ],
+      extraOptions: <String>[
+        '-lflutter_tizen_${buildInfo.deviceProfile}',
+        '-L"${libDir.path.toPosixPath()}"',
+        '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
+        '-I"${publicDir.path.toPosixPath()}"',
+        ...userIncludes.map((String f) => '-I"${f.toPosixPath()}"'),
+        if (pluginsLib.existsSync()) '-lflutter_plugins',
+        '-Wl,-unresolved-symbols=ignore-in-shared-libs',
+      ],
+      rootstrap: rootstrap.id,
+      environment: <String, String>{
+        'PATH': getDefaultPathVariable(),
+        'USER_SRCS': userSources.map((String f) => f.toPosixPath()).join(' '),
+      },
+    );
     if (result.exitCode != 0) {
       throwToolExit('Failed to build native application:\n$result');
     }

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -36,7 +36,7 @@ class NativePlugins extends Target {
 
   @override
   List<Source> get inputs => const <Source>[
-        Source.pattern('{FLUTTER_ROOT}/../lib/tizen_build_target.dart'),
+        Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/plugins.dart'),
         Source.pattern('{PROJECT_DIR}/.packages'),
       ];
 
@@ -201,16 +201,20 @@ class NativePlugins extends Target {
       for (final Directory directory
           in pluginLibDirs.where((Directory d) => d.existsSync())) {
         for (final File lib in directory.listSync().whereType<File>()) {
-          if (lib.basename.endsWith('.so') || lib.basename.endsWith('.a')) {
+          final bool isSharedLib = lib.basename.endsWith('.so');
+          final bool isStaticLib = lib.basename.endsWith('.a');
+          if (isSharedLib || isStaticLib) {
             final String libName = getLibNameForFileName(lib.basename);
             if (userLibs.contains(libName)) {
               continue;
             }
             lib.copySync(libDir.childFile(lib.basename).path);
-            userLibs.add(getLibNameForFileName(lib.basename));
+            userLibs.add(libName);
 
             inputs.add(lib);
-            outputs.add(libDir.childFile(lib.basename));
+            if (isSharedLib) {
+              outputs.add(libDir.childFile(lib.basename));
+            }
           }
         }
       }

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -34,6 +34,7 @@ class NativePlugins extends Target {
   @override
   List<Source> get inputs => const <Source>[
         Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/plugins.dart'),
+        Source.pattern('{FLUTTER_ROOT}/../lib/tizen_sdk.dart'),
         Source.pattern('{PROJECT_DIR}/.packages'),
       ];
 
@@ -58,8 +59,8 @@ class NativePlugins extends Target {
         if (key == 'type') {
           if (value != 'staticLib') {
             logger.printStatus(
-              'The project type of ${plugin.name} plugin is $value,'
-              ' which is deprecated in favor of staticLib.',
+              'The project type of ${plugin.name} plugin is "$value",'
+              ' which is deprecated in favor of "staticLib".',
             );
           }
           line = 'type = staticLib';
@@ -147,13 +148,15 @@ class NativePlugins extends Target {
         pluginCopy.directory.path,
         configuration: buildConfig,
         arch: getTizenCliArch(buildInfo.targetArch),
-        predefine: '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+        predefines: <String>[
+          '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+        ],
         extraOptions: <String>[
           '-fPIC',
           '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
           '-I"${publicDir.path.toPosixPath()}"',
         ],
-        rootstrap: rootstrap,
+        rootstrap: rootstrap.id,
         environment: <String, String>{
           'PATH': getDefaultPathVariable(),
         },
@@ -266,7 +269,7 @@ USER_LIBS = ${userLibs.join(' ')}
         for (String className in pluginClasses)
           '-Wl,--undefined=${className}RegisterWithRegistrar',
       ],
-      rootstrap: rootstrap,
+      rootstrap: rootstrap.id,
       environment: <String, String>{
         'PATH': getDefaultPathVariable(),
       },

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -64,34 +64,10 @@ class NativePlugins extends Target {
         FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
 
-    // Create a dummy project in the build directory.
-    final Directory rootDir = environment.buildDir
-        .childDirectory('tizen_plugins')
-          ..createSync(recursive: true);
-    final File projectDef = rootDir.childFile('project_def.prop');
-
-    final TizenManifest tizenManifest =
-        TizenManifest.parseFromXml(tizenProject.manifestFile);
-    final String profile = tizenManifest.profile;
-    final String apiVersion = tizenManifest.apiVersion;
-    inputs.add(tizenProject.manifestFile);
-
-    projectDef.writeAsStringSync('''
-APPNAME = flutter_plugins
-type = sharedLib
-profile = $profile-$apiVersion
-
-USER_CPP_DEFS = TIZEN_DEPRECATION DEPRECATION_WARNING FLUTTER_PLUGIN_IMPL
-USER_CPPFLAGS_MISC = -c -fmessage-length=0
-USER_LFLAGS = -Wl,-rpath='\$\$ORIGIN'
-''');
-
     // Check if there's anything to build.
     final List<TizenPlugin> nativePlugins =
         await findTizenPlugins(project, nativeOnly: true);
     if (nativePlugins.isEmpty) {
-      rootDir.deleteSync(recursive: true);
-
       depfileService.writeToFile(
         Depfile(inputs, outputs),
         environment.buildDir.childFile('tizen_plugins.d'),
@@ -99,71 +75,21 @@ USER_LFLAGS = -Wl,-rpath='\$\$ORIGIN'
       return;
     }
 
-    // Prepare for build.
+    // Create a dummy project in the build directory.
+    final Directory rootDir = environment.buildDir
+        .childDirectory('tizen_plugins')
+          ..createSync(recursive: true);
     final Directory includeDir = rootDir.childDirectory('include')
       ..createSync(recursive: true);
     final Directory libDir = rootDir.childDirectory('lib')
       ..createSync(recursive: true);
 
-    final List<String> userIncludes = <String>[];
-    final List<String> userSources = <String>[];
-    final List<String> userLibs = <String>[];
-
-    for (final TizenPlugin plugin in nativePlugins) {
-      inputs.add(plugin.projectFile);
-
-      // TODO(swift-kim): Currently only checks for USER_INC_DIRS, USER_SRCS,
-      // and USER_LIBS. More properties may be parsed in the future.
-      userIncludes.addAll(plugin.getPropertyAsAbsolutePaths('USER_INC_DIRS'));
-      userSources.addAll(plugin.getPropertyAsAbsolutePaths('USER_SRCS'));
-
-      final Directory headerDir = plugin.directory.childDirectory('inc');
-      if (headerDir.existsSync()) {
-        headerDir
-            .listSync(recursive: true)
-            .whereType<File>()
-            .forEach(inputs.add);
-      }
-      final Directory sourceDir = plugin.directory.childDirectory('src');
-      if (sourceDir.existsSync()) {
-        sourceDir
-            .listSync(recursive: true)
-            .whereType<File>()
-            .forEach(inputs.add);
-      }
-
-      for (final String libName in plugin.getProperty('USER_LIBS')) {
-        File libFile = plugin.directory
-            .childDirectory('lib')
-            .childDirectory(getTizenBuildArch(buildInfo.targetArch))
-            .childFile('lib$libName.a');
-        if (!libFile.existsSync()) {
-          libFile = libFile.parent.childFile('lib$libName.so');
-          if (!libFile.existsSync()) {
-            continue;
-          }
-        }
-        userLibs.add(libName);
-        libFile.copySync(libDir.childFile(libFile.basename).path);
-
-        inputs.add(libFile);
-        outputs.add(libDir.childFile(libFile.basename));
-      }
-
-      // The plugin header is used when building native apps.
-      final File header = headerDir.childFile(plugin.fileName);
-      header.copySync(includeDir.childFile(header.basename).path);
-      outputs.add(includeDir.childFile(header.basename));
-    }
-
     final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
     final Directory engineDir =
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
-    final File embedder =
-        engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
-    inputs.add(embedder);
-
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
+
     final Directory clientWrapperDir =
         commonDir.childDirectory('cpp_client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
@@ -173,41 +99,166 @@ USER_LFLAGS = -Wl,-rpath='\$\$ORIGIN'
         .forEach(inputs.add);
     publicDir.listSync(recursive: true).whereType<File>().forEach(inputs.add);
 
-    userSources.add(clientWrapperDir.childFile('*.cc').path);
-
-    final Map<String, String> variables = <String, String>{
-      'PATH': getDefaultPathVariable(),
-      'USER_SRCS': userSources.map((String f) => f.toPosixPath()).join(' '),
-      'USER_LIBS': userLibs.join(' '),
-    };
-    final List<String> extraOptions = <String>[
-      '-lflutter_tizen_${buildInfo.deviceProfile}',
-      '-L"${engineDir.path.toPosixPath()}"',
-      '-fvisibility=hidden',
-      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
-      '-I"${publicDir.path.toPosixPath()}"',
-      ...userIncludes.map((String f) => '-I"${f.toPosixPath()}"'),
-      '-L"${libDir.path.toPosixPath()}"',
-      '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
-    ];
-
     assert(tizenSdk != null);
+    final TizenManifest tizenManifest =
+        TizenManifest.parseFromXml(tizenProject.manifestFile);
+    final String profile = tizenManifest.profile;
+    final String apiVersion = tizenManifest.apiVersion;
     final Rootstrap rootstrap = tizenSdk.getFlutterRootstrap(
       profile: profile,
       apiVersion: apiVersion,
       arch: buildInfo.targetArch,
     );
+    inputs.add(tizenProject.manifestFile);
+
+    final List<String> userLibs = <String>[];
+    final List<String> pluginClasses = <String>[];
+
+    for (final TizenPlugin plugin in nativePlugins) {
+      // Create a copy of the plugin to allow editing its projectFile.
+      final TizenPlugin pluginCopy = plugin.copyWith(
+        directory: environment.fileSystem.systemTempDirectory.createTempSync(),
+      );
+      copyDirectory(plugin.directory, pluginCopy.directory);
+
+      final List<String> properties = <String>[];
+      for (String line in plugin.projectFile.readAsLinesSync()) {
+        if (line.startsWith('type =')) {
+          line = 'type = staticLib';
+        }
+        properties.add(line);
+      }
+      pluginCopy.projectFile.writeAsStringSync(properties.join('\n'));
+      inputs.add(plugin.projectFile);
+
+      final Map<String, String> variables = <String, String>{
+        'PATH': getDefaultPathVariable(),
+      };
+      final List<String> extraOptions = <String>[
+        '-fPIC',
+        '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
+        '-I"${publicDir.path.toPosixPath()}"',
+        '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+      ];
+
+      final RunResult result = await _processUtils.run(<String>[
+        tizenSdk.tizenCli.path,
+        'build-native',
+        '-a',
+        getTizenCliArch(buildInfo.targetArch),
+        '-C',
+        buildConfig,
+        '-c',
+        tizenSdk.defaultNativeCompiler,
+        '-r',
+        rootstrap.id,
+        '-e',
+        extraOptions.join(' '),
+        '--',
+        pluginCopy.directory.path,
+      ], environment: variables);
+      if (result.exitCode != 0) {
+        throwToolExit('Failed to build ${plugin.name} plugin:\n$result');
+      }
+
+      final String libName =
+          getLibNameForFileName(plugin.fileName.toLowerCase());
+      final File libFile = pluginCopy.directory
+          .childDirectory(buildConfig)
+          .childFile('lib$libName.a');
+      if (!libFile.existsSync()) {
+        throwToolExit(
+          'Build succeeded but the file ${libFile.path} is not found:\n'
+          '${result.stdout}',
+        );
+      }
+      libFile.copySync(libDir.childFile(libFile.basename).path);
+      userLibs.add(libName);
+      pluginClasses.add(plugin.pluginClass);
+
+      final Directory pluginIncludeDir = plugin.directory.childDirectory('inc');
+      if (pluginIncludeDir.existsSync()) {
+        pluginIncludeDir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .forEach(inputs.add);
+      }
+      final Directory pluginSourceDir = plugin.directory.childDirectory('src');
+      if (pluginSourceDir.existsSync()) {
+        pluginSourceDir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .forEach(inputs.add);
+      }
+
+      // Copy user libs for later linking.
+      final Directory pluginLibDir = plugin.directory.childDirectory('lib');
+      final List<Directory> pluginLibDirs = <Directory>[
+        pluginLibDir.childDirectory(buildInfo.targetArch),
+        pluginLibDir.childDirectory(getTizenBuildArch(buildInfo.targetArch)),
+        pluginLibDir,
+      ];
+      for (final Directory directory
+          in pluginLibDirs.where((Directory d) => d.existsSync())) {
+        for (final File lib in directory.listSync().whereType<File>()) {
+          if (lib.basename.endsWith('.so') || lib.basename.endsWith('.a')) {
+            final String libName = getLibNameForFileName(lib.basename);
+            if (userLibs.contains(libName)) {
+              continue;
+            }
+            lib.copySync(libDir.childFile(lib.basename).path);
+            userLibs.add(getLibNameForFileName(lib.basename));
+
+            inputs.add(lib);
+            outputs.add(libDir.childFile(lib.basename));
+          }
+        }
+      }
+
+      // The plugin header is used by the native app builder.
+      final File header = pluginIncludeDir.childFile(plugin.fileName);
+      header.copySync(includeDir.childFile(header.basename).path);
+      outputs.add(includeDir.childFile(header.basename));
+    }
+
+    final File projectDef = rootDir.childFile('project_def.prop');
+    projectDef.writeAsStringSync('''
+APPNAME = flutter_plugins
+type = sharedLib
+profile = $profile-$apiVersion
+
+USER_SRCS = ${clientWrapperDir.childFile('*.cc').path}
+USER_LFLAGS = -Wl,-rpath='\$\$ORIGIN'
+USER_LIBS = ${userLibs.join(' ')}
+''');
+
+    final File embedder =
+        engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
+    inputs.add(embedder);
+
+    final Map<String, String> variables = <String, String>{
+      'PATH': getDefaultPathVariable(),
+    };
+    final List<String> extraOptions = <String>[
+      '-l${getLibNameForFileName(embedder.basename)}',
+      '-L"${engineDir.path.toPosixPath()}"',
+      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
+      '-I"${publicDir.path.toPosixPath()}"',
+      '-L"${libDir.path.toPosixPath()}"',
+      // Forces plugin entrypoints to be exported, because unreferenced
+      // objects are not included in the output shared object by default.
+      // Another option is to use the -Wl,--[no-]whole-archive flag with
+      // -Wl,-unresolved-symbols=ignore-in-object-files.
+      for (String className in pluginClasses)
+        '-Wl,--undefined=${className}RegisterWithRegistrar',
+    ];
 
     // Create a temp directory to use as a build directory.
     // This is a workaround for the long path issue on Windows:
     // https://github.com/flutter-tizen/flutter-tizen/issues/122
-    final Directory tempDir = environment.fileSystem.systemTempDirectory
-        .childDirectory('0')
-          ..createSync(recursive: true);
+    final Directory tempDir =
+        environment.fileSystem.systemTempDirectory.createTempSync();
     projectDef.copySync(tempDir.childFile(projectDef.basename).path);
-
-    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
-    final Directory buildDir = tempDir.childDirectory(buildConfig);
 
     // Run the native build.
     final RunResult result = await _processUtils.run(<String>[
@@ -227,20 +278,28 @@ USER_LFLAGS = -Wl,-rpath='\$\$ORIGIN'
       tempDir.path,
     ], environment: variables);
     if (result.exitCode != 0) {
-      throwToolExit('Failed to build Flutter plugins:\n$result');
+      throwToolExit('Failed to build native plugins:\n$result');
     }
 
-    final File outputLib = buildDir.childFile('libflutter_plugins.so');
+    final File outputLib =
+        tempDir.childDirectory(buildConfig).childFile('libflutter_plugins.so');
     if (!outputLib.existsSync()) {
       throwToolExit(
         'Build succeeded but the file ${outputLib.path} is not found:\n'
         '${result.stdout}',
       );
     }
-
     final File outputLibCopy =
         outputLib.copySync(rootDir.childFile(outputLib.basename).path);
     outputs.add(outputLibCopy);
+
+    // Remove intermediate files.
+    for (final File lib in libDir
+        .listSync()
+        .whereType<File>()
+        .where((File f) => f.basename.endsWith('.a'))) {
+      lib.deleteSync();
+    }
 
     depfileService.writeToFile(
       Depfile(inputs, outputs),

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -56,3 +56,14 @@ Directory getEngineArtifactsDirectory(String arch, BuildMode mode) {
       .getArtifactDirectory('engine')
       .childDirectory('tizen-$arch-${mode.name}');
 }
+
+/// Removes the "lib" prefix and file extension from [name] and returns.
+String getLibNameForFileName(String name) {
+  if (name.startsWith('lib')) {
+    name = name.substring(3);
+  }
+  if (name.lastIndexOf('.') > 0) {
+    name = name.substring(0, name.lastIndexOf('.'));
+  }
+  return name;
+}

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -66,6 +66,16 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
   final String dartPluginClass;
   final String fileName;
 
+  TizenPlugin copyWith({Directory directory}) {
+    return TizenPlugin(
+      name: name,
+      directory: directory ?? this.directory,
+      pluginClass: pluginClass,
+      dartPluginClass: dartPluginClass,
+      fileName: fileName,
+    );
+  }
+
   @override
   bool isNative() => pluginClass != null;
 
@@ -80,43 +90,6 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 
   File get projectFile => directory.childFile('project_def.prop');
-
-  final RegExp _propertyFormat = RegExp(r'(\S+)\s*\+?=(.*)');
-
-  Map<String, List<String>> _properties;
-
-  List<String> getProperty(String key) {
-    if (_properties == null) {
-      if (!projectFile.existsSync()) {
-        return <String>[];
-      }
-      _properties = <String, List<String>>{};
-
-      for (final String line in projectFile.readAsLinesSync()) {
-        final Match match = _propertyFormat.firstMatch(line);
-        if (match == null) {
-          continue;
-        }
-        final String key = match.group(1);
-        final String value = match.group(2).trim();
-        _properties[key] = value.split(' ');
-      }
-    }
-    return _properties.containsKey(key) ? _properties[key] : <String>[];
-  }
-
-  List<String> getPropertyAsAbsolutePaths(String key) {
-    final List<String> paths = <String>[];
-    for (final String element in getProperty(key)) {
-      if (globals.fs.path.isAbsolute(element)) {
-        paths.add(element);
-      } else {
-        paths.add(globals.fs.path
-            .normalize(globals.fs.path.join(directory.path, element)));
-      }
-    }
-    return paths;
-  }
 }
 
 /// Any [FlutterCommand] that references [targetFile] should extend this mixin

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -127,29 +127,32 @@ class TizenSdk {
     @required String configuration,
     @required String arch,
     String compiler,
-    String predefine,
+    List<String> predefines = const <String>[],
     List<String> extraOptions = const <String>[],
-    Rootstrap rootstrap,
+    String rootstrap,
     Map<String, String> environment,
   }) async {
     assert(configuration != null);
     assert(arch != null);
 
-    return _processUtils.run(<String>[
-      tizenSdk.tizenCli.path,
-      'build-native',
-      '-C',
-      configuration,
-      '-a',
-      arch,
-      '-c',
-      compiler ?? defaultNativeCompiler,
-      if (predefine != null) ...<String>['-d', predefine],
-      if (extraOptions.isNotEmpty) ...<String>['-e', extraOptions.join(' ')],
-      if (rootstrap != null) ...<String>['-r', rootstrap.id],
-      '--',
-      workingDirectory,
-    ], environment: environment);
+    return _processUtils.run(
+      <String>[
+        tizenCli.path,
+        'build-native',
+        '-C',
+        configuration,
+        '-a',
+        arch,
+        '-c',
+        compiler ?? defaultNativeCompiler,
+        for (String macro in predefines) ...<String>['-d', macro],
+        if (extraOptions.isNotEmpty) ...<String>['-e', extraOptions.join(' ')],
+        if (rootstrap != null) ...<String>['-r', rootstrap],
+        '--',
+        workingDirectory,
+      ],
+      environment: environment,
+    );
   }
 
   Rootstrap getFlutterRootstrap({

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:meta/meta.dart';
 
@@ -48,6 +49,11 @@ class TizenSdk {
     }
     return TizenSdk._(tizenHomeDir);
   }
+
+  final ProcessUtils _processUtils = ProcessUtils(
+    logger: globals.logger,
+    processManager: globals.processManager,
+  );
 
   final Directory directory;
 
@@ -115,6 +121,36 @@ class TizenSdk {
   String get defaultNativeCompiler => 'llvm-10.0';
 
   String get defaultGccVersion => '9.2';
+
+  Future<RunResult> buildNative(
+    String workingDirectory, {
+    @required String configuration,
+    @required String arch,
+    String compiler,
+    String predefine,
+    List<String> extraOptions = const <String>[],
+    Rootstrap rootstrap,
+    Map<String, String> environment,
+  }) async {
+    assert(configuration != null);
+    assert(arch != null);
+
+    return _processUtils.run(<String>[
+      tizenSdk.tizenCli.path,
+      'build-native',
+      '-C',
+      configuration,
+      '-a',
+      arch,
+      '-c',
+      compiler ?? defaultNativeCompiler,
+      if (predefine != null) ...<String>['-d', predefine],
+      if (extraOptions.isNotEmpty) ...<String>['-e', extraOptions.join(' ')],
+      if (rootstrap != null) ...<String>['-r', rootstrap.id],
+      '--',
+      workingDirectory,
+    ], environment: environment);
+  }
 
   Rootstrap getFlutterRootstrap({
     @required String profile,

--- a/templates/plugin/cpp/project_def.prop.tmpl
+++ b/templates/plugin/cpp/project_def.prop.tmpl
@@ -2,7 +2,7 @@
 # for details.
 
 APPNAME = {{projectName}}_plugin
-type = sharedLib
+type = staticLib
 profile = common-4.0
 
 # Source files
@@ -11,22 +11,12 @@ USER_SRCS += src/*.cc
 # User defines
 USER_DEFS =
 USER_UNDEFS =
-USER_CPP_DEFS = TIZEN_DEPRECATION DEPRECATION_WARNING FLUTTER_PLUGIN_IMPL
+USER_CPP_DEFS = FLUTTER_PLUGIN_IMPL
 USER_CPP_UNDEFS =
 
-# Compiler/linker flags
+# Compiler flags
 USER_CFLAGS_MISC =
-USER_CPPFLAGS_MISC = -c -fmessage-length=0
-USER_LFLAGS =
-
-# Libraries and objects
-# To provide libraries for your plugin, you must put them in specific
-# directories that match their supporting cpu architecture type.
-# Due to compatibility issue with Tizen CLI, directory names must be armel for arm 
-# and i586 for x86.
-USER_LIB_DIRS = lib/${BUILD_ARCH}
-USER_LIBS =
-USER_OBJS =
+USER_CPPFLAGS_MISC =
 
 # User includes
 USER_INC_DIRS = inc src


### PR DESCRIPTION
Implements #193.

- Each plugin is built as a static library, and included when the final shared object (`libflutter_plugins.so`) is built.
- Because the target project type is now `staticLib`, linker-specific properties defined in `project_def.prop` do not apply. However, you can still place your libs in `lib` or arch-specific directories under it, such as `lib/arm` and `lib/armel`. The libs will be automatically included during linking even though they are not defined anywhere.
  - `lib/arm/libstatic.a` precedes `lib/libstatic.a` if they both exist.

cc @WonyoungChoi

The inputs and outputs of the `tizen_native_plugins` target include:

(Inputs)
- `flutter-tizen/lib/build_targets/plugins.dart`
- `flutter-tizen/lib/tizen_sdk.dart`
- `APP_DIR/.packages` (to create a list of plugins to build)
- `APP_DIR/tizen/tizen-manifest.xml` (to check the target profile and API version)
- `flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/**` 
- `flutter/bin/cache/artifacts/engine/tizen-common/public/**`
- `flutter/bin/cache/artifacts/engine/tizen-ARCH-MODE/libflutter_tizen_PROFILE.so`
- `PLUGIN_DIR/tizen/project_def.prop`
- `PLUGIN_DIR/tizen/inc/**`
- `PLUGIN_DIR/tizen/src/**`
- `PLUGIN_DIR/tizen/lib/**`

(Outputs)
- `BUILD_DIR/tizen_plugins/lib/*.so` (copied from `PLUGIN_DIR/tizen/lib/`)
- `BUILD_DIR/tizen_plugins/include/*.h` (copied from `PLUGIN_DIR/tizen/inc/PLUGIN_CLASS.h`)
- `BUILD_DIR/tizen_plugins/libflutter_plugins.so` (build output)
