### PR TITLE
Fix the output TPK resolution mechanism

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -323,10 +323,14 @@ class NativeTpk {
       throwToolExit('Failed to build native application:\n$result');
     }
 
-    final String buildArch = getTizenBuildArch(buildInfo.targetArch);
-    final File outputTpk = buildDir.childFile(
-        '${tizenManifest.packageId}_Tizen-${tizenManifest.apiVersion}_${buildArch}_$buildConfig.tpk');
-    if (!outputTpk.existsSync()) {
+    File outputTpk;
+    for (final File file in buildDir.listSync().whereType<File>()) {
+      if (file.basename.endsWith('.tpk')) {
+        outputTpk = file;
+        break;
+      }
+    }
+    if (outputTpk == null) {
       throwToolExit('Build succeeded but the expected TPK not found:\n$result');
     }
     // Copy and rename the output TPK.


### PR DESCRIPTION
Currently building **native apps** in **release mode** fails because output TPKs generated by the Tizen builder do not have the build mode suffix is their names:

- Debug mode: `[PACKAGE_ID]_[ROOTSTRAP_VERSION]_[BUILD_ARCH]_Debug.tpk`
- Release mode: `[PACKAGE_ID]_[ROOTSTRAP_VERSION]_[BUILD_ARCH].tpk` 

This PR partially reverts https://github.com/flutter-tizen/flutter-tizen/pull/213.