### PR TITLE
Replace git restore with git checkout

### DIFF
--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -224,11 +224,11 @@ class TizenCreateCommand extends CreateCommand {
 
   void _runGitClean(Directory directory) {
     ProcessResult result = globals.processManager.runSync(
-      <String>['git', 'restore', '.'],
+      <String>['git', 'checkout', '--', '.'],
       workingDirectory: directory.path,
     );
     if (result.exitCode != 0) {
-      throwToolExit('Failed to run git restore: ${result.stderr}');
+      throwToolExit('Failed to run git checkout: ${result.stderr}');
     }
     result = globals.processManager.runSync(
       <String>['git', 'clean', '-df', '.'],


### PR DESCRIPTION
The `git restore` command requires Git 2.23 and is not generally available on some old Linux distributions.

Reported by @haesik.