### PR TITLE
Allow spaces in the path to the flutter-tizen installation directory

### DIFF
--- a/doc/configure-device.md
+++ b/doc/configure-device.md
@@ -29,7 +29,7 @@
 1. Find the path to `sdb` and add to your PATH. For example, if you're using Linux or macOS and Tizen Studio has been installed to the default location, run:
 
    ```sh
-   export PATH=$HOME/tizen-studio/tools:$PATH
+   export PATH="$HOME/tizen-studio/tools:$PATH"
    ```
 
 1. Connect to the device using the device's IP address.

--- a/doc/linux-install.md
+++ b/doc/linux-install.md
@@ -2,11 +2,11 @@
 
 ## System requirements
 
-- Operating system: Linux (64-bit)
+- Operating system: Linux (x64)
 - Tools:
   - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
   - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux) (3.0 or later)
-  - `curl` `file` `git` `make` `xz-utils` `zip`
+  - `bash` `curl` `file` `git` `make` `mkdir` `rm` `unzip` `which` `xz-utils` `zip`
 
 ## Installing flutter-tizen
 
@@ -15,8 +15,6 @@
    ```sh
    git clone https://github.com/flutter-tizen/flutter-tizen.git
    ```
-
-   Note: The target path must not contain spaces.
 
 1. Add `flutter-tizen/bin` to your PATH.
 

--- a/doc/macos-install.md
+++ b/doc/macos-install.md
@@ -2,7 +2,7 @@
 
 ## System requirements
 
-- Operating system: macOS (Intel 64-bit)
+- Operating system: macOS (x64)
 - Tools:
   - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
   - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/macos) (3.0 or later)
@@ -14,8 +14,6 @@
    ```sh
    git clone https://github.com/flutter-tizen/flutter-tizen.git
    ```
-
-   Note: The target path must not contain spaces.
 
 1. Add `flutter-tizen/bin` to your PATH.
 

--- a/doc/windows-install.md
+++ b/doc/windows-install.md
@@ -2,7 +2,7 @@
 
 ## System requirements
 
-- Operating system: Windows 7 SP1 or later (64-bit)
+- Operating system: Windows 10 or later (x64)
 - Tools:
   - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
   - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/windows) (3.0 or later)
@@ -15,8 +15,6 @@
    ```powershell
    git clone https://github.com/flutter-tizen/flutter-tizen.git
    ```
-
-   Note: The target path must not contain spaces.
 
 1. Add `flutter-tizen\bin` to your PATH.
 

--- a/embedding/cpp/.gitignore
+++ b/embedding/cpp/.gitignore
@@ -1,0 +1,5 @@
+.cproject
+.sign
+crash-info/
+Debug/
+Release/

--- a/embedding/cpp/project_def.prop
+++ b/embedding/cpp/project_def.prop
@@ -1,0 +1,13 @@
+# Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+APPNAME = embedding_cpp
+type = staticLib
+profile = common-4.0
+
+USER_INC_DIRS = include \
+    ../../flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include \
+    ../../flutter/bin/cache/artifacts/engine/tizen-common/public
+USER_SRCS = *.cc \
+    ../../flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/*.cc

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -288,15 +288,15 @@ class NativeTpk {
     final List<String> extraOptions = <String>[
       '-Wl,-unresolved-symbols=ignore-in-shared-libs',
       '-lflutter_tizen_${buildInfo.deviceProfile}',
-      '-L"${libDir.path.toPosixPath()}"',
-      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
-      '-I"${publicDir.path.toPosixPath()}"',
-      '-I"${embeddingDir.childDirectory('include').path.toPosixPath()}"',
+      '-L${libDir.path.toPosixPath()}',
+      '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
+      '-I${publicDir.path.toPosixPath()}',
+      '-I${embeddingDir.childDirectory('include').path.toPosixPath()}',
       '-Wl,--whole-archive',
       embeddingLib.path.toPosixPath(),
       '-Wl,--no-whole-archive',
       for (String lib in embeddingDependencies) '-l$lib',
-      '-I"${pluginsDir.childDirectory('include').path.toPosixPath()}"',
+      '-I${pluginsDir.childDirectory('include').path.toPosixPath()}',
       if (pluginsLib.existsSync()) '-lflutter_plugins',
     ];
 
@@ -330,9 +330,6 @@ class NativeTpk {
         'targets': <String>['b1'],
       },
       sign: securityProfile,
-      environment: <String, String>{
-        'PATH': getDefaultPathVariable(),
-      },
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to build native application:\n$result');

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -286,15 +286,17 @@ class NativeTpk {
     }
 
     final List<String> extraOptions = <String>[
-      '-Wl,-unresolved-symbols=ignore-in-shared-libs',
+      // The extra quotation marks ("") for linker flags are required due to
+      // https://github.com/flutter-tizen/flutter-tizen/issues/218.
+      '"-Wl,--unresolved-symbols=ignore-in-shared-libs"',
       '-lflutter_tizen_${buildInfo.deviceProfile}',
       '-L${libDir.path.toPosixPath()}',
       '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
       '-I${publicDir.path.toPosixPath()}',
       '-I${embeddingDir.childDirectory('include').path.toPosixPath()}',
-      '-Wl,--whole-archive',
+      '"-Wl,--whole-archive"',
       embeddingLib.path.toPosixPath(),
-      '-Wl,--no-whole-archive',
+      '"-Wl,--no-whole-archive"',
       for (String lib in embeddingDependencies) '-l$lib',
       '-I${pluginsDir.childDirectory('include').path.toPosixPath()}',
       if (pluginsLib.existsSync()) '-lflutter_plugins',

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -185,6 +185,7 @@ class NativeTpk {
     );
 
     final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
     final Directory engineDir =
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
@@ -226,30 +227,6 @@ class NativeTpk {
         .childDirectory('embedding')
         .childDirectory('cpp');
 
-    final List<String> userIncludes = <String>[
-      embeddingDir.childDirectory('include').path,
-      pluginsDir.childDirectory('include').path,
-    ];
-    final List<String> userSources = <String>[
-      clientWrapperDir.childFile('*.cc').path,
-      embeddingDir.childFile('*.cc').path,
-    ];
-
-    final Map<String, String> variables = <String, String>{
-      'PATH': getDefaultPathVariable(),
-      'USER_SRCS': userSources.map((String f) => f.toPosixPath()).join(' '),
-    };
-    final List<String> extraOptions = <String>[
-      '-lflutter_tizen_${buildInfo.deviceProfile}',
-      '-L"${libDir.path.toPosixPath()}"',
-      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
-      '-I"${publicDir.path.toPosixPath()}"',
-      ...userIncludes.map((String f) => '-I"${f.toPosixPath()}"'),
-      if (pluginsLib.existsSync()) '-lflutter_plugins',
-      '-D${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
-      '-Wl,-unresolved-symbols=ignore-in-shared-libs',
-    ];
-
     assert(tizenSdk != null);
     final TizenManifest tizenManifest =
         TizenManifest.parseFromXml(tizenProject.manifestFile);
@@ -259,7 +236,28 @@ class NativeTpk {
       arch: buildInfo.targetArch,
     );
 
-    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    // We need to build the C++ embedding separately because the absolute path
+    // to the embedding directory may contain spaces.
+    RunResult result = await tizenSdk.buildNative(
+      embeddingDir.path,
+      configuration: buildConfig,
+      arch: getTizenCliArch(buildInfo.targetArch),
+      extraOptions: <String>['-fPIC'],
+      rootstrap: rootstrap.id,
+    );
+    final File embeddingLib = embeddingDir
+        .childDirectory(buildConfig)
+        .childFile('libembedding_cpp.a');
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to build ${embeddingLib.basename}:\n$result');
+    }
+    const List<String> embeddingDependencies = <String>[
+      'appcore-agent',
+      'capi-appfw-app-common',
+      'capi-appfw-application',
+      'dlog',
+    ];
+
     final Directory buildDir = projectDir.childDirectory(buildConfig);
     if (buildDir.existsSync()) {
       buildDir.deleteSync(recursive: true);
@@ -287,8 +285,23 @@ class NativeTpk {
       );
     }
 
+    final List<String> extraOptions = <String>[
+      '-Wl,-unresolved-symbols=ignore-in-shared-libs',
+      '-lflutter_tizen_${buildInfo.deviceProfile}',
+      '-L"${libDir.path.toPosixPath()}"',
+      '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
+      '-I"${publicDir.path.toPosixPath()}"',
+      '-I"${embeddingDir.childDirectory('include').path.toPosixPath()}"',
+      '-Wl,--whole-archive',
+      embeddingLib.path.toPosixPath(),
+      '-Wl,--no-whole-archive',
+      for (String lib in embeddingDependencies) '-l$lib',
+      '-I"${pluginsDir.childDirectory('include').path.toPosixPath()}"',
+      if (pluginsLib.existsSync()) '-lflutter_plugins',
+    ];
+
     // Build the app.
-    final RunResult result = await tizenSdk.buildApp(
+    result = await tizenSdk.buildApp(
       tizenDir.path,
       build: <String, dynamic>{
         'name': 'b1',
@@ -317,7 +330,9 @@ class NativeTpk {
         'targets': <String>['b1'],
       },
       sign: securityProfile,
-      environment: variables,
+      environment: <String, String>{
+        'PATH': getDefaultPathVariable(),
+      },
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to build native application:\n$result');

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -153,13 +153,10 @@ class NativePlugins extends Target {
         ],
         extraOptions: <String>[
           '-fPIC',
-          '-I"${clientWrapperDir.childDirectory('include').path.toPosixPath()}"',
-          '-I"${publicDir.path.toPosixPath()}"',
+          '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
+          '-I${publicDir.path.toPosixPath()}',
         ],
         rootstrap: rootstrap.id,
-        environment: <String, String>{
-          'PATH': getDefaultPathVariable(),
-        },
       );
       if (result.exitCode != 0) {
         throwToolExit('Failed to build ${plugin.name} plugin:\n$result');
@@ -266,9 +263,9 @@ USER_LIBS = ${userLibs.join(' ')}
       arch: getTizenCliArch(buildInfo.targetArch),
       extraOptions: <String>[
         '-l${getLibNameForFileName(embedder.basename)}',
-        '-L"${engineDir.path.toPosixPath()}"',
-        '-I"${publicDir.path.toPosixPath()}"',
-        '-L"${libDir.path.toPosixPath()}"',
+        '-L${engineDir.path.toPosixPath()}',
+        '-I${publicDir.path.toPosixPath()}',
+        '-L${libDir.path.toPosixPath()}',
         // Forces plugin entrypoints to be exported, because unreferenced
         // objects are not included in the output shared object by default.
         // Another option is to use the -Wl,--[no-]whole-archive flag.
@@ -276,9 +273,6 @@ USER_LIBS = ${userLibs.join(' ')}
           '-Wl,--undefined=${className}RegisterWithRegistrar',
       ],
       rootstrap: rootstrap.id,
-      environment: <String, String>{
-        'PATH': getDefaultPathVariable(),
-      },
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to build native plugins:\n$result');

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -4,49 +4,27 @@
 
 // @dart = 2.8
 
-import 'dart:io';
-
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
-import '../tizen_sdk.dart';
-
 extension PathUtils on String {
-  /// On non-Windows, returns the path string unchanged.
+  /// On non-Windows, encloses the string with [encloseWith].
   ///
   /// On Windows, converts Windows-style path (e.g. 'C:\x\y') into POSIX path
-  /// ('/c/x/y') and returns.
-  String toPosixPath() {
+  /// ('/c/x/y') and encloses with [encloseWith].
+  String toPosixPath([String encloseWith = '"']) {
     String path = this;
-    if (Platform.isWindows) {
+    if (globals.platform.isWindows) {
       path = path.replaceAll(r'\', '/');
       if (path.startsWith(':', 1)) {
         path = '/${path[0].toLowerCase()}${path.substring(2)}';
       }
     }
-    return path;
+    return encloseWith + path + encloseWith;
   }
-}
-
-/// On non-Windows, returns the PATH environment variable.
-///
-/// On Windows, appends the msys2 executables directory to PATH and returns.
-String getDefaultPathVariable() {
-  final Map<String, String> variables = globals.platform.environment;
-  String path = variables.containsKey('PATH') ? variables['PATH'] : '';
-  if (Platform.isWindows) {
-    assert(tizenSdk != null);
-    final String msysUsrBin = tizenSdk.toolsDirectory
-        .childDirectory('msys2')
-        .childDirectory('usr')
-        .childDirectory('bin')
-        .path;
-    path += ';$msysUsrBin';
-  }
-  return path;
 }
 
 /// See: [CachedArtifacts._getEngineArtifactsPath]

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -122,6 +122,21 @@ class TizenSdk {
 
   String get defaultGccVersion => '9.2';
 
+  /// On non-Windows, returns the PATH environment variable.
+  ///
+  /// On Windows, appends the msys2 executables directory to PATH and returns.
+  String _getPathVariable() {
+    String path = globals.platform.environment['PATH'] ?? '';
+    if (globals.platform.isWindows) {
+      final Directory msysUsrBin = toolsDirectory
+          .childDirectory('msys2')
+          .childDirectory('usr')
+          .childDirectory('bin');
+      path += ';${msysUsrBin.path}';
+    }
+    return path;
+  }
+
   Future<RunResult> buildApp(
     String workingDirectory, {
     Map<String, dynamic> build = const <String, dynamic>{},
@@ -129,7 +144,6 @@ class TizenSdk {
     String output,
     Map<String, dynamic> package = const <String, dynamic>{},
     String sign,
-    Map<String, String> environment,
   }) {
     String stringify(dynamic argument) {
       if (argument is String) {
@@ -163,7 +177,9 @@ class TizenSdk {
         '--',
         workingDirectory,
       ],
-      environment: environment,
+      environment: <String, String>{
+        'PATH': _getPathVariable(),
+      },
     );
   }
 
@@ -175,7 +191,6 @@ class TizenSdk {
     List<String> predefines = const <String>[],
     List<String> extraOptions = const <String>[],
     String rootstrap,
-    Map<String, String> environment,
   }) async {
     assert(configuration != null);
     assert(arch != null);
@@ -196,7 +211,9 @@ class TizenSdk {
         '--',
         workingDirectory,
       ],
-      environment: environment,
+      environment: <String, String>{
+        'PATH': _getPathVariable(),
+      },
     );
   }
 


### PR DESCRIPTION
`project_def.prop` files accept `USER_SRCS` as a space-separated list of source paths. As a result, compiling the C++ embedding or cpp_client_wrapper fails if the path to flutter-tizen root directory contains any space character. This change works around the limitation by using only relative paths in `project_def.prop` files.

Fully fixes https://github.com/flutter-tizen/plugins/issues/104.

Related PR: https://github.com/flutter-tizen/flutter-tizen/pull/120

p.s. I also left a question in https://github.sec.samsung.net/RS-TizenStudio/home/issues/201.

Also fixes https://github.com/flutter-tizen/flutter-tizen/issues/218.