### PR TITLE
Support attaching a debugger in VS Code

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -30,6 +30,7 @@ import 'package:process/process.dart';
 import 'tizen_builder.dart';
 import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
+import 'vscode_helper.dart';
 
 /// Tizen device implementation.
 ///
@@ -436,6 +437,9 @@ class TizenDevice extends Device {
           );
           return LaunchResult.failed();
         }
+      }
+      if (!prebuiltApplication) {
+        updateLaunchJsonFile(FlutterProject.current(), observatoryUri);
       }
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } on Exception catch (error) {

--- a/lib/vscode_helper.dart
+++ b/lib/vscode_helper.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
-const String kConfigNameAttach = 'Attach (flutter-tizen)';
+const String kConfigNameAttach = 'flutter-tizen: Attach';
 
 final RegExp _commentFormat =
     RegExp(r'(:?)(/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/|//.*\n?)');
@@ -28,14 +28,14 @@ String _removeComments(String jsonString) {
 
 void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
   Directory vscodeDir;
-  String cwd = r'${workspaceFolder}';
+  String workingDirectory = r'${workspaceFolder}';
   if (project.directory.basename == 'example') {
     final FlutterProject parentProject =
         FlutterProject.fromDirectory(project.directory.parent);
     if (parentProject.isPlugin || parentProject.isModule) {
       vscodeDir = parentProject.directory.childDirectory('.vscode')
         ..createSync(recursive: true);
-      cwd += '/example';
+      workingDirectory += '/example';
     }
   }
   vscodeDir ??= project.directory.childDirectory('.vscode')
@@ -74,7 +74,7 @@ void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
     if (config['name'] != kConfigNameAttach) {
       continue;
     }
-    config['cwd'] = cwd;
+    config['cwd'] = workingDirectory;
     config['observatoryUri'] = observatoryUri.toString();
   }
 

--- a/lib/vscode_helper.dart
+++ b/lib/vscode_helper.dart
@@ -27,20 +27,16 @@ String _removeComments(String jsonString) {
 }
 
 void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
-  Directory vscodeDir;
-  String workingDirectory = r'${workspaceFolder}';
   if (project.directory.basename == 'example') {
     final FlutterProject parentProject =
         FlutterProject.fromDirectory(project.directory.parent);
     if (parentProject.isPlugin || parentProject.isModule) {
-      vscodeDir = parentProject.directory.childDirectory('.vscode')
-        ..createSync(recursive: true);
-      workingDirectory += '/example';
+      updateLaunchJsonFile(parentProject, observatoryUri);
     }
   }
-  vscodeDir ??= project.directory.childDirectory('.vscode')
-    ..createSync(recursive: true);
 
+  final Directory vscodeDir = project.directory.childDirectory('.vscode')
+    ..createSync(recursive: true);
   final File launchJsonFile = vscodeDir.childFile('launch.json');
   String jsonString = '';
   if (launchJsonFile.existsSync()) {
@@ -74,7 +70,10 @@ void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
     if (config['name'] != kConfigNameAttach) {
       continue;
     }
-    config['cwd'] = workingDirectory;
+    config['cwd'] = r'${workspaceFolder}';
+    if (project.hasExampleApp) {
+      config['cwd'] += '/example';
+    }
     config['observatoryUri'] = observatoryUri.toString();
   }
 

--- a/lib/vscode_helper.dart
+++ b/lib/vscode_helper.dart
@@ -1,0 +1,83 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
+
+const String kConfigNameAttach = 'Attach (flutter-tizen)';
+
+final RegExp _commentFormat =
+    RegExp(r'(:?)(/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/|//.*\n?)');
+
+String _removeComments(String jsonString) {
+  return jsonString.replaceAllMapped(
+    _commentFormat,
+    (Match match) {
+      // "aaa://bbb" contains "//" but is not a comment.
+      return match.group(1) == ':' ? match.group(0) : '';
+    },
+  ).trim();
+}
+
+void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
+  Directory vscodeDir;
+  String cwd = r'${workspaceFolder}';
+  if (project.directory.basename == 'example') {
+    final FlutterProject parentProject =
+        FlutterProject.fromDirectory(project.directory.parent);
+    if (parentProject.isPlugin || parentProject.isModule) {
+      vscodeDir = parentProject.directory.childDirectory('.vscode')
+        ..createSync(recursive: true);
+      cwd += '/example';
+    }
+  }
+  vscodeDir ??= project.directory.childDirectory('.vscode')
+    ..createSync(recursive: true);
+
+  final File launchJsonFile = vscodeDir.childFile('launch.json');
+  String jsonString = '';
+  if (launchJsonFile.existsSync()) {
+    // Comments are allowed in launch.json file. Remove them to prevent
+    // decoding errors.
+    jsonString = _removeComments(launchJsonFile.readAsStringSync());
+  }
+
+  Map<dynamic, dynamic> decoded = <dynamic, dynamic>{};
+  if (jsonString.isNotEmpty) {
+    try {
+      decoded = jsonDecode(jsonString) as Map<dynamic, dynamic>;
+    } on FormatException catch (error) {
+      globals.printError('Failed to parse ${launchJsonFile.path}:\n$error');
+      return;
+    }
+  }
+  decoded['version'] ??= '0.2.0';
+  decoded['configurations'] ??= <dynamic>[];
+
+  final List<dynamic> configs = decoded['configurations'] as List<dynamic>;
+  if (!configs.any((dynamic conf) => conf['name'] == kConfigNameAttach)) {
+    configs.add(<String, String>{
+      'name': kConfigNameAttach,
+      'request': 'attach',
+      'type': 'dart',
+      'deviceId': 'flutter-tester',
+    });
+  }
+  for (final dynamic config in configs) {
+    if (config['name'] != kConfigNameAttach) {
+      continue;
+    }
+    config['cwd'] = cwd;
+    config['observatoryUri'] = observatoryUri.toString();
+  }
+
+  const JsonEncoder encoder = JsonEncoder.withIndent('    ');
+  launchJsonFile.writeAsStringSync(encoder.convert(decoded));
+}


### PR DESCRIPTION
Context: https://github.com/flutter-tizen/flutter-tizen/issues/190#issuecomment-897563757

Automatically creates or updates `.vscode/launch.json` file in the project directory to provide a debug configuration for the VS Code debugger. If the project is an example app of another plugin or module project, `.vscode/launch.json` in the parent directory is also created or updated.

Usage:
1. Run an app in either debug or profile mode using the `flutter-tizen run` command. (You can optionally specify the `--start-paused` option.)
2. Once the app is launched, open the **Run and Debug** menu in VS Code and choose **flutter-tizen: Attach (project_name)** from available configurations.
3. Press Run (▷) or F5 to attach to the running app.
4. Try breakpoints, widget inspector, etc.
