### PR TITLE
Migrate more files to null safety

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -18,7 +18,7 @@ import 'package:flutter_tools/src/build_system/targets/assets.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/icon_tree_shaker.dart';
 
-import '../tizen_builder.dart';
+import '../tizen_build_info.dart';
 import 'plugins.dart';
 
 /// Prepares the pre-built Flutter bundle.

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
-import '../tizen_builder.dart';
+import '../tizen_build_info.dart';
 import '../tizen_project.dart';
 import '../tizen_sdk.dart';
 import '../tizen_tpk.dart';

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -15,7 +15,7 @@ import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/source.dart';
 import 'package:flutter_tools/src/project.dart';
 
-import '../tizen_builder.dart';
+import '../tizen_build_info.dart';
 import '../tizen_plugins.dart';
 import '../tizen_project.dart';
 import '../tizen_sdk.dart';

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -124,7 +122,7 @@ class NativePlugins extends Target {
         TizenManifest.parseFromXml(tizenProject.manifestFile);
     final String profile = tizenManifest.profile;
     final String apiVersion = tizenManifest.apiVersion;
-    final Rootstrap rootstrap = tizenSdk.getFlutterRootstrap(
+    final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
       profile: profile,
       apiVersion: apiVersion,
       arch: buildInfo.targetArch,
@@ -144,7 +142,7 @@ class NativePlugins extends Target {
       _ensureStaticLibType(pluginCopy, environment.logger);
       inputs.add(plugin.projectFile);
 
-      final RunResult result = await tizenSdk.buildNative(
+      final RunResult result = await tizenSdk!.buildNative(
         pluginCopy.directory.path,
         configuration: buildConfig,
         arch: getTizenCliArch(buildInfo.targetArch),
@@ -162,8 +160,10 @@ class NativePlugins extends Target {
         throwToolExit('Failed to build ${plugin.name} plugin:\n$result');
       }
 
+      assert(plugin.fileName != null);
+      assert(plugin.pluginClass != null);
       final String libName =
-          getLibNameForFileName(plugin.fileName.toLowerCase());
+          getLibNameForFileName(plugin.fileName!.toLowerCase());
       final File libFile = pluginCopy.directory
           .childDirectory(buildConfig)
           .childFile('lib$libName.a');
@@ -175,7 +175,7 @@ class NativePlugins extends Target {
       }
       libFile.copySync(libDir.childFile(libFile.basename).path);
       userLibs.add(libName);
-      pluginClasses.add(plugin.pluginClass);
+      pluginClasses.add(plugin.pluginClass!);
 
       final Directory pluginIncludeDir = plugin.directory.childDirectory('inc');
       if (pluginIncludeDir.existsSync()) {
@@ -221,7 +221,7 @@ class NativePlugins extends Target {
       }
 
       // The plugin header is used by the native app builder.
-      final File header = pluginIncludeDir.childFile(plugin.fileName);
+      final File header = pluginIncludeDir.childFile(plugin.fileName!);
       header.copySync(includeDir.childFile(header.basename).path);
       outputs.add(includeDir.childFile(header.basename));
     }
@@ -257,7 +257,7 @@ USER_LIBS = ${userLibs.join(' ')}
     copyDirectory(rootDir, tempDir);
 
     // Run the native build.
-    final RunResult result = await tizenSdk.buildNative(
+    final RunResult result = await tizenSdk!.buildNative(
       tempDir.path,
       configuration: buildConfig,
       arch: getTizenCliArch(buildInfo.targetArch),

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 extension PathUtils on String {
   /// On non-Windows, encloses the string with [encloseWith].
@@ -29,7 +27,6 @@ extension PathUtils on String {
 
 /// See: [CachedArtifacts._getEngineArtifactsPath]
 Directory getEngineArtifactsDirectory(String arch, BuildMode mode) {
-  assert(mode != null, 'Need to specify a build mode.');
   return globals.cache
       .getArtifactDirectory('engine')
       .childDirectory('tizen-$arch-${mode.name}');

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 
+import '../tizen_build_info.dart';
 import '../tizen_builder.dart';
 import '../tizen_cache.dart';
 import '../tizen_plugins.dart';

--- a/lib/tizen_build_info.dart
+++ b/lib/tizen_build_info.dart
@@ -1,0 +1,20 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/build_info.dart';
+
+/// See: [AndroidBuildInfo] in `build_info.dart`
+class TizenBuildInfo {
+  const TizenBuildInfo(
+    this.buildInfo, {
+    required this.targetArch,
+    required this.deviceProfile,
+    this.securityProfile,
+  });
+
+  final BuildInfo buildInfo;
+  final String targetArch;
+  final String deviceProfile;
+  final String? securityProfile;
+}

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -32,6 +32,7 @@ import 'package:process/process.dart';
 
 import 'build_targets/application.dart';
 import 'build_targets/package.dart';
+import 'tizen_build_info.dart';
 import 'tizen_project.dart';
 import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';
@@ -40,22 +41,6 @@ import 'tizen_tpk.dart';
 const String kDeviceProfile = 'DeviceProfile';
 
 TizenBuilder get tizenBuilder => context.get<TizenBuilder>();
-
-/// See: [AndroidBuildInfo] in `build_info.dart`
-class TizenBuildInfo {
-  const TizenBuildInfo(
-    this.buildInfo, {
-    @required this.targetArch,
-    @required this.deviceProfile,
-    this.securityProfile,
-  })  : assert(targetArch != null),
-        assert(deviceProfile != null);
-
-  final BuildInfo buildInfo;
-  final String targetArch;
-  final String deviceProfile;
-  final String securityProfile;
-}
 
 /// See:
 /// - [AndroidGradleBuilder.buildApk] in `gradle.dart`

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -27,6 +27,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:process/process.dart';
 
+import 'tizen_build_info.dart';
 import 'tizen_builder.dart';
 import 'tizen_sdk.dart';
 import 'tizen_tpk.dart';

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -2,30 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/file.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/process.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:meta/meta.dart';
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:xml/xml.dart';
 
-TizenSdk get tizenSdk => context.get<TizenSdk>();
+TizenSdk? get tizenSdk => context.get<TizenSdk>();
 
-File get dotnetCli => globals.os.which('dotnet');
+File? get dotnetCli => globals.os.which('dotnet');
 
 class TizenSdk {
   TizenSdk._(this.directory);
 
   /// See: [AndroidSdk.locateAndroidSdk] in `android_sdk.dart`
-  static TizenSdk locateSdk() {
-    Directory tizenHomeDir;
+  static TizenSdk? locateSdk() {
+    Directory? tizenHomeDir;
     final Map<String, String> environment = globals.platform.environment;
-    final File sdb = globals.os.which('sdb');
+    final File? sdb = globals.os.which('sdb');
     if (environment.containsKey('TIZEN_SDK')) {
       tizenHomeDir = globals.fs.directory(environment['TIZEN_SDK']);
     } else if (sdb != null && sdb.parent.basename == 'tools') {
@@ -78,7 +76,7 @@ class TizenSdk {
   }
 
   /// The SDK version number in the "x.y[.z]" format, or null if not found.
-  String get sdkVersion {
+  String? get sdkVersion {
     final File versionFile = directory.childFile('sdk.version');
     if (!versionFile.existsSync()) {
       return null;
@@ -111,15 +109,15 @@ class TizenSdk {
           ? 'package-manager-cli.exe'
           : 'package-manager-cli.bin');
 
-  SecurityProfiles get securityProfiles {
+  SecurityProfiles? get securityProfiles {
     final File manifest =
         sdkDataDirectory.childDirectory('profile').childFile('profiles.xml');
     return SecurityProfiles.parseFromXml(manifest);
   }
 
-  String get defaultNativeCompiler => 'llvm-10.0';
+  final String defaultNativeCompiler = 'llvm-10.0';
 
-  String get defaultGccVersion => '9.2';
+  final String defaultGccVersion = '9.2';
 
   /// On non-Windows, returns the PATH environment variable.
   ///
@@ -138,19 +136,19 @@ class TizenSdk {
 
   Future<RunResult> buildApp(
     String workingDirectory, {
-    Map<String, dynamic> build = const <String, dynamic>{},
-    Map<String, dynamic> method = const <String, dynamic>{},
-    String output,
-    Map<String, dynamic> package = const <String, dynamic>{},
-    String sign,
+    Map<String, Object> build = const <String, Object>{},
+    Map<String, Object> method = const <String, Object>{},
+    String? output,
+    Map<String, Object> package = const <String, Object>{},
+    String? sign,
   }) {
-    String stringify(dynamic argument) {
+    String stringify(Object argument) {
       if (argument is String) {
         return '"${argument.replaceAll('"', r'\"')}"';
-      } else if (argument is List) {
-        return argument.map(stringify).toList().toString();
-      } else if (argument is Map<String, dynamic>) {
-        for (final MapEntry<String, dynamic> entry in argument.entries) {
+      } else if (argument is List<Object>) {
+        return argument.map<String>(stringify).toList().toString();
+      } else if (argument is Map<String, Object>) {
+        for (final MapEntry<String, Object> entry in argument.entries) {
           argument[entry.key] = stringify(entry.value);
         }
         return argument.toString();
@@ -159,7 +157,7 @@ class TizenSdk {
       }
     }
 
-    String flatten(Map<String, dynamic> argument) {
+    String flatten(Map<String, Object> argument) {
       final String string = stringify(argument);
       return string.substring(1, string.length - 1);
     }
@@ -184,16 +182,13 @@ class TizenSdk {
 
   Future<RunResult> buildNative(
     String workingDirectory, {
-    @required String configuration,
-    @required String arch,
-    String compiler,
+    required String configuration,
+    required String arch,
+    String? compiler,
     List<String> predefines = const <String>[],
     List<String> extraOptions = const <String>[],
-    String rootstrap,
-  }) async {
-    assert(configuration != null);
-    assert(arch != null);
-
+    String? rootstrap,
+  }) {
     return _processUtils.run(
       <String>[
         tizenCli.path,
@@ -219,8 +214,8 @@ class TizenSdk {
   Future<RunResult> package(
     String workingDirectory, {
     String type = 'tpk',
-    String reference,
-    String sign,
+    String? reference,
+    String? sign,
   }) {
     return _processUtils.run(<String>[
       tizenCli.path,
@@ -235,13 +230,10 @@ class TizenSdk {
   }
 
   Rootstrap getFlutterRootstrap({
-    @required String profile,
-    @required String apiVersion,
-    @required String arch,
+    required String profile,
+    required String apiVersion,
+    required String arch,
   }) {
-    assert(profile != null);
-    assert(apiVersion != null);
-
     if (profile == 'common') {
       // Note: The headless profile is not supported.
       profile = 'iot-headed';
@@ -252,7 +244,7 @@ class TizenSdk {
     }
 
     double versionToDouble(String versionString) {
-      final double version = double.tryParse(versionString);
+      final double? version = double.tryParse(versionString);
       if (version == null) {
         throwToolExit('The API version $versionString is invalid.');
       }
@@ -286,7 +278,7 @@ class TizenSdk {
     Rootstrap rootstrap = getRootstrap(profile, apiVersion, type);
     if (!rootstrap.isValid && profile == 'tv-samsung') {
       globals.printStatus(
-          'The TV SDK could not be found. Trying with the Wearable SDK...');
+          'TV SDK could not be found. Trying with Wearable SDK...');
       profile = 'wearable';
       rootstrap = getRootstrap(profile, apiVersion, type);
     }
@@ -388,10 +380,10 @@ String getTizenCliArch(String arch) {
 }
 
 class SecurityProfiles {
-  SecurityProfiles._(this.profiles, {@required this.active});
+  SecurityProfiles._(this.profiles, {required this.active});
 
-  static SecurityProfiles parseFromXml(File xmlFile) {
-    if (xmlFile == null || !xmlFile.existsSync()) {
+  static SecurityProfiles? parseFromXml(File xmlFile) {
+    if (!xmlFile.existsSync()) {
       return null;
     }
 
@@ -408,7 +400,7 @@ class SecurityProfiles {
       return null;
     }
 
-    String active = document.rootElement.getAttribute('active');
+    String? active = document.rootElement.getAttribute('active');
     if (active != null && active.isEmpty) {
       active = null;
     }
@@ -416,7 +408,7 @@ class SecurityProfiles {
     final List<String> profiles = <String>[];
     for (final XmlElement profile
         in document.rootElement.findAllElements('profile')) {
-      final String name = profile.getAttribute('name');
+      final String? name = profile.getAttribute('name');
       if (name != null) {
         profiles.add(name);
       }
@@ -426,7 +418,7 @@ class SecurityProfiles {
   }
 
   final List<String> profiles;
-  final String active;
+  final String? active;
 
   bool contains(String name) => profiles.contains(name);
 }


### PR DESCRIPTION
`tizen_builder.dart` cannot be migrated to null safety right now so `TizenBuildInfo` has been extracted to a separate file.