### PR TITLE
Add tests for test.dart

### DIFF
--- a/lib/commands/test.dart
+++ b/lib/commands/test.dart
@@ -52,7 +52,8 @@ class TizenTestRunner implements FlutterTestRunner {
   bool isIntegrationTest = false;
 
   /// See: [_generateEntrypointWithPluginRegistrant] in `tizen_plugins.dart`
-  Stream<String> _generateEntrypointWrappers(List<String> testFiles) async* {
+  Future<List<String>> _generateEntrypointWrappers(
+      List<String> testFiles) async {
     final FlutterProject project = FlutterProject.current();
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       project.packageConfigFile,
@@ -62,6 +63,7 @@ class TizenTestRunner implements FlutterTestRunner {
         await findTizenPlugins(project, dartOnly: true);
     final Directory runnerDir = globals.fs.systemTempDirectory.createTempSync();
 
+    final List<String> newTestFiles = <String>[];
     for (final File testFile
         in testFiles.map((String path) => globals.fs.file(path))) {
       final Uri testFileUri = testFile.absolute.uri;
@@ -98,8 +100,9 @@ void main() {
         context,
         newTestFile,
       );
-      yield newTestFile.absolute.path;
+      newTestFiles.add(newTestFile.absolute.path);
     }
+    return newTestFiles;
   }
 
   @override
@@ -134,7 +137,7 @@ void main() {
     String integrationTestUserIdentifier,
   }) async {
     if (isIntegrationTest) {
-      testFiles = await _generateEntrypointWrappers(testFiles).toList();
+      testFiles = await _generateEntrypointWrappers(testFiles);
     }
     return testRunner.runTests(
       testWrapper,

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -149,10 +149,7 @@ Future<void> main(List<String> args) async {
         featureFlags: featureFlags,
       ),
       TizenRunCommand(verboseHelp: verboseHelp),
-      TizenTestCommand(
-        verboseHelp: verboseHelp,
-        testWrapper: TizenTestWrapper(),
-      ),
+      TizenTestCommand(verboseHelp: verboseHelp),
     ],
     verbose: verbose,
     verboseHelp: verboseHelp,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,5 @@ dev_dependencies:
   file_testing:
   flutter_test:
     sdk: flutter
-  mockito:
-  pedantic:
   pubspec_parse:
   test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   yaml:
 
 dev_dependencies:
+  args:
   file_testing:
   flutter_test:
     sdk: flutter

--- a/test/commands/create_test.dart
+++ b/test/commands/create_test.dart
@@ -75,13 +75,12 @@ void main() {
       projectDir.path,
     ]);
 
-    expect(projectDir.childDirectory('lib').childFile('main.dart'), exists);
-    final Directory tizenDir = projectDir.childDirectory('tizen');
-    expect(tizenDir.childDirectory('shared').listSync(), isNotEmpty);
-    expect(tizenDir.childFile('.gitignore'), exists);
-    expect(tizenDir.childFile('App.cs'), exists);
-    expect(tizenDir.childFile('Runner.csproj'), exists);
-    expect(tizenDir.childFile('tizen-manifest.xml'), exists);
+    expect(projectDir.childFile('lib/main.dart'), exists);
+    expect(projectDir.childDirectory('tizen/shared').listSync(), isNotEmpty);
+    expect(projectDir.childFile('tizen/.gitignore'), exists);
+    expect(projectDir.childFile('tizen/App.cs'), exists);
+    expect(projectDir.childFile('tizen/Runner.csproj'), exists);
+    expect(projectDir.childFile('tizen/tizen-manifest.xml'), exists);
   }, overrides: <Type, Generator>{});
 
   testUsingContext('Can create a C++ service app project', () async {
@@ -97,15 +96,14 @@ void main() {
       projectDir.path,
     ]);
 
-    expect(projectDir.childDirectory('lib').childFile('main.dart'), exists);
-    final Directory tizenDir = projectDir.childDirectory('tizen');
-    expect(tizenDir.childDirectory('inc').listSync(), isNotEmpty);
-    expect(tizenDir.childDirectory('shared').listSync(), isNotEmpty);
-    expect(tizenDir.childDirectory('src').listSync(), isNotEmpty);
-    expect(tizenDir.childFile('.exportMap'), exists);
-    expect(tizenDir.childFile('.gitignore'), exists);
-    expect(tizenDir.childFile('project_def.prop'), exists);
-    expect(tizenDir.childFile('tizen-manifest.xml'), exists);
+    expect(projectDir.childFile('lib/main.dart'), exists);
+    expect(projectDir.childDirectory('tizen/inc').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/shared').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/src').listSync(), isNotEmpty);
+    expect(projectDir.childFile('tizen/.exportMap'), exists);
+    expect(projectDir.childFile('tizen/.gitignore'), exists);
+    expect(projectDir.childFile('tizen/project_def.prop'), exists);
+    expect(projectDir.childFile('tizen/tizen-manifest.xml'), exists);
   }, overrides: <Type, Generator>{});
 
   testUsingContext('Cannot create a C# multi app project', () async {
@@ -135,8 +133,7 @@ void main() {
       projectDir.path,
     ]);
 
-    final File mainDart =
-        projectDir.childDirectory('lib').childFile('main.dart');
+    final File mainDart = projectDir.childFile('lib/main.dart');
     expect(mainDart.readAsStringSync(), contains('Tizen Multi App Demo'));
 
     final String rawPubspec =
@@ -145,9 +142,8 @@ void main() {
     expect(pubspec.dependencies, contains('tizen_app_control'));
     expect(pubspec.dependencies, contains('messageport_tizen'));
 
-    final Directory tizenDir = projectDir.childDirectory('tizen');
-    expect(tizenDir.childDirectory('ui').listSync(), isNotEmpty);
-    expect(tizenDir.childDirectory('service').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/ui').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/service').listSync(), isNotEmpty);
 
     final ProcessResult result = await Process.run(
       'git',
@@ -176,14 +172,12 @@ void main() {
       unexpectedPlatforms: <String>['tizen'],
     );
 
-    final Directory exampleDir = projectDir.childDirectory('example');
-    expect(exampleDir.childDirectory('lib').childFile('main.dart'), exists);
-    expect(exampleDir.childDirectory('tizen').listSync(), isNotEmpty);
-    final Directory tizenDir = projectDir.childDirectory('tizen');
-    expect(tizenDir.childDirectory('inc').listSync(), isNotEmpty);
-    expect(tizenDir.childDirectory('src').listSync(), isNotEmpty);
-    expect(tizenDir.childFile('.gitignore'), exists);
-    expect(tizenDir.childFile('project_def.prop'), exists);
+    expect(projectDir.childFile('example/lib/main.dart'), exists);
+    expect(projectDir.childDirectory('example/tizen').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/inc').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('tizen/src').listSync(), isNotEmpty);
+    expect(projectDir.childFile('tizen/.gitignore'), exists);
+    expect(projectDir.childFile('tizen/project_def.prop'), exists);
     expect(logger.errorText, contains(_kNoPlatformsMessage));
   }, overrides: <Type, Generator>{
     Logger: () => logger,
@@ -216,9 +210,7 @@ void main() {
       '--template=plugin',
       projectDir.path,
     ]);
-
-    final Directory exampleDir = projectDir.childDirectory('example');
-    expect(exampleDir.childDirectory('tizen'), isNot(exists));
+    expect(projectDir.childDirectory('example/tizen'), isNot(exists));
     expect(projectDir.childDirectory('tizen'), isNot(exists));
     expect(logger.errorText, contains(_kNoPlatformsMessage));
 
@@ -228,7 +220,7 @@ void main() {
       '--platforms=tizen',
       projectDir.path,
     ]);
-    expect(exampleDir.childDirectory('tizen').listSync(), isNotEmpty);
+    expect(projectDir.childDirectory('example/tizen').listSync(), isNotEmpty);
     expect(projectDir.childDirectory('tizen').listSync(), isNotEmpty);
     expect(logger.statusText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{

--- a/test/commands/test_test.dart
+++ b/test/commands/test_test.dart
@@ -35,13 +35,10 @@ void main() {
     final Directory projectDir = fileSystem.directory('/project');
     pubspecFile = projectDir.childFile('pubspec.yaml')
       ..createSync(recursive: true);
-    packageConfigFile = projectDir
-        .childDirectory('.dart_tool')
-        .childFile('package_config.json')
+    packageConfigFile = projectDir.childFile('.dart_tool/package_config.json')
       ..createSync(recursive: true);
     projectDir
-        .childDirectory('integration_test')
-        .childFile('some_integration_test.dart')
+        .childFile('integration_test/some_integration_test.dart')
         .createSync(recursive: true);
     fileSystem.currentDirectory = projectDir.path;
 
@@ -118,7 +115,6 @@ dependencies:
   some_dart_plugin:
     path: ${pluginDir.path}
 ''');
-    final Uri pluginUri = Uri.file(pluginDir.path);
     packageConfigFile.writeAsStringSync('''
 {
   "configVersion": 2,
@@ -137,7 +133,7 @@ dependencies:
     },
     {
       "name": "some_dart_plugin",
-      "rootUri": "${pluginUri.toString()}",
+      "rootUri": "${pluginDir.uri}",
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }

--- a/test/commands/test_test.dart
+++ b/test/commands/test_test.dart
@@ -77,10 +77,7 @@ void main() {
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
-  ],
-  "generated": "2021-02-24T07:55:20.084834Z",
-  "generator": "pub",
-  "generatorVersion": "2.13.0"
+  ]
 }
 ''');
     await runner.run(const <String>[
@@ -144,10 +141,7 @@ dependencies:
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
-  ],
-  "generated": "2021-02-24T07:55:20.084834Z",
-  "generator": "pub",
-  "generatorVersion": "2.13.0"
+  ]
 }
 ''');
     await runner.run(const <String>[

--- a/test/commands/test_test.dart
+++ b/test/commands/test_test.dart
@@ -1,0 +1,203 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/commands/test.dart';
+import 'package:flutter_tizen/tizen_cache.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/test/test_wrapper.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_devices.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  File pubspecFile;
+  File packageConfigFile;
+  DeviceManager deviceManager;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    final Directory projectDir = fileSystem.directory('/project');
+    pubspecFile = projectDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true);
+    packageConfigFile = projectDir
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json')
+      ..createSync(recursive: true);
+    projectDir
+        .childDirectory('integration_test')
+        .childFile('some_integration_test.dart')
+        .createSync(recursive: true);
+    fileSystem.currentDirectory = projectDir.path;
+
+    deviceManager = _FakeDeviceManager(<Device>[
+      FakeDevice(
+        'ephemeral',
+        'ephemeral',
+        ephemeral: true,
+        isSupported: true,
+        type: PlatformType.custom,
+      ),
+    ]);
+  });
+
+  testUsingContext('Requests Tizen artifacts', () async {
+    final _FakeTestWrapper testWrapper = _FakeTestWrapper();
+    final TizenTestCommand command = TizenTestCommand(testWrapper: testWrapper);
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    packageConfigFile.writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "test_api",
+      "rootUri": "file:///path/to/pubcache/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.19",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "integration_test",
+      "rootUri": "file:///path/to/flutter/packages/integration_test",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ],
+  "generated": "2021-02-24T07:55:20.084834Z",
+  "generator": "pub",
+  "generatorVersion": "2.13.0"
+}
+''');
+    await runner.run(const <String>[
+      'test',
+      '--no-pub',
+      'integration_test',
+    ]);
+
+    expect(await command.requiredArtifacts, <DevelopmentArtifact>[
+      DevelopmentArtifact.androidGenSnapshot,
+      TizenDevelopmentArtifact.tizen,
+    ]);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    DeviceManager: () => deviceManager,
+  });
+
+  testUsingContext('Can generate entrypoint wrapper for integration test',
+      () async {
+    final _FakeTestWrapper testWrapper = _FakeTestWrapper();
+    final TizenTestCommand command = TizenTestCommand(testWrapper: testWrapper);
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    final Directory pluginDir = fileSystem.directory('/some_dart_plugin');
+    pluginDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+flutter:
+  plugin:
+    platforms:
+      tizen:
+        dartPluginClass: SomeDartPlugin
+        fileName: some_dart_plugin.dart
+''');
+    pubspecFile.writeAsStringSync('''
+dependencies:
+  some_dart_plugin:
+    path: ${pluginDir.path}
+''');
+    final Uri pluginUri = Uri.file(pluginDir.path);
+    packageConfigFile.writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "test_api",
+      "rootUri": "file:///path/to/pubcache/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.19",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "integration_test",
+      "rootUri": "file:///path/to/flutter/packages/integration_test",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "some_dart_plugin",
+      "rootUri": "${pluginUri.toString()}",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ],
+  "generated": "2021-02-24T07:55:20.084834Z",
+  "generator": "pub",
+  "generatorVersion": "2.13.0"
+}
+''');
+    await runner.run(const <String>[
+      'test',
+      '--no-pub',
+      'integration_test',
+    ]);
+
+    final File generatedEntrypoint =
+        fileSystem.file('/.tmp_rand0/rand0/some_integration_test.dart');
+    expect(testWrapper.lastArgs, contains(generatedEntrypoint.path));
+    expect(generatedEntrypoint.readAsStringSync(), contains('''
+import 'file:///project/integration_test/some_integration_test.dart' as entrypoint;
+import 'package:some_dart_plugin/some_dart_plugin.dart';
+
+void main() {
+  SomeDartPlugin.register();
+  entrypoint.main();
+}
+'''));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    DeviceManager: () => deviceManager,
+  });
+}
+
+class _FakeDeviceManager extends DeviceManager {
+  _FakeDeviceManager(this._devices);
+
+  final List<Device> _devices;
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
+
+  @override
+  Future<List<Device>> getAllConnectedDevices() async => _devices;
+}
+
+class _FakeTestWrapper implements TestWrapper {
+  List<String> lastArgs;
+
+  @override
+  Future<void> main(List<String> args) async {
+    lastArgs = args;
+  }
+
+  @override
+  void registerPlatformPlugin(
+    Iterable<Runtime> runtimes,
+    FutureOr<PlatformPlugin> Function() platforms,
+  ) {}
+}

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -6,7 +6,6 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tizen/tizen_device.dart';
-import 'package:flutter_tizen/tizen_sdk.dart';
 import 'package:flutter_tizen/tizen_tpk.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -18,6 +17,7 @@ import 'package:test/fake.dart';
 import '../src/common.dart';
 import '../src/fake_devices.dart';
 import '../src/fake_process_manager.dart';
+import '../src/fake_tizen_sdk.dart';
 
 const String _kDeviceId = 'TestDeviceId';
 
@@ -31,13 +31,13 @@ TizenDevice _createTizenDevice({
     modelId: 'TestModel',
     logger: BufferLogger.test(),
     processManager: processManager ?? FakeProcessManager.any(),
-    tizenSdk: _FakeTizenSdk(fileSystem),
+    tizenSdk: FakeTizenSdk(fileSystem),
     fileSystem: fileSystem,
   );
 }
 
 List<String> _sdbCommand(List<String> args) {
-  return <String>['sdb', '-s', _kDeviceId, ...args];
+  return <String>['/tizen-studio/tools/sdb', '-s', _kDeviceId, ...args];
 }
 
 void main() {
@@ -209,13 +209,6 @@ void main() {
     expect(tvDevice.deviceProfile, equals('tv'));
     expect(tvDevice.isSupported(), isFalse);
   });
-}
-
-class _FakeTizenSdk extends Fake implements TizenSdk {
-  _FakeTizenSdk(FileSystem fileSystem) : sdb = fileSystem.file('sdb');
-
-  @override
-  File sdb;
 }
 
 class _FakeTizenManifest extends Fake implements TizenManifest {

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -31,7 +31,7 @@ TizenDevice _createTizenDevice({
     modelId: 'TestModel',
     logger: BufferLogger.test(),
     processManager: processManager ?? FakeProcessManager.any(),
-    tizenSdk: FakeTizenSdk(fileSystem),
+    tizenSdk: _FakeTizenSdk(fileSystem),
     fileSystem: fileSystem,
   );
 }
@@ -54,7 +54,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
     );
-    final FakeTizenManifest tizenManifest = FakeTizenManifest();
+    final TizenManifest tizenManifest = _FakeTizenManifest();
     final TizenTpk tpk = TizenTpk(
       file: fileSystem.file('app.tpk')..createSync(),
       manifest: tizenManifest,
@@ -115,7 +115,7 @@ void main() {
     );
     final TizenTpk tpk = TizenTpk(
       file: fileSystem.file('app.tpk')..createSync(),
-      manifest: FakeTizenManifest(),
+      manifest: _FakeTizenManifest(),
     );
 
     processManager.addCommands(<FakeCommand>[
@@ -211,15 +211,15 @@ void main() {
   });
 }
 
-class FakeTizenSdk extends Fake implements TizenSdk {
-  FakeTizenSdk(FileSystem fileSystem) : sdb = fileSystem.file('sdb');
+class _FakeTizenSdk extends Fake implements TizenSdk {
+  _FakeTizenSdk(FileSystem fileSystem) : sdb = fileSystem.file('sdb');
 
   @override
   File sdb;
 }
 
-class FakeTizenManifest extends Fake implements TizenManifest {
-  FakeTizenManifest();
+class _FakeTizenManifest extends Fake implements TizenManifest {
+  _FakeTizenManifest();
 
   @override
   String packageId = 'TestPackage';

--- a/test/src/fake_tizen_sdk.dart
+++ b/test/src/fake_tizen_sdk.dart
@@ -1,0 +1,43 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+import 'fake_process_manager.dart';
+
+class FakeTizenSdk extends TizenSdk {
+  FakeTizenSdk(
+    FileSystem fileSystem, {
+    Logger logger,
+    Platform platform,
+    ProcessManager processManager,
+  }) : super(
+          fileSystem.directory('/tizen-studio'),
+          logger: logger ?? BufferLogger.test(),
+          platform: platform ?? FakePlatform(),
+          processManager: processManager ?? FakeProcessManager.any(),
+        );
+
+  @override
+  File get sdb => super.sdb..createSync(recursive: true);
+
+  @override
+  File get tizenCli => super.tizenCli..createSync(recursive: true);
+
+  @override
+  Rootstrap getFlutterRootstrap({
+    @required String profile,
+    @required String apiVersion,
+    @required String arch,
+  }) {
+    return Rootstrap('rootstrap', directory.childDirectory('rootstrap'));
+  }
+}


### PR DESCRIPTION
Major changes:
- Refactor `test.dart`.
  - Remove `TizenTestWrapper` and replace with `TizenTestRunner` which implements `FlutterTestRunner`, in order to improve testability. `TizenTestWrapper` cannot be tested because it directly invokes `test.main`.
- Add `test_test.dart`.

Additional changes:
- Reduce the use of `globals` in `TizenSdk` to improve testability.
- Create a common `FakeTizenSdk` class for use by multiple tests (later).
- Minor cleanups.