### PR TITLE
Set a proper version for the generated rootstrap definition

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -244,7 +244,7 @@ class TizenSdk {
     pluginsDir.childFile('flutter-rootstrap.xml').writeAsStringSync('''
 <?xml version="1.0"?>
 <extension point="rootstrapDefinition">
-  <rootstrap id="$flutterRootstrapId" name="flutter" version="flutter" architecture="$buildArch" path="${rootstrap.rootDirectory.path}" supportToolchainType="tizen.core">
+  <rootstrap id="$flutterRootstrapId" name="Flutter" version="Tizen $apiVersion" architecture="$buildArch" path="${rootstrap.rootDirectory.path}" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="${configFile.path}"/>
     <property key="LINKER_MISCELLANEOUS_OPTION" value="${linkerFlags.join(' ')}"/>
     <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17"/>


### PR DESCRIPTION
Contributes to #143.

The version attribute of the generated rootstrap definition is used as part of the output TPK name when building a multi app. This change lets the attribute have a meaningful value.

```sh
# Before:
com.example.multi_app_flutter-null_armel_Debug.tpk

# After:
com.example.multi_app_Tizen-4.0_armel_Debug.tpk
```