### PR TITLE
Exclude .vscode from version control by default

### DIFF
--- a/templates/multi-app/.gitignore.patch
+++ b/templates/multi-app/.gitignore.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+index 0fa6b675c0..eadf111d1f 100644
+--- a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
++++ b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+@@ -15,10 +15,8 @@
+ *.iws
+ .idea/
+ 
+-# The .vscode folder contains launch configuration and tasks you configure in
+-# VS Code which you may wish to be included in version control, so this line
+-# is commented out by default.
+-#.vscode/
++# VS Code related
++.vscode/
+ 
+ # Flutter/Dart/Pub related
+ **/doc/api/

--- a/templates/service-app/.gitignore.patch
+++ b/templates/service-app/.gitignore.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+index 0fa6b675c0..eadf111d1f 100644
+--- a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
++++ b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+@@ -15,10 +15,8 @@
+ *.iws
+ .idea/
+ 
+-# The .vscode folder contains launch configuration and tasks you configure in
+-# VS Code which you may wish to be included in version control, so this line
+-# is commented out by default.
+-#.vscode/
++# VS Code related
++.vscode/
+ 
+ # Flutter/Dart/Pub related
+ **/doc/api/

--- a/templates/ui-app/.gitignore.patch
+++ b/templates/ui-app/.gitignore.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+index 0fa6b675c0..eadf111d1f 100644
+--- a/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
++++ b/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+@@ -15,10 +15,8 @@
+ *.iws
+ .idea/
+ 
+-# The .vscode folder contains launch configuration and tasks you configure in
+-# VS Code which you may wish to be included in version control, so this line
+-# is commented out by default.
+-#.vscode/
++# VS Code related
++.vscode/
+ 
+ # Flutter/Dart/Pub related
+ **/doc/api/


### PR DESCRIPTION
The `.vscode/launch.json` file is modified by the flutter-tizen tool on every debug/profile launch (https://github.com/flutter-tizen/flutter-tizen/pull/196), so the file could be excluded from version control by default.

Depends on https://github.com/flutter-tizen/flutter-tizen/pull/243.