### PR TITLE
embedding/csharp: Add MethodChannel and related classes

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+using System.Linq;
+using NSubstitute;
+using Xunit;
+
+namespace Tizen.Flutter.Embedding.Tests.Channels
+{
+    public class MethodChannelTests
+    {
+        private const string TEST_CHANNEL_NAME = "TEST_METHOD_CHANNEL";
+        private const string TEST_METHOD_NAME = "TEST_METHOD_NAME";
+
+        public class TheCtor
+        {
+            [Fact]
+            public void Ensures_Name_Is_Not_Null_Or_Empty()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                Assert.Throws<ArgumentException>(() => new MethodChannel("", StandardMethodCodec.Instance, messenger));
+                Assert.Throws<ArgumentException>(() => new MethodChannel(null, StandardMethodCodec.Instance, messenger));
+            }
+
+            [Fact]
+            public void Ensures_Codec_Is_Not_Null()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                Assert.Throws<ArgumentNullException>(() => new MethodChannel(TEST_CHANNEL_NAME, null, messenger));
+            }
+
+            [Fact]
+            public void Ensures_Messenger_Is_Not_Null()
+            {
+                Assert.Throws<ArgumentNullException>(() => new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, null));
+            }
+        }
+
+        public class TheInvokeMethod
+        {
+            [Fact]
+            public void Requests_Correct_MethodCall()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var codec = StandardMethodCodec.Instance;
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, codec, messenger);
+                var call = new MethodCall(TEST_METHOD_NAME, new int[] { 1, 2, 5 });
+                channel.InvokeMethod(call.Method, call.Arguments);
+
+                messenger.Received().Send(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
+                                          Arg.Is<byte[]>(x => x.SequenceEqual(codec.EncodeMethodCall(call))));
+            }
+
+            [Fact]
+            public void Requests_Null_Method_Name()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+
+                Assert.Throws<ArgumentNullException>(() => channel.InvokeMethod(null, null));
+            }
+
+            [Fact]
+            public void Requests_Null_Method_Call()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+
+                Assert.Throws<ArgumentNullException>(() => channel.InvokeMethod(null));
+            }
+        }
+
+        public class TheInvokeAsyncMethod
+        {
+            [Fact]
+            public async void Requests_Correct_MethodCall_And_Returns_Success_Envelope()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var codec = StandardMethodCodec.Instance;
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, codec, messenger);
+                var call = new MethodCall(TEST_METHOD_NAME, new int[] { 1, 2, 5 });
+                byte[] encodedCall = codec.EncodeMethodCall(call);
+                messenger.SendAsync(TEST_CHANNEL_NAME, Arg.Any<byte[]>())
+                         .Returns(codec.EncodeSuccessEnvelope("TEST_RESULT"));
+
+                var result = await channel.InvokeMethodAsync(call.Method, call.Arguments) as string;
+                await messenger.Received().SendAsync(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
+                                                     Arg.Is<byte[]>(x => x.SequenceEqual(encodedCall)));
+                Assert.Equal("TEST_RESULT", result);
+            }
+
+            [Fact]
+            public async void Requests_Correct_MethodCall_And_Returns_Error_Envelope()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var codec = StandardMethodCodec.Instance;
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, codec, messenger);
+                var call = new MethodCall(TEST_METHOD_NAME, new int[] { 1, 2, 5 });
+                byte[] encodedCall = codec.EncodeMethodCall(call);
+                messenger.SendAsync(TEST_CHANNEL_NAME, Arg.Any<byte[]>())
+                         .Returns(codec.EncodeErrorEnvelope("E0001", "TEST_ERROR", "TEST_ERROR_DETAILS"));
+
+                var ex = await Assert.ThrowsAsync<FlutterException>(() =>
+                  {
+                      return channel.InvokeMethodAsync(call.Method, call.Arguments);
+                  });
+                Assert.Equal("E0001", ex.Code);
+                Assert.Equal("TEST_ERROR", ex.Message);
+                Assert.Equal("TEST_ERROR_DETAILS", ex.Details as string);
+            }
+
+            [Fact]
+            public void Requests_Null_Method_Name()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+
+                Assert.ThrowsAsync<ArgumentNullException>(() => channel.InvokeMethodAsync(null, null));
+            }
+
+            [Fact]
+            public void Requests_Null_Method_Call()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+
+                Assert.ThrowsAsync<ArgumentNullException>(() => channel.InvokeMethodAsync(null));
+            }
+        }
+
+        public class TheSetMethodCallHandlerMethod
+        {
+            [Fact]
+            public void Registers_Message_Handler()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+                channel.SetMethodCallHandler((call) =>
+                {
+                    return null;
+                });
+
+                messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
+                                                       Arg.Any<BinaryMessageHandler>());
+            }
+
+            [Fact]
+            public void Unregisters_Message_Handler()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+                channel.SetMethodCallHandler(null);
+
+                messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME), null);
+            }
+        }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
@@ -98,7 +98,6 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
                 var codec = StandardMethodCodec.Instance;
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, codec, messenger);
                 var call = new MethodCall(TEST_METHOD_NAME, new int[] { 1, 2, 5 });
-                byte[] encodedCall = codec.EncodeMethodCall(call);
                 messenger.SendAsync(TEST_CHANNEL_NAME, Arg.Any<byte[]>())
                          .Returns(codec.EncodeErrorEnvelope("E0001", "TEST_ERROR", "TEST_ERROR_DETAILS"));
 
@@ -162,7 +161,7 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var codec = StandardMethodCodec.Instance;
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
-                byte[] testCall = codec.EncodeMethodCall(new MethodCall("test", 1));
+                byte[] testCall = codec.EncodeMethodCall(new MethodCall(TEST_METHOD_NAME, 1));
                 byte[] expected = codec.EncodeErrorEnvelope("E0001", "TEST_MESSAGE", "TEST_DETAIL");
                 messenger.When(x => x.SetMessageHandler(TEST_CHANNEL_NAME, Arg.Any<BinaryMessageHandler>()))
                          .Do(async x =>
@@ -185,7 +184,7 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
             {
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
-                byte[] testCall = StandardMethodCodec.Instance.EncodeMethodCall(new MethodCall("test", 1));
+                byte[] testCall = StandardMethodCodec.Instance.EncodeMethodCall(new MethodCall(TEST_METHOD_NAME, 1));
                 messenger.When(x => x.SetMessageHandler(TEST_CHANNEL_NAME, Arg.Any<BinaryMessageHandler>()))
                          .Do(async x =>
                          {
@@ -195,7 +194,7 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
                          });
                 channel.SetMethodCallHandler((call) =>
                 {
-                    throw new MissingPluginException("Not found method.");
+                    throw new MissingPluginException();
                 });
             }
         }

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+using System.IO;
+using System.Collections;
+using Xunit;
+using static Tizen.Flutter.Embedding.StandardMessageHelper;
+
+namespace Tizen.Flutter.Embedding.Tests.Channels
+{
+    public class StandardMethodCodecTests
+    {
+        [Fact]
+        public void Encodes_Correct_MethodCall()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var methodCall = new MethodCall("TestMethod", new ArrayList() { 1, "TestArg", true });
+            byte[] result = codec.EncodeMethodCall(methodCall);
+            byte[] expected;
+            using (var stream = new MemoryStream())
+            {
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "TestMethod");
+                stream.WriteByte(12); // LIST
+                WriteSize(stream, 3);
+                stream.WriteByte(3); // INT
+                stream.Write(BitConverter.GetBytes(1));
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "TestArg");
+                stream.WriteByte(1); // TRUE
+                expected = stream.ToArray();
+            }
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Encodes_Correct_SuccessEnvelope()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var encoded = codec.EncodeSuccessEnvelope("TestObject");
+            byte[] expected;
+            using (var stream = new MemoryStream())
+            {
+                stream.WriteByte(0); // SUCCESS
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "TestObject");
+                expected = stream.ToArray();
+            }
+            Assert.Equal(expected, encoded);
+        }
+
+        [Fact]
+        public void Encodes_Correct_ErrorEnvelope()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var encoded = codec.EncodeErrorEnvelope("E0001", "TestError", new ArrayList() { 1, "TestData", false });
+            byte[] expected;
+            using (var stream = new MemoryStream())
+            {
+                stream.WriteByte(1); // ERROR
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "E0001");
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "TestError");
+                stream.WriteByte(12); // LIST
+                WriteSize(stream, 3);
+                stream.WriteByte(3); // INT
+                stream.Write(BitConverter.GetBytes(1));
+                stream.WriteByte(7); // STRING
+                WriteUTF8String(stream, "TestData");
+                stream.WriteByte(2); // FALSE
+                expected = stream.ToArray();
+            }
+            Assert.Equal(expected, encoded);
+        }
+
+        [Fact]
+        public void Decodes_Correct_MethodCall()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var methodCall = new MethodCall("TestMethod", new ArrayList() { 1, "TestArg", true });
+            byte[] encoded = codec.EncodeMethodCall(methodCall);
+            MethodCall decoded = codec.DecodeMethodCall(encoded);
+
+            Assert.Equal("TestMethod", decoded.Method);
+            Assert.IsType<ArrayList>(decoded.Arguments);
+            var arguments = decoded.Arguments as ArrayList;
+            Assert.Equal(3, arguments.Count);
+            Assert.Equal(1, arguments[0]);
+            Assert.Equal("TestArg", arguments[1]);
+            Assert.Equal(true, arguments[2]);
+        }
+
+        [Fact]
+        public void Decodes_Correct_Success_Envelope()
+        {
+            var codec = StandardMethodCodec.Instance;
+            byte[] encoded = codec.EncodeSuccessEnvelope("SUCCESS_ENVELOPE");
+            string decoded = codec.DecodeEnvelope(encoded) as string;
+            Assert.Equal("SUCCESS_ENVELOPE", decoded);
+        }
+
+        [Fact]
+        public void Decodes_Correct_Error_Envelope()
+        {
+            var codec = StandardMethodCodec.Instance;
+            byte[] encoded = codec.EncodeErrorEnvelope("E0001", "TEST_MESSAGE", "TEST_DETAILS");
+            var exception = Assert.Throws<FlutterException>(() =>
+            {
+                codec.DecodeEnvelope(encoded);
+            });
+            Assert.Equal("E0001", exception.Code);
+            Assert.Equal("TEST_MESSAGE", exception.Message);
+            Assert.Equal("TEST_DETAILS", exception.Details);
+        }
+
+        [Fact]
+        public void Throws_When_Message_Is_Corrupted()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var encoded = codec.EncodeMethodCall(new MethodCall("TEST_METHOD", 1));
+            using (var corrupted = new MemoryStream(encoded))
+            {
+                corrupted.WriteByte(127);
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    codec.DecodeMethodCall(corrupted.ToArray());
+                });
+            }
+        }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
@@ -13,6 +13,12 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
     public class StandardMethodCodecTests
     {
         [Fact]
+        public void Ensures_Message_Codec_Is_Not_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StandardMethodCodec(null));
+        }
+
+        [Fact]
         public void Encodes_Correct_MethodCall()
         {
             var codec = StandardMethodCodec.Instance;

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
@@ -128,14 +128,12 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
         {
             var codec = StandardMethodCodec.Instance;
             var encoded = codec.EncodeMethodCall(new MethodCall("TEST_METHOD", 1));
-            using (var corrupted = new MemoryStream(encoded))
+            using var corrupted = new MemoryStream(encoded);
+            corrupted.WriteByte(127);
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                corrupted.WriteByte(127);
-                Assert.Throws<InvalidOperationException>(() =>
-                {
-                    codec.DecodeMethodCall(corrupted.ToArray());
-                });
-            }
+                codec.DecodeMethodCall(corrupted.ToArray());
+            });
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/StandardMethodCodecTests.cs
@@ -84,6 +84,20 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
         }
 
         [Fact]
+        public void Ensures_ErrorEnvelope_With_Null_Details()
+        {
+            var codec = StandardMethodCodec.Instance;
+            var encoded = codec.EncodeErrorEnvelope("error", "TEST_MESSAGE", null);
+            var exception = Assert.Throws<FlutterException>(() =>
+            {
+                codec.DecodeEnvelope(encoded);
+            });
+            Assert.Equal("error", exception.Code);
+            Assert.Equal("TEST_MESSAGE", exception.Message);
+            Assert.Null(exception.Details);
+        }
+
+        [Fact]
         public void Decodes_Correct_MethodCall()
         {
             var codec = StandardMethodCodec.Instance;

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMethodCodec.cs
@@ -1,0 +1,63 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// A codec for method calls and enveloped results.
+    /// </summary>
+    public interface IMethodCodec
+    {
+        /// <summary>
+        /// Encodes a message call into binary.
+        /// </summary>
+        /// <param name="methodCall">A <see cref="MethodCall"/></param>
+        /// <returns>A byte array containing the encoding.</returns>
+        byte[] EncodeMethodCall(MethodCall methodCall);
+
+        /// <summary>
+        /// Decodes a message call from binary.
+        /// </summary>
+        /// <param name="methodCall">The binary encoding of the method call as a byte array.</param>
+        /// <returns>A <see cref="MethodCall"/> representation of the bytes.</returns>
+        MethodCall DecodeMethodCall(byte[] methodCall);
+
+        /// <summary>
+        /// Encodes a successful result into a binary envelope message.
+        /// </summary>
+        /// <param name="result">The result value, possibly null.</param>
+        /// <returns>A byte array containing the encoding.</returns>
+        byte[] EncodeSuccessEnvelope(object result);
+
+        /// <summary>
+        /// Encodes an error result into a binary envelope message.
+        /// </summary>
+        /// <param name="errorCode">An error code string.</param>
+        /// <param name="errorMessage">An error message String, possibly null.</param>
+        /// <param name="errorDetails">Error details, possibly null. Consider supporting
+        /// <see cref="Exception"/>in your codec.This is the most common value passed to this field.</param>
+        /// <returns>A byte array containing the encoding.</returns>
+        byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails);
+
+        /// <summary>
+        /// Encodes an error result into a binary envelope message.
+        /// </summary>
+        /// <param name="errorCode">An error code string.</param>
+        /// <param name="errorMessage">An error message String, possibly null.</param>
+        /// <param name="errorDetails">Error details, possibly null. Consider supporting
+        /// <see cref="Exception"/>in your codec.This is the most common value passed to this field.</param>
+        /// <param name="errorStacktrace">Platform stacktrace for the error. possibly null.</param>
+        /// <returns>A byte array containing the encoding.</returns>
+        byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails, string errorStacktrace);
+
+        /// <summary>
+        /// Decodes a result envelope from binary.
+        /// </summary>
+        /// <param name="envelope">The binary encoding of a result envelope as a byte array.</param>
+        /// <returns>The enveloped result Object.</returns>
+        object DecodeEnvelope(byte[] envelope);
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodCall.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodCall.cs
@@ -1,0 +1,35 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// Command object representing a method call on a <see cref="MethodChannel"/>.
+    /// </summary>
+    public class MethodCall
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodCall"/> with the specified method name and arguments.
+        /// </summary>
+        /// <param name="method">The method name String, not null.</param>
+        /// <param name="arguments">The arguments, a value supported by the channel's message codec.</param>
+        public MethodCall(string method, object arguments)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            Arguments = arguments;
+        }
+
+        /// <summary>
+        /// The name of the called method.
+        /// </summary>
+        public string Method { get; }
+
+        /// <summary>
+        /// Arguments for the call.
+        /// </summary>
+        public object Arguments { get; }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
@@ -64,7 +64,7 @@ namespace Tizen.Flutter.Embedding
         public string Name { get; }
 
         /// <summary>
-        /// The message codec used by this channel, not null.
+        /// The method codec used by this channel, not null.
         /// </summary>
         public IMethodCodec Codec { get; }
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
@@ -134,7 +134,7 @@ namespace Tizen.Flutter.Embedding
         /// <param name="handler">A <see cref="MethodCallHandler"/>, or null to deregister.</param>
         public void SetMethodCallHandler(MethodCallHandler handler)
         {
-            BinaryMessageHandler binaryHandler = async (bytes) =>
+            async Task<byte[]> binaryHandler(byte[] bytes)
             {
                 MethodCall call = Codec.DecodeMethodCall(bytes);
                 try
@@ -149,8 +149,8 @@ namespace Tizen.Flutter.Embedding
                 {
                     return Codec.EncodeErrorEnvelope("error", e.Message, null);
                 }
-            };
-            BinaryMessenger.SetMessageHandler(Name, handler == null ? null : binaryHandler);
+            }
+            BinaryMessenger.SetMessageHandler(Name, handler == null ? null : (BinaryMessageHandler)binaryHandler);
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
@@ -1,0 +1,156 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// A handler of incoming method calls.
+    /// </summary>
+    /// <param name="call">A <see cref="MethodCall"/>.</param>
+    /// <returns>A result used for submitting the result of the call.</returns>
+    public delegate Task<object> MethodCallHandler(MethodCall call);
+
+    /// <summary>
+    /// A named channel for communicating with the Flutter application using asynchronous method calls.
+    /// </summary>
+    public class MethodChannel
+    {
+        /// <summary>
+        /// Creates a new channel associated with the specified name and the standard <see cref="IMethodCodec"/>
+        /// and the default <see cref="IBinaryMessenger"/>.
+        /// </summary>
+        /// <param name="name">A channel name string.</param>
+        public MethodChannel(string name)
+            : this(name, StandardMethodCodec.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new channel associated with the specified name and the specified <see cref="IMethodCodec"/>
+        /// and the default <see cref="IBinaryMessenger"/>.
+        /// </summary>
+        /// <param name="name">A channel name string.</param>
+        /// <param name="codec">A <see cref="IMethodCodec"/>.</param>
+        public MethodChannel(string name, IMethodCodec codec)
+            : this(name, codec, DefaultBinaryMessenger.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new channel associated with the specified name and the specified <see cref="IMethodCodec"/>
+        /// and the specified <see cref="IBinaryMessenger"/>.
+        /// </summary>
+        /// <param name="name">A channel name string.</param>
+        /// <param name="codec">A <see cref="IMethodCodec"/>.</param>
+        /// <param name="messenger">A <see cref="IBinaryMessenger"/>.</param>
+        public MethodChannel(string name, IMethodCodec codec, IBinaryMessenger messenger)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("name cannot be null or empty");
+            }
+            Name = name;
+            Codec = codec ?? throw new ArgumentNullException(nameof(codec));
+            BinaryMessenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+        }
+
+        /// <summary>
+        /// The logical channel on which communication happens, not null.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The message codec used by this channel, not null.
+        /// </summary>
+        public IMethodCodec Codec { get; }
+
+        /// <summary>
+        /// The messenger used by this channel to send messages.
+        /// </summary>
+        public IBinaryMessenger BinaryMessenger { get; }
+
+        /// <summary>
+        /// Invokes a method on this channel, expecting no result.
+        /// </summary>
+        /// <param name="method">The name string of the method.</param>
+        /// <param name="arguments">The arguments for the invocation, possibly null.</param>
+        public void InvokeMethod(string method, object arguments)
+        {
+            InvokeMethod(new MethodCall(method, arguments));
+        }
+
+        /// <summary>
+        /// Invokes a method on this channel, expecting no result.
+        /// </summary>
+        /// <param name="call">A <see cref="MethodCall"/>.</param>
+        public void InvokeMethod(MethodCall call)
+        {
+            if (call == null)
+            {
+                throw new ArgumentNullException(nameof(call));
+            }
+            BinaryMessenger.Send(Name, Codec.EncodeMethodCall(call));
+        }
+
+        /// <summary>
+        /// Invokes a method on this channel, expecting a result.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="FlutterException"/> is thrown, if the invocation failed in the Flutter application.
+        /// </remarks>
+        /// <param name="method">The name string of the method.</param>
+        /// <param name="arguments">The arguments for the invocation, possibly null.</param>
+        /// <returns>A <see cref="Task"/> that completes with a result.</returns>
+        public Task<object> InvokeMethodAsync(string method, object arguments)
+        {
+            return InvokeMethodAsync(new MethodCall(method, arguments));
+        }
+
+        /// <summary>
+        /// Invokes a method on this channel, expecting a result.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="FlutterException"/> is thrown, if the invocation failed in the Flutter application.
+        /// </remarks>
+        /// <param name="call">A <see cref="MethodCall"/>.</param>
+        /// <returns>A <see cref="Task"/> that completes with a result.</returns>
+        public async Task<object> InvokeMethodAsync(MethodCall call)
+        {
+            if (call == null)
+            {
+                throw new ArgumentNullException(nameof(call));
+            }
+            byte[] result = await BinaryMessenger.SendAsync(Name, Codec.EncodeMethodCall(call));
+            return Codec.DecodeEnvelope(result);
+        }
+
+        /// <summary>
+        /// Registers a method call handler on this channel.
+        /// </summary>
+        /// <param name="handler">A <see cref="MethodCallHandler"/>, or null to deregister.</param>
+        public void SetMethodCallHandler(MethodCallHandler handler)
+        {
+            BinaryMessageHandler binaryHandler = async (bytes) =>
+            {
+                MethodCall call = Codec.DecodeMethodCall(bytes);
+                try
+                {
+                    return Codec.EncodeSuccessEnvelope(await handler(call));
+                }
+                catch (FlutterException fe)
+                {
+                    return Codec.EncodeErrorEnvelope(fe.Code, fe.Message, fe.Details, fe.StackTrace);
+                }
+                catch (Exception e)
+                {
+                    return Codec.EncodeErrorEnvelope("error", e.Message, null);
+                }
+            };
+            BinaryMessenger.SetMessageHandler(Name, handler == null ? null : binaryHandler);
+        }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
@@ -141,13 +141,17 @@ namespace Tizen.Flutter.Embedding
                 {
                     return Codec.EncodeSuccessEnvelope(await handler(call));
                 }
-                catch (FlutterException fe)
+                catch (FlutterException e)
                 {
-                    return Codec.EncodeErrorEnvelope(fe.Code, fe.Message, fe.Details, fe.StackTrace);
+                    return Codec.EncodeErrorEnvelope(e.Code, e.Message, e.Details, e.StackTrace);
+                }
+                catch (MissingPluginException)
+                {
+                    return null;
                 }
                 catch (Exception e)
                 {
-                    return Codec.EncodeErrorEnvelope("error", e.Message, null);
+                    return Codec.EncodeErrorEnvelope("error", e.Message, null, e.StackTrace);
                 }
             }
             BinaryMessenger.SetMessageHandler(Name, handler == null ? null : (BinaryMessageHandler)binaryHandler);

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
@@ -21,17 +21,16 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// Creates a new method codec based on the specified message codec.
         /// </summary>
-        /// <param name="messageCodec"></param>
+        /// <param name="messageCodec">A specified message codec.</param>
         public StandardMethodCodec(StandardMessageCodec messageCodec)
         {
-            MessageCodec = messageCodec;
+            MessageCodec = messageCodec ?? throw new ArgumentNullException(nameof(messageCodec));
         }
 
         /// <summary>
         /// A singleton <see cref="StandardMethodCodec"/> instance created with the <see cref="StandardMessageCodec"/>.
         /// </summary>
         public static StandardMethodCodec Instance => new StandardMethodCodec(StandardMessageCodec.Instance);
-
 
         /// <summary>
         /// A <see cref="StandardMessageCodec"/>.

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
@@ -18,14 +18,24 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class StandardMethodCodec : IMethodCodec
     {
+        /// <summary>
+        /// Creates a new method codec based on the specified message codec.
+        /// </summary>
+        /// <param name="messageCodec"></param>
         public StandardMethodCodec(StandardMessageCodec messageCodec)
         {
             MessageCodec = messageCodec;
         }
 
+        /// <summary>
+        /// A singleton <see cref="StandardMethodCodec"/> instance created with the <see cref="StandardMessageCodec"/>.
+        /// </summary>
         public static StandardMethodCodec Instance => new StandardMethodCodec(StandardMessageCodec.Instance);
 
 
+        /// <summary>
+        /// A <see cref="StandardMessageCodec"/>.
+        /// </summary>
         public StandardMessageCodec MessageCodec { get; private set; }
 
         /// <InheritDoc/>

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
@@ -1,0 +1,132 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+using System.IO;
+using Tizen.Flutter.Embedding.Common;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// <see cref="IMethodCodec" /> using the Flutter standard binary encoding.
+    /// <para>
+    /// This codec is guaranteed to be compatible with the corresponding
+    /// <see href = "https://api.flutter.dev/flutter/services/StandardMethodCodec-class.html">StandardMethodCodec</see>
+    /// on the Dart side. These parts of the Flutter SDK are evolved synchronously.
+    /// </para>
+    /// </summary>
+    public class StandardMethodCodec : IMethodCodec
+    {
+        public StandardMethodCodec(StandardMessageCodec messageCodec)
+        {
+            MessageCodec = messageCodec;
+        }
+
+        public static StandardMethodCodec Instance => new StandardMethodCodec(StandardMessageCodec.Instance);
+
+
+        public StandardMessageCodec MessageCodec { get; private set; }
+
+        /// <InheritDoc/>
+        public byte[] EncodeMethodCall(MethodCall methodCall)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                MessageCodec.WriteValue(writer, methodCall.Method);
+                MessageCodec.WriteValue(writer, methodCall.Arguments);
+                return stream.ToArray();
+            }
+        }
+
+        /// <InheritDoc/>
+        public MethodCall DecodeMethodCall(byte[] methodCall)
+        {
+            using (var stream = new MemoryStream(methodCall))
+            using (var reader = new BinaryReader(stream))
+            {
+                object method = MessageCodec.ReadValue(reader);
+                object arguments = MessageCodec.ReadValue(reader);
+                if (method is String strMethod && !stream.HasRemaining())
+                {
+                    return new MethodCall(strMethod, arguments);
+                }
+                throw new ArgumentException("Method call corrupted");
+            }
+        }
+
+        /// <InheritDoc/>
+        public byte[] EncodeSuccessEnvelope(object result)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                stream.WriteByte(0);
+                MessageCodec.WriteValue(writer, result);
+                return stream.ToArray();
+            }
+        }
+
+        /// <InheritDoc/>
+        public byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails)
+        {
+            return EncodeErrorEnvelope(errorCode, errorMessage, errorDetails, null);
+        }
+
+        /// <InheritDoc/>
+        public byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails, String errorStacktrace)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                stream.WriteByte(1);
+                MessageCodec.WriteValue(writer, errorCode);
+                MessageCodec.WriteValue(writer, errorMessage);
+                if (errorDetails is Exception exception)
+                {
+                    MessageCodec.WriteValue(writer, exception.StackTrace);
+                }
+                else
+                {
+                    MessageCodec.WriteValue(writer, errorDetails);
+                }
+                if (!string.IsNullOrEmpty(errorStacktrace))
+                {
+                    MessageCodec.WriteValue(writer, errorStacktrace);
+                }
+                return stream.ToArray();
+            }
+        }
+
+        /// <InheritDoc/>
+        public object DecodeEnvelope(byte[] envelope)
+        {
+            using (var stream = new MemoryStream(envelope))
+            using (var reader = new BinaryReader(stream))
+            {
+                var flag = stream.ReadByte();
+                if (flag == 0)
+                {
+                    var result = MessageCodec.ReadValue(reader);
+                    if (stream.HasRemaining())
+                    {
+                        throw new InvalidOperationException("Envelope corrupted");
+                    }
+                    return result;
+                }
+                else if (flag == 1)
+                {
+                    object code = MessageCodec.ReadValue(reader);
+                    object message = MessageCodec.ReadValue(reader);
+                    object details = MessageCodec.ReadValue(reader);
+                    if (code is String && (message == null || message is String) && !stream.HasRemaining())
+                    {
+                        throw new FlutterException(code as string, message as string, details);
+                    }
+                }
+                throw new InvalidOperationException("Envelope corrupted");
+            }
+        }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterException.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// Thrown to indicate that a Flutter method invocation failed on the Flutter side.
+    /// </summary>
+    public class FlutterException : Exception
+    {
+        public FlutterException(string code, string message, object details) : base(message)
+        {
+            Code = code;
+            Details = details;
+        }
+
+        public string Code { get; }
+
+        public object Details { get; }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/MissingPluginException.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/MissingPluginException.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
+
+namespace Tizen.Flutter.Embedding
+{
+    /// <summary>
+    /// Thrown to indicate that a platform interaction failed to find a handling plugin.
+    /// </summary>
+    public class MissingPluginException : Exception
+    {
+        public MissingPluginException() : base()
+        {
+        }
+
+        public MissingPluginException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- #127
- Add `MethodChannel`, `StandardMethodCodec` and related classes
- Add tests for the added classes

#### Usage
```c#
            var channel = new MethodChannel("test_method_channel");
            channel.SetMethodCallHandler(async (call) =>
            {
                if (call.Method == "method1")
                {
                    // handle the "method1" method and return a result
                    return new ArrayList() { 1, "TEST_STRING", true };
                }
                return null;
            });
```