### PR TITLE
Rewire all Dart entry points in generated_main.dart

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  analyzer:
   archive:
   flutter_tools:
     path: flutter/packages/flutter_tools


### PR DESCRIPTION
This change relands https://github.com/flutter-tizen/flutter-tizen/pull/228 which has been reverted by https://github.com/flutter-tizen/flutter-tizen/pull/249, because exported entry points are tree-shaken and in turn discarded in release builds. i.e. `export '{{mainImport}}'` only works for debug builds.

The issue can be reproduced with the tizen_app_control example app in [plugins](https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control).
```
$ flutter-tizen run --release
...
Flutter run key commands.
h List all available interactive commands.
c Clear the screen
q Quit (terminate the application on the device).

E/ConsoleMessage(21086): [ERROR:flutter/shell/common/shell.cc(93)] Dart Unhandled Exception: NoSuchMethodError: No top-level getter 'serviceMain' declared.
E/ConsoleMessage(21086): Receiver: top-level
E/ConsoleMessage(21086): Tried calling: serviceMain, stack trace: #0      NoSuchMethodError._throwNew (dart:core-patch/errors_patch.dart:214)
E/ConsoleMessage(21086):
E/ConsoleMessage(21086): [ERROR:flutter/runtime/dart_isolate.cc(707)] Could not resolve main entrypoint function.
E/ConsoleMessage(21086): [ERROR:flutter/runtime/dart_isolate.cc(191)] Could not run the run main Dart entrypoint.
E/ConsoleMessage(21086): [ERROR:flutter/runtime/runtime_controller.cc(382)] Could not create root isolate.
E/ConsoleMessage(21086): [ERROR:flutter/shell/common/shell.cc(576)] Could not launch engine with configuration.
```

The same issue has been reported by https://github.com/flutter/flutter/issues/91841#issuecomment-949285756 and this change may be reverted again in the future according their solution.