### PR TITLE
Unsupport the custom-devices command

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1,6 +1,6 @@
 # Supported commands
 
-Not all commands from the [`flutter`](https://flutter.dev/docs/reference/flutter-cli) CLI are supported by `flutter-tizen`.
+The following commands from the [Flutter CLI](https://flutter.dev/docs/reference/flutter-cli) are supported by flutter-tizen.
 
 ## Global options
 
@@ -78,14 +78,6 @@ Not all commands from the [`flutter`](https://flutter.dev/docs/reference/flutter
 
   # Create a new plugin project in "plugin_name" directory.
   flutter-tizen create --platforms tizen --template plugin plugin_name
-  ```
-
-- ### `custom-devices`
-
-  List, reset, add and delete custom devices, such as [flutter-pi](https://github.com/ardera/flutter-pi) devices.
-
-  ```sh
-  flutter-tizen custom-devices list
   ```
 
 - ### `devices`
@@ -224,3 +216,16 @@ Not all commands from the [`flutter`](https://flutter.dev/docs/reference/flutter
   # Run all integration tests in "integration_test" directory.
   flutter-tizen test integration_test
   ```
+
+## Not supported
+
+The following commands from the Flutter CLI are not supported by flutter-tizen.
+
+- `assemble`
+- `attach`
+- `bash-completion`
+- `channel`
+- `custom-devices`
+- `downgrade`
+- `logs`
+- `upgrade`

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -18,7 +18,6 @@ import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/commands/config.dart';
-import 'package:flutter_tools/src/commands/custom_devices.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
@@ -103,16 +102,6 @@ Future<void> main(List<String> args) async {
         artifacts: globals.artifacts,
       ),
       ConfigCommand(verboseHelp: verboseHelp),
-      CustomDevicesCommand(
-        customDevicesConfig: globals.customDevicesConfig,
-        operatingSystemUtils: globals.os,
-        terminal: globals.terminal,
-        platform: globals.platform,
-        featureFlags: featureFlags,
-        processManager: globals.processManager,
-        fileSystem: globals.fs,
-        logger: globals.logger,
-      ),
       DaemonCommand(hidden: !verboseHelp),
       DevicesCommand(verboseHelp: verboseHelp),
       DoctorCommand(verbose: verbose),


### PR DESCRIPTION
The command is not relevant for Tizen app development.