### PR TITLE
Check the app termination result correctly

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -475,7 +475,10 @@ class TizenDevice extends Device {
           ? <String>['shell', '0', 'kill', app.applicationId]
           : <String>['shell', 'app_launcher', '-k', app.applicationId];
       final String stdout = (await runSdbAsync(command)).stdout;
-      return stdout.contains('Kill appId') || stdout.contains('is Terminated');
+      return stdout.contains('Kill appId') ||
+          stdout.contains('Terminate appId') ||
+          stdout.contains('is Terminated') ||
+          stdout.contains('is already Terminated');
     } on Exception catch (error) {
       _logger.printError(error.toString());
       return false;


### PR DESCRIPTION
Added two conditions.

- `Terminate appId`: Just for debugging purpose. Not normally expected.
- `is already Terminated`: When running integration tests on TV emulator, a process exists earlier than running the kill command (I'm not sure why), resulting in the following `Failed to stop app` error.

```
All tests passed.
I/ConsoleMessage(13931): flutter: 00:03 +6: (tearDownAll)
I/ConsoleMessage(13931): flutter: 00:03 +7: All tests passed!
Failed to stop app
E/ConsoleMessage(13931): appcore: disconnect wl2_display
```

I also considered changing the kill command `app_launcher -k` to `app_launcher -t` but didn't apply, to be always safe.
