### PR TITLE
Update the multi app template

### DIFF
--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -53,11 +53,14 @@ class TizenCreateCommand extends CreateCommand {
       return super.runCommand();
     }
 
-    // Check if the main.dart file exists before running super.runCommand().
+    // Check if main.dart/pubspec.yaml exists before running super.runCommand().
     final File mainFile =
         projectDir.childDirectory('lib').childFile('main.dart');
+    final File pubspecFile = projectDir.childFile('pubspec.yaml');
     final bool overwriteMainFile =
         boolArg('overwrite') || !mainFile.existsSync();
+    final bool overwritePubspecFile =
+        boolArg('overwrite') || !pubspecFile.existsSync();
 
     final FlutterCommandResult result = await super.runCommand();
     if (result != FlutterCommandResult.success()) {
@@ -96,10 +99,16 @@ class TizenCreateCommand extends CreateCommand {
     if (stringArg('app-type') == 'multi') {
       final File createdMainFile =
           projectDir.childDirectory('tizen').childFile('main.dart');
+      final File createdPubspecFile =
+          projectDir.childDirectory('tizen').childFile('pubspec.yaml');
       if (overwriteMainFile) {
         createdMainFile.copySync(mainFile.path);
       }
+      if (overwritePubspecFile) {
+        createdPubspecFile.copySync(pubspecFile.path);
+      }
       createdMainFile.deleteSync();
+      createdPubspecFile.deleteSync();
     }
 
     return result;

--- a/templates/multi-app/cpp/main.dart.tmpl
+++ b/templates/multi-app/cpp/main.dart.tmpl
@@ -1,152 +1,132 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:messageport_tizen/messageport_tizen.dart';
+import 'package:tizen_app_control/app_control.dart';
+import 'package:tizen_app_control/app_manager.dart';
 
-class ServiceControl {
-  static int id = 0;
-  static const String serviceId = "{{androidIdentifier}}_service";
-  static const MethodChannel channel =
-      MethodChannel('tizen/internal/app_control_method');
+const String _kAppId = '{{androidIdentifier}}';
+const String _kServiceAppId = '{{androidIdentifier}}_service';
+const String _kPortName = 'port_name';
 
-  static Future<void> setupAppControl() async {
-    id = await channel.invokeMethod<int>('create') as int;
-    final args = <String, dynamic>{'id': id, 'appId': serviceId};
-    return channel.invokeMethod<void>('setAppControlData', args);
-  }
-
-  static void launchService() async {
-    await setupAppControl();
-    await channel
-        .invokeMethod<bool>('sendLaunchRequest', <String, dynamic>{'id': id});
-  }
-
-  static void stopService() async {
-    await setupAppControl();
-    await channel.invokeMethod<bool>(
-        'sendTerminateRequest', <String, dynamic>{'id': id});
-  }
+// UI and service applications share the same Dart code but have different
+// entry points. This is the main entry point for your UI application.
+void main() {
+  runApp(const MyApp());
 }
 
-Future<void> main() async {
-  runApp(MyApp());
-
-  return ServiceControl.launchService();
-}
-
-// Below code is an example of working service application, modify it with own logic.
+// This is the main entry point for your service application.
+// @pragma('vm:entry-point') prevents this function from being optimized out
+// (tree-shaken) during AOT compilation.
 @pragma('vm:entry-point')
-Future<void> serviceMain() async {
-  int counter = 0;
-  while (true) {
-    print('Counter: $counter');
-    await Future.delayed(Duration(seconds: 1));
-    counter += 1;
-  }
+void serviceMain() {
+  // This call is necessary for setting up internal platform channels.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // UI and service applications are run as separate processes and do not
+  // share memory. They can communicate with each other in various ways,
+  // such as inter-process communication through message ports, networking,
+  // or even simple file I/O (applications in a package share the same data
+  // directory).
+  // In this example, we use Tizen's Message Port API (messageport_tizen) to
+  // send serialized messages from the service application to the UI
+  // application. Modify this with your own logic.
+  TizenMessagePort.connectToRemotePort(_kAppId, _kPortName)
+      .then((RemotePort remotePort) async {
+    while (true) {
+      if (await remotePort.check()) {
+        await remotePort.send('text message');
+      } else {
+        break;
+      }
+      await Future<void>.delayed(const Duration(seconds: 1));
+    }
+  }).whenComplete(() async {
+    // Close the application if the connection has failed or ended.
+    await SystemNavigator.pop();
+  });
 }
 
-class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // Try running your application with "flutter run". You'll see the
-        // application has a blue toolbar. Then, without quitting the app, try
-        // changing the primarySwatch below to Colors.green and then invoke
-        // "hot reload" (press "r" in the console where you ran "flutter run",
-        // or simply save your changes to "hot reload" in a Flutter IDE).
-        // Notice that the counter didn't reset back to zero; the application
-        // is not restarted.
-        primarySwatch: Colors.blue,
-      ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  _MyAppState createState() => _MyAppState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _MyAppState extends State<MyApp> {
+  LocalPort? _localPort;
+  int _messagesCount = 0;
+  bool _isServiceStarted = false;
 
-  void _incrementCounter() {
+  @override
+  void initState() {
+    super.initState();
+
+    // The UI application receives messages from the service application
+    // through this local message port.
+    TizenMessagePort.createLocalPort(_kPortName).then((LocalPort value) {
+      _localPort = value;
+      _localPort?.register((dynamic message, [RemotePort? remotePort]) {
+        setState(() {
+          _messagesCount++;
+        });
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    _localPort?.unregister();
+  }
+
+  Future<void> _launchService() async {
+    await AppControl(appId: _kServiceAppId).sendLaunchRequest();
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _isServiceStarted = AppManager.isRunning(_kServiceAppId);
+    });
+  }
+
+  void _terminateService() {
+    AppManager.terminateBackgroundApplication(_kServiceAppId);
+    setState(() {
+      _isServiceStarted = AppManager.isRunning(_kServiceAppId);
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Tizen Multi App Demo'),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (_isServiceStarted)
+                ElevatedButton(
+                  onPressed: _terminateService,
+                  style: ElevatedButton.styleFrom(
+                    primary: Colors.redAccent,
+                  ),
+                  child: const Text('Terminate service'),
+                )
+              else
+                ElevatedButton(
+                  onPressed: _launchService,
+                  child: const Text('Launch service'),
+                ),
+              const SizedBox(height: 10),
+              Text('Received messages: $_messagesCount'),
+            ],
+          ),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/templates/multi-app/cpp/pubspec.yaml.tmpl
+++ b/templates/multi-app/cpp/pubspec.yaml.tmpl
@@ -1,0 +1,73 @@
+name: {{projectName}}
+description: {{description}}
+
+# The following line prevents the package from being accidentally published to
+# pub.dev using `pub publish`. This is preferred for private packages.
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+# The following defines the version and build number for your application.
+# A version number is three numbers separated by dots, like 1.2.43
+# followed by an optional build number separated by a +.
+# Both the version and the builder number may be overridden in flutter
+# build by specifying --build-name and --build-number, respectively.
+# In Android, build-name is used as versionName while build-number used as versionCode.
+# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
+# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
+# Read more about iOS versioning at
+# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+version: 1.0.0+1
+
+environment:
+  sdk: {{dartSdkVersionBounds}}
+
+dependencies:
+  flutter:
+    sdk: flutter
+  messageport_tizen: ^0.1.0
+  tizen_app_control: ^0.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter.
+flutter:
+
+  # The following line ensures that the Material Icons font is
+  # included with your application, so that you can use the icons in
+  # the material Icons class.
+  uses-material-design: true
+
+  # To add assets to your application, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+  #   - images/a_dot_ham.jpeg
+
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/assets-and-images/#resolution-aware.
+
+  # For details regarding adding assets from package dependencies, see
+  # https://flutter.dev/assets-and-images/#from-packages
+
+  # To add custom fonts to your application, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts from package dependencies,
+  # see https://flutter.dev/custom-fonts/#from-packages

--- a/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
@@ -7,6 +7,7 @@
     </ui-application>
     <privileges>
         <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+        <privilege>http://tizen.org/privilege/appmanager.kill.bgapp</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/template_manifest.json
+++ b/templates/template_manifest.json
@@ -17,6 +17,7 @@
         "templates/plugin/tizen.tmpl/src/log.h.tmpl",
         "templates/plugin/tizen.tmpl/src/projectName_plugin.cc.tmpl",
         "templates/app/tizen.tmpl/main.dart.tmpl",
+        "templates/app/tizen.tmpl/pubspec.yaml.tmpl",
         "templates/app/tizen.tmpl/ui/.gitignore",
         "templates/app/tizen.tmpl/ui/App.cs",
         "templates/app/tizen.tmpl/ui/Runner.csproj",


### PR DESCRIPTION
Replace the multi app template with a simplified version of [`tizen_app_control`'s example app](https://github.com/flutter-tizen/plugins/blob/master/packages/tizen_app_control/example/lib/main.dart).

`tizen_app_control` should be published first to be able to use this template. You can modify `pubspec.yaml` as follows for testing until then.

```yaml
tizen_app_control:
  git:
    url: https://github.com/flutter-tizen/plugins
    path: packages/tizen_app_control
```

Closes https://github.com/flutter-tizen/flutter-tizen/issues/210.