### PR TITLE
Fix OperatingSystemUtils.unzip() on Windows

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -339,19 +339,5 @@ class NativeTpk {
     // Extract the contents of the TPK to support code size analysis.
     final Directory tpkrootDir = outputDir.childDirectory('tpkroot');
     globals.os.unzip(outputTpk, tpkrootDir);
-
-    // Manually copy files if unzipping failed.
-    // Issue: https://github.com/flutter-tizen/flutter-tizen/issues/121
-    if (!tpkrootDir.existsSync()) {
-      final File runner = buildDir.childFile('runner');
-      final Directory sharedDir = tizenDir.childDirectory('shared');
-      final File tizenManifest = tizenProject.manifestFile;
-      runner.copySync(
-          tpkrootDir.childDirectory('bin').childFile(runner.basename).path);
-      copyDirectory(libDir, tpkrootDir.childDirectory('lib'));
-      copyDirectory(resDir, tpkrootDir.childDirectory('res'));
-      copyDirectory(sharedDir, tpkrootDir.childDirectory('shared'));
-      tizenManifest.copySync(tpkrootDir.childFile(tizenManifest.basename).path);
-    }
   }
 }

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/runner.dart' as runner;
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/config.dart';
@@ -48,6 +49,7 @@ import 'tizen_cache.dart';
 import 'tizen_device_discovery.dart';
 import 'tizen_doctor.dart';
 import 'tizen_emulator.dart';
+import 'tizen_osutils.dart';
 import 'tizen_pub.dart';
 import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
@@ -160,9 +162,15 @@ Future<void> main(List<String> args) async {
       EmulatorManager: () => TizenEmulatorManager(
             tizenSdk: tizenSdk,
             tizenWorkflow: tizenWorkflow,
-            processManager: globals.processManager,
-            logger: globals.logger,
             fileSystem: globals.fs,
+            logger: globals.logger,
+            processManager: globals.processManager,
+          ),
+      OperatingSystemUtils: () => TizenOperatingSystemUtils(
+            fileSystem: globals.fs,
+            logger: globals.logger,
+            platform: globals.platform,
+            processManager: globals.processManager,
           ),
       TemplateRenderer: () => const MustacheTemplateRenderer(),
       TizenSdk: () => TizenSdk.locateSdk(),

--- a/lib/tizen_osutils.dart
+++ b/lib/tizen_osutils.dart
@@ -1,0 +1,88 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:archive/archive.dart';
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:process/process.dart';
+
+/// Used for overriding [OperatingSystemUtils.unzip].
+class TizenOperatingSystemUtils implements OperatingSystemUtils {
+  TizenOperatingSystemUtils({
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
+  })  : _osUtils = OperatingSystemUtils(
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        ),
+        _platform = platform;
+
+  final OperatingSystemUtils _osUtils;
+  final Platform _platform;
+
+  @override
+  void chmod(FileSystemEntity entity, String mode) =>
+      _osUtils.chmod(entity, mode);
+
+  @override
+  Future<int> findFreePort({bool ipv6 = false}) =>
+      _osUtils.findFreePort(ipv6: ipv6);
+
+  @override
+  Stream<List<int>> gzipLevel1Stream(Stream<List<int>> stream) =>
+      _osUtils.gzipLevel1Stream(stream);
+
+  @override
+  HostPlatform get hostPlatform => _osUtils.hostPlatform;
+
+  @override
+  void makeExecutable(File file) => _osUtils.makeExecutable(file);
+
+  @override
+  File makePipe(String path) => _osUtils.makePipe(path);
+
+  @override
+  String get name => _osUtils.name;
+
+  @override
+  String get pathVarSeparator => _osUtils.pathVarSeparator;
+
+  @override
+  void unpack(File gzippedTarFile, Directory targetDirectory) =>
+      _osUtils.unpack(gzippedTarFile, targetDirectory);
+
+  /// Source: [_WindowsUtils._unpackArchive] in `os.dart`
+  @override
+  void unzip(File file, Directory targetDirectory) {
+    // Unzipping a native TPK using _osUtils.unzip() fails on Windows.
+    // Issue: https://github.com/flutter-tizen/flutter-tizen/issues/198
+    if (!_platform.isWindows) {
+      return _osUtils.unzip(file, targetDirectory);
+    }
+    final Archive archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+    for (final ArchiveFile archiveFile in archive.files) {
+      // The archive package doesn't correctly set isFile.
+      if (archiveFile.name.endsWith('/')) {
+        continue;
+      }
+      final File destFile = targetDirectory.childFile(archiveFile.name);
+      if (!destFile.parent.existsSync()) {
+        destFile.parent.createSync(recursive: true);
+      }
+      destFile.writeAsBytesSync(archiveFile.content as List<int>);
+    }
+  }
+
+  @override
+  File? which(String execName) => _osUtils.which(execName);
+
+  @override
+  List<File> whichAll(String execName) => _osUtils.whichAll(execName);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,10 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  archive:
   flutter_tools:
     path: flutter/packages/flutter_tools
-  file: # inherit from flutter_tools
+  file:
   meta:
   package_config:
   path:


### PR DESCRIPTION
Implement `TizenOperatingSystemUtils.unzip()` which doesn't use `ArchiveFile.isFile` to check whether an ArchiveFile is a file on Windows.

Fixes #198.