### PR TITLE
Add tizen_builder_test.dart and plugins_test.dart

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -40,6 +40,7 @@ import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:path/path.dart';
 
+import 'build_targets/package.dart';
 import 'commands/attach.dart';
 import 'commands/build.dart';
 import 'commands/clean.dart';
@@ -221,6 +222,7 @@ Future<void> main(List<String> args) async {
             tizenSdk: tizenSdk,
             operatingSystemUtils: globals.os,
           ),
+      PackageBuilder: () => const PackageBuilder(),
       Pub: () => TizenPub(
             fileSystem: globals.fs,
             logger: globals.logger,

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -274,9 +274,8 @@ Future<List<TizenPlugin>> findTizenPlugins(
 }) async {
   final List<TizenPlugin> plugins = <TizenPlugin>[];
   final FileSystem fs = project.directory.fileSystem;
-  final File packagesFile = project.directory.childFile('.packages');
   final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-    packagesFile,
+    project.packageConfigFile,
     logger: globals.logger,
     throwOnError: throwOnError,
   );

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -1,0 +1,256 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tizen/build_targets/plugins.dart';
+import 'package:flutter_tizen/tizen_build_info.dart';
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fake_tizen_sdk.dart';
+import '../../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  FakeProcessManager processManager;
+  Logger logger;
+  Artifacts artifacts;
+  Directory pluginDir;
+  Directory projectDir;
+  Cache cache;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.empty();
+    logger = BufferLogger.test();
+    artifacts = Artifacts.test();
+
+    pluginDir = fileSystem.directory('/some_native_plugin');
+    pluginDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+flutter:
+  plugin:
+    platforms:
+      tizen:
+        pluginClass: SomeNativePlugin
+        fileName: some_native_plugin.h
+''');
+    pluginDir.childFile('tizen/project_def.prop').createSync(recursive: true);
+    pluginDir
+        .childFile('tizen/inc/some_native_plugin.h')
+        .createSync(recursive: true);
+
+    projectDir = fileSystem.directory('/project');
+    projectDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+dependencies:
+  some_native_plugin:
+    path: ${pluginDir.path}
+''');
+    projectDir.childFile('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "some_dart_plugin",
+      "rootUri": "${pluginDir.uri}",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ]
+}
+''');
+    projectDir.childFile('tizen/tizen-manifest.xml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+<manifest package="package_id" version="1.0.0" api-version="4.0">
+    <profile name="common"/>
+    <ui-application appid="app_id" exec="Runner.dll" type="dotnet"/>
+</manifest>
+''');
+
+    cache = Cache.test(
+      fileSystem: fileSystem,
+      processManager: FakeProcessManager.any(),
+    );
+    final Directory engineArtifactDir = cache.getArtifactDirectory('engine');
+    engineArtifactDir
+        .childDirectory('tizen-common/cpp_client_wrapper')
+        .createSync(recursive: true);
+    engineArtifactDir
+        .childDirectory('tizen-common/public')
+        .createSync(recursive: true);
+  });
+
+  testUsingContext('Can build shared object for debug-x86', () async {
+    final Environment environment = Environment.test(
+      projectDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+
+    processManager.addCommand(FakeCommand(
+      command: _tizenBuildCommand(
+        'Debug',
+        'x86',
+        '/.tmp_rand0/rand0',
+        predefine: 'WEARABLE_PROFILE',
+        extraOptions: <String>[
+          '-fPIC',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include"',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
+        ],
+      ),
+      onRun: () {
+        fileSystem
+            .file('/.tmp_rand0/rand0/Debug/libsome_native_plugin.a')
+            .createSync(recursive: true);
+      },
+    ));
+    processManager.addCommand(FakeCommand(
+      command: _tizenBuildCommand(
+        'Debug',
+        'x86',
+        '/.tmp_rand0/rand1',
+        extraOptions: <String>[
+          '-lflutter_tizen_wearable',
+          '-L"cache/bin/cache/artifacts/engine/tizen-x86-debug"',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
+          '-L"/project/build/2ca1f4ebdc59348ffdc31d97a51a98d5/tizen_plugins/lib"',
+          '-Wl,--undefined=SomeNativePluginRegisterWithRegistrar',
+        ],
+      ),
+      onRun: () => fileSystem
+          .file('/.tmp_rand0/rand1/Debug/libflutter_plugins.so')
+          .createSync(recursive: true),
+    ));
+
+    await NativePlugins(const TizenBuildInfo(
+      BuildInfo.debug,
+      targetArch: 'x86',
+      deviceProfile: 'wearable',
+    )).build(environment);
+
+    final File outputLib =
+        environment.buildDir.childFile('tizen_plugins/libflutter_plugins.so');
+    expect(outputLib, exists);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Cache: () => cache,
+    TizenSdk: () => FakeTizenSdk(fileSystem, processManager: processManager),
+  });
+
+  testUsingContext('Copies user libs to build dir if exist', () async {
+    final Environment environment = Environment.test(
+      projectDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+
+    pluginDir.childFile('tizen/lib/libstatic.a').createSync(recursive: true);
+    pluginDir.childFile('tizen/lib/libshared.so').createSync(recursive: true);
+
+    processManager.addCommand(FakeCommand(
+      command: _tizenBuildCommand(
+        'Release',
+        'arm',
+        '/.tmp_rand0/rand0',
+        predefine: 'COMMON_PROFILE',
+        extraOptions: <String>[
+          '-fPIC',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include"',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
+        ],
+      ),
+      onRun: () {
+        fileSystem
+            .file('/.tmp_rand0/rand0/Release/libsome_native_plugin.a')
+            .createSync(recursive: true);
+      },
+    ));
+    processManager.addCommand(FakeCommand(
+      command: _tizenBuildCommand(
+        'Release',
+        'arm',
+        '/.tmp_rand0/rand1',
+        extraOptions: <String>[
+          '-lflutter_tizen_common',
+          '-L"cache/bin/cache/artifacts/engine/tizen-arm-release"',
+          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
+          '-L"/project/build/2ca1f4ebdc59348ffdc31d97a51a98d5/tizen_plugins/lib"',
+          '-Wl,--undefined=SomeNativePluginRegisterWithRegistrar',
+        ],
+      ),
+      onRun: () => fileSystem
+          .file('/.tmp_rand0/rand1/Release/libflutter_plugins.so')
+          .createSync(recursive: true),
+    ));
+
+    await NativePlugins(const TizenBuildInfo(
+      BuildInfo.release,
+      targetArch: 'arm',
+      deviceProfile: 'common',
+    )).build(environment);
+
+    final Directory userLibDir =
+        environment.buildDir.childDirectory('tizen_plugins/lib');
+    expect(userLibDir.listSync(), isNotEmpty);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Cache: () => cache,
+    TizenSdk: () => FakeTizenSdk(fileSystem, processManager: processManager),
+  });
+}
+
+List<String> _tizenBuildCommand(
+  String buildMode,
+  String arch,
+  String workingDir, {
+  String predefine,
+  List<String> extraOptions,
+}) {
+  return <String>[
+    '/tizen-studio/tools/ide/bin/tizen',
+    'build-native',
+    '-C',
+    buildMode,
+    '-a',
+    arch,
+    '-c',
+    'llvm-10.0',
+    if (predefine != null) ...<String>['-d', predefine],
+    if (extraOptions.isNotEmpty) ...<String>['-e', extraOptions.join(' ')],
+    '-r',
+    'rootstrap',
+    '--',
+    workingDir,
+  ];
+}

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -102,7 +102,7 @@ dependencies:
         .createSync(recursive: true);
   });
 
-  testUsingContext('Can build shared object for debug-x86', () async {
+  testUsingContext('Can build for debug x86', () async {
     final Environment environment = Environment.test(
       projectDir,
       fileSystem: fileSystem,
@@ -164,7 +164,7 @@ dependencies:
     TizenSdk: () => FakeTizenSdk(fileSystem, processManager: processManager),
   });
 
-  testUsingContext('Copies user libs to build dir if exist', () async {
+  testUsingContext('Can link to user libraries', () async {
     final Environment environment = Environment.test(
       projectDir,
       fileSystem: fileSystem,
@@ -218,9 +218,14 @@ dependencies:
       deviceProfile: 'common',
     )).build(environment);
 
-    final Directory userLibDir =
-        environment.buildDir.childDirectory('tizen_plugins/lib');
-    expect(userLibDir.listSync(), isNotEmpty);
+    final Directory rootDir =
+        environment.buildDir.childDirectory('tizen_plugins');
+    expect(
+      rootDir.childFile('project_def.prop').readAsStringSync(),
+      contains('USER_LIBS = some_native_plugin static shared'),
+    );
+    expect(rootDir.childFile('lib/libstatic.a'), isNot(exists));
+    expect(rootDir.childFile('lib/libshared.so'), exists);
     expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/test/general/tizen_builder_test.dart
+++ b/test/general/tizen_builder_test.dart
@@ -1,0 +1,171 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/build_targets/package.dart';
+import 'package:flutter_tizen/tizen_build_info.dart';
+import 'package:flutter_tizen/tizen_builder.dart';
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_tizen_sdk.dart';
+import '../src/test_build_system.dart';
+import '../src/test_flutter_command_runner.dart';
+
+const String _kTizenManifestContents = '''
+<manifest package="package_id" version="1.0.0" api-version="4.0">
+    <profile name="common"/>
+    <ui-application appid="app_id" exec="Runner.dll" type="dotnet"/>
+</manifest>
+''';
+
+void main() {
+  FileSystem fileSystem;
+  ProcessManager processManager;
+  FlutterProject project;
+  TizenBuildInfo tizenBuildInfo;
+  TizenBuilder tizenBuilder;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages": []}');
+    processManager = FakeProcessManager.any();
+    project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+
+    tizenBuildInfo = const TizenBuildInfo(
+      BuildInfo.debug,
+      targetArch: 'arm',
+      deviceProfile: 'common',
+    );
+    tizenBuilder = TizenBuilder(
+      logger: BufferLogger.test(),
+      processManager: processManager,
+      fileSystem: fileSystem,
+      artifacts: Artifacts.test(),
+      usage: TestUsage(),
+      platform: FakePlatform(),
+    );
+  });
+
+  testUsingContext('Build fails if there is no Tizen project', () async {
+    await expectLater(
+      () => tizenBuilder.buildTpk(
+        project: project,
+        tizenBuildInfo: tizenBuildInfo,
+        targetFile: 'main.dart',
+      ),
+      throwsToolExit(message: 'This project is not configured for Tizen.'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
+  testUsingContext('Build fails if Tizen Studio is not installed', () async {
+    fileSystem.file('tizen/tizen-manifest.xml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(_kTizenManifestContents);
+
+    await expectLater(
+      () => tizenBuilder.buildTpk(
+        project: project,
+        tizenBuildInfo: tizenBuildInfo,
+        targetFile: 'main.dart',
+      ),
+      throwsToolExit(message: 'Unable to locate Tizen CLI executable.'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
+  testUsingContext('Output TPK is missing', () async {
+    fileSystem.file('tizen/tizen-manifest.xml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(_kTizenManifestContents);
+
+    await expectLater(
+      () => tizenBuilder.buildTpk(
+        project: project,
+        tizenBuildInfo: tizenBuildInfo,
+        targetFile: 'main.dart',
+      ),
+      throwsToolExit(message: 'The output TPK does not exist.'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+    BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
+    PackageBuilder: () => _FakePackageBuilder(null),
+  });
+
+  testUsingContext('Can update tizen-manifest.xml', () async {
+    fileSystem.file('tizen/tizen-manifest.xml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(_kTizenManifestContents);
+
+    const BuildInfo buildInfo = BuildInfo(
+      BuildMode.debug,
+      null,
+      treeShakeIcons: false,
+      buildName: '9.9.9',
+    );
+    await tizenBuilder.buildTpk(
+      project: project,
+      tizenBuildInfo: const TizenBuildInfo(
+        buildInfo,
+        targetArch: 'arm',
+        deviceProfile: 'wearable',
+      ),
+      targetFile: 'main.dart',
+    );
+
+    final String tizenManifest =
+        fileSystem.file('tizen/tizen-manifest.xml').readAsStringSync();
+    expect(tizenManifest, isNot(equals(_kTizenManifestContents)));
+    expect(tizenManifest, contains('9.9.9'));
+    expect(tizenManifest, contains('wearable'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+    BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
+    PackageBuilder: () => _FakePackageBuilder('tpk/package_id-9.9.9.tpk'),
+  });
+}
+
+class _FakePackageBuilder extends PackageBuilder {
+  _FakePackageBuilder(this._relativeOutputPath);
+
+  final String _relativeOutputPath;
+
+  @override
+  Future<void> build(Target target, Environment environment) async {
+    if (_relativeOutputPath != null) {
+      environment.outputDir
+          .childFile(_relativeOutputPath)
+          .createSync(recursive: true);
+    }
+  }
+}

--- a/test/src/test_build_system.dart
+++ b/test/src/test_build_system.dart
@@ -1,0 +1,3 @@
+// @dart = 2.8
+
+export '../../flutter/packages/flutter_tools/test/src/test_build_system.dart';


### PR DESCRIPTION
- Create a class `PackageBuilder` to enable testing `TizenBuilder.buildTpk`.
- Add tests for `tizen_builder.dart` and `build_targets/plugins.dart`.

The total test coverage as of this PR is 39.8% (612 of 1538 lines).