### PR TITLE
Enable the simultaneous use of Dart plugins and custom Dart entrypoints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  analyzer:
   archive:
   flutter_tools:
     path: flutter/packages/flutter_tools


### PR DESCRIPTION
Find entry points functions from the main dart file and inject to the generated main file.

Resolves the limitation mentioned in https://github.com/flutter-tizen/flutter-tizen/pull/171 ("The use of custom entrypoints may break ...").

Note that this change doesn't take account of all possible uses of the `vm:entry-point` pragma described in https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md#syntax. Only functions are allowed and the second parameter of `@pragma` is not honored.

@jkpu @pkosko

See also: The AST analyzer (https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/doc/tutorial/ast.md)