### PR TITLE
Make Dart entrypoint setters public

### DIFF
--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -40,10 +40,14 @@ class FlutterApp : public flutter::PluginRegistry {
 
   virtual int Run(int argc, char **argv);
 
-  bool IsRunning() { return handle_ != nullptr; }
-
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string &plugin_name) override;
+
+  bool IsRunning() { return handle_ != nullptr; }
+
+  void SetDartEntrypoint(const std::string &entrypoint) {
+    dart_entrypoint_ = entrypoint;
+  }
 
  protected:
   void ParseEngineArgs();

--- a/embedding/csharp/FlutterApplication.cs
+++ b/embedding/csharp/FlutterApplication.cs
@@ -59,7 +59,7 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// The optional entrypoint in the Dart project. If the value is empty, defaults to main().
         /// </summary>
-        protected string DartEntrypoint { get; set; } = string.Empty;
+        public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
         /// The list of Dart entrypoint arguments.

--- a/embedding/csharp/FlutterServiceApplication.cs
+++ b/embedding/csharp/FlutterServiceApplication.cs
@@ -24,7 +24,7 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// The optional entrypoint in the Dart project. If the value is empty, defaults to main().
         /// </summary>
-        protected string DartEntrypoint { get; set; } = string.Empty;
+        public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
         /// The list of Dart entrypoint arguments.


### PR DESCRIPTION
I think we can now provide stable APIs for setting Dart entry points.

The entry points can be set before the `Run()` method is called on app instances.

Example (C++):
```cpp
App app;
app.SetDartEntrypoint("anotherMain");
return app.Run(argc, argv);
```

Example (C#):
```csharp
var app = new App();
app.DartEntrypoint = "anotherMain";
app.Run(args);
```

Contributes to #143.

cc @pkosko