### PR TITLE
Ignore avoid_private_typedef_functions in generated_main.dart

### DIFF
--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -152,6 +152,7 @@ Future<void> _generateEntrypointWithPluginRegistrant(
 // @dart = {{dartLanguageVersion}}
 
 // ignore_for_file: avoid_classes_with_only_static_members
+// ignore_for_file: avoid_private_typedef_functions
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unnecessary_cast


### PR DESCRIPTION
A lint warning is generated because `_NullaryFunction` is referenced only once unless multiple entry points exist.