### PR TITLE
Minor refactoring for NativeTpk.build()

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -151,9 +151,6 @@ class NativeTpk {
 
   final TizenBuildInfo buildInfo;
 
-  final ProcessUtils _processUtils = ProcessUtils(
-      logger: globals.logger, processManager: globals.processManager);
-
   Future<void> build(Environment environment) async {
     final FlutterProject project =
         FlutterProject.fromDirectory(environment.projectDir);
@@ -326,15 +323,10 @@ class NativeTpk {
       throwToolExit('Failed to build native application:\n$result');
     }
 
-    // TODO(pkosko): find better way to determine file name
-    File outputTpk;
-    for (final File file in buildDir.listSync().whereType<File>()) {
-      if (file.basename.endsWith('.tpk')) {
-        outputTpk = file;
-        break;
-      }
-    }
-    if (outputTpk == null || !outputTpk.existsSync()) {
+    final String buildArch = getTizenBuildArch(buildInfo.targetArch);
+    final File outputTpk = buildDir.childFile(
+        '${tizenManifest.packageId}_Tizen-${tizenManifest.apiVersion}_${buildArch}_$buildConfig.tpk');
+    if (!outputTpk.existsSync()) {
       throwToolExit('Build succeeded but the expected TPK not found:\n$result');
     }
     // Copy and rename the output TPK.

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -300,25 +300,17 @@ class NativeTpk {
         'name: "b1", methods: ["m1"], targets: ["${targets.join('","')}"]';
     final String package = 'name: "${tizenManifest.packageId}", targets:["b1"]';
 
-    final List<String> buildAppCommand = <String>[
-      tizenSdk.tizenCli.path,
-      'build-app',
-      '-m',
-      method,
-      '-b',
-      build,
-      '-p',
-      package,
-      if (securityProfile != null) ...<String>['-s', securityProfile],
-      '-o',
-      buildDir.path,
-      '--',
+    final RunResult result = await tizenSdk.buildApp(
       tizenDir.path,
-    ];
-    final RunResult result =
-        await _processUtils.run(buildAppCommand, environment: variables);
+      build: build,
+      method: method,
+      output: buildDir.path,
+      package: package,
+      sign: securityProfile,
+      environment: variables,
+    );
     if (result.exitCode != 0) {
-      throwToolExit('Failed to generate TPK:\n$result');
+      throwToolExit('Failed to build native application:\n$result');
     }
 
     // TODO(pkosko): find better way to determine file name

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -155,6 +155,24 @@ class TizenSdk {
     );
   }
 
+  Future<RunResult> package(
+    String workingDirectory, {
+    String type = 'tpk',
+    String reference,
+    String sign,
+  }) {
+    return _processUtils.run(<String>[
+      tizenCli.path,
+      'package',
+      '-t',
+      type,
+      if (sign != null) ...<String>['-s', sign],
+      if (reference != null) ...<String>['-r', reference],
+      '--',
+      workingDirectory,
+    ]);
+  }
+
   Rootstrap getFlutterRootstrap({
     @required String profile,
     @required String apiVersion,

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -122,6 +122,36 @@ class TizenSdk {
 
   String get defaultGccVersion => '9.2';
 
+  Future<RunResult> buildApp(
+    String workingDirectory, {
+    @required String build,
+    String method,
+    // Map<String, String> method = const <String, String>{},
+    @required String output,
+    @required String package,
+    String sign,
+    Map<String, String> environment,
+  }) {
+    return _processUtils.run(
+      <String>[
+        tizenCli.path,
+        'build-app',
+        '-m',
+        method,
+        '-b',
+        build,
+        '-p',
+        package,
+        if (sign != null) ...<String>['-s', sign],
+        '-o',
+        output,
+        '--',
+        workingDirectory,
+      ],
+      environment: environment,
+    );
+  }
+
   Future<RunResult> buildNative(
     String workingDirectory, {
     @required String configuration,


### PR DESCRIPTION
- Create `TizenSdk.package()` and `TizenSdk.buildApp()`.
- The native TPK builder throws an error if no security profile could be found. I tried replacing `tizen build-app` with `tizen build-native` and `tizen package -r [service_tpk] -- [ui_tpk]` but it wasn't successful (the `package` command removes certificates in the output TPK).
- Improve the mechanism for locating `outputTpk`.

cc @pkosko