### PR TITLE
Migrate tizen_device_discovery.dart to null safety

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -50,7 +50,7 @@ import 'commands/test.dart';
 import 'tizen_application_package.dart';
 import 'tizen_builder.dart';
 import 'tizen_cache.dart';
-import 'tizen_device_discovery.dart';
+import 'tizen_device_manager.dart';
 import 'tizen_doctor.dart';
 import 'tizen_emulator.dart';
 import 'tizen_osutils.dart';

--- a/lib/tizen_device_discovery.dart
+++ b/lib/tizen_device_discovery.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:convert';
 import 'dart:io';
 
@@ -14,7 +12,6 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'tizen_device.dart';
@@ -26,11 +23,13 @@ import 'tizen_sdk.dart';
 /// Source: [AndroidDevices] in `android_device_discovery.dart`
 class TizenDeviceDiscovery extends PollingDeviceDiscovery {
   TizenDeviceDiscovery({
-    @required TizenWorkflow tizenWorkflow,
-    @required Logger logger,
-    @required FileSystem fileSystem,
-    @required ProcessManager processManager,
-  })  : _tizenWorkflow = tizenWorkflow,
+    required TizenSdk? tizenSdk,
+    required TizenWorkflow tizenWorkflow,
+    required Logger logger,
+    required FileSystem fileSystem,
+    required ProcessManager processManager,
+  })  : _tizenSdk = tizenSdk,
+        _tizenWorkflow = tizenWorkflow,
         _logger = logger,
         _fileSystem = fileSystem,
         _processManager = processManager,
@@ -38,6 +37,7 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
             ProcessUtils(logger: logger, processManager: processManager),
         super('Tizen devices');
 
+  final TizenSdk? _tizenSdk;
   final TizenWorkflow _tizenWorkflow;
   final Logger _logger;
   final FileSystem _fileSystem;
@@ -53,19 +53,17 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
   final RegExp _splitPattern = RegExp(r'\s{2,}|\t');
 
   @override
-  Future<List<Device>> pollingGetDevices({Duration timeout}) async {
-    if (tizenSdk == null || !tizenSdk.sdb.existsSync()) {
+  Future<List<Device>> pollingGetDevices({Duration? timeout}) async {
+    if (_tizenSdk == null || !_tizenSdk!.sdb.existsSync()) {
       return <TizenDevice>[];
     }
 
-    String stdout;
-    try {
-      final RunResult result = await _processUtils
-          .run(<String>[tizenSdk.sdb.path, 'devices'], throwOnError: true);
-      stdout = result.stdout.trim();
-    } on ProcessException catch (ex) {
-      throwToolExit('sdb failed to list attached devices:\n$ex');
+    final RunResult result =
+        await _processUtils.run(<String>[_tizenSdk!.sdb.path, 'devices']);
+    if (result.exitCode != 0) {
+      throwToolExit('sdb failed to list attached devices:\n$result');
     }
+    final String stdout = result.stdout.trim();
 
     final List<TizenDevice> devices = <TizenDevice>[];
     for (final String line in LineSplitter.split(stdout)) {
@@ -91,7 +89,7 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
         modelId: deviceModel,
         logger: _logger,
         processManager: _processManager,
-        tizenSdk: tizenSdk,
+        tizenSdk: _tizenSdk!,
         fileSystem: _fileSystem,
       );
 
@@ -111,12 +109,12 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async {
-    if (tizenSdk == null) {
+    if (_tizenSdk == null) {
       return <String>[];
     }
 
     final RunResult result =
-        await _processUtils.run(<String>[tizenSdk.sdb.path, 'devices']);
+        await _processUtils.run(<String>[_tizenSdk!.sdb.path, 'devices']);
     if (result.exitCode != 0) {
       return <String>[];
     }
@@ -139,8 +137,7 @@ class TizenDeviceDiscovery extends PollingDeviceDiscovery {
       final List<String> splitLine = line.split(_splitPattern);
       if (splitLine.length != 3) {
         messages.add(
-          'Unexpected failure parsing device information from sdb output:\n$line',
-        );
+            'Unexpected failure parsing device information from sdb output:\n$line');
         continue;
       }
 

--- a/lib/tizen_device_discovery.dart
+++ b/lib/tizen_device_discovery.dart
@@ -10,82 +10,16 @@ import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/android/android_device_discovery.dart';
-import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/common.dart';
-import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
-import 'package:flutter_tools/src/context_runner.dart';
-import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/flutter_device_manager.dart';
-import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/macos/macos_workflow.dart';
-import 'package:flutter_tools/src/windows/uwptool.dart';
-import 'package:flutter_tools/src/windows/windows_workflow.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'tizen_device.dart';
 import 'tizen_doctor.dart';
 import 'tizen_sdk.dart';
-
-/// An extended [FlutterDeviceManager] for managing Tizen devices.
-class TizenDeviceManager extends FlutterDeviceManager {
-  /// See: [runInContext] in `context_runner.dart`
-  TizenDeviceManager({
-    @required Logger logger,
-    @required FileSystem fileSystem,
-    @required Platform platform,
-    @required ProcessManager processManager,
-  })  : _tizenDeviceDiscovery = TizenDeviceDiscovery(
-          tizenWorkflow: tizenWorkflow,
-          logger: logger,
-          fileSystem: fileSystem,
-          processManager: processManager,
-        ),
-        super(
-          logger: logger,
-          processManager: processManager,
-          platform: platform,
-          androidSdk: globals.androidSdk,
-          iosSimulatorUtils: globals.iosSimulatorUtils,
-          featureFlags: featureFlags,
-          fileSystem: fileSystem,
-          iosWorkflow: globals.iosWorkflow,
-          artifacts: globals.artifacts,
-          flutterVersion: globals.flutterVersion,
-          androidWorkflow: androidWorkflow,
-          fuchsiaWorkflow: fuchsiaWorkflow,
-          xcDevice: globals.xcdevice,
-          userMessages: globals.userMessages,
-          windowsWorkflow: windowsWorkflow,
-          macOSWorkflow: context.get<MacOSWorkflow>(),
-          operatingSystemUtils: globals.os,
-          terminal: globals.terminal,
-          customDevicesConfig: CustomDevicesConfig(
-            fileSystem: fileSystem,
-            logger: logger,
-            platform: platform,
-          ),
-          uwptool: UwpTool(
-            artifacts: globals.artifacts,
-            logger: globals.logger,
-            processManager: globals.processManager,
-          ),
-        );
-
-  final TizenDeviceDiscovery _tizenDeviceDiscovery;
-
-  @override
-  List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[
-        ...super.deviceDiscoverers,
-        _tizenDeviceDiscovery,
-      ];
-}
 
 /// Device discovery for Tizen devices.
 ///

--- a/lib/tizen_device_manager.dart
+++ b/lib/tizen_device_manager.dart
@@ -1,0 +1,80 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/context_runner.dart';
+import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/flutter_device_manager.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/macos/macos_workflow.dart';
+import 'package:flutter_tools/src/windows/uwptool.dart';
+import 'package:flutter_tools/src/windows/windows_workflow.dart';
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+import 'tizen_device_discovery.dart';
+import 'tizen_doctor.dart';
+
+/// An extended [FlutterDeviceManager] for managing Tizen devices.
+class TizenDeviceManager extends FlutterDeviceManager {
+  /// See: [runInContext] in `context_runner.dart`
+  TizenDeviceManager({
+    @required Logger logger,
+    @required FileSystem fileSystem,
+    @required Platform platform,
+    @required ProcessManager processManager,
+  })  : _tizenDeviceDiscovery = TizenDeviceDiscovery(
+          tizenWorkflow: tizenWorkflow,
+          logger: logger,
+          fileSystem: fileSystem,
+          processManager: processManager,
+        ),
+        super(
+          logger: logger,
+          processManager: processManager,
+          platform: platform,
+          androidSdk: globals.androidSdk,
+          iosSimulatorUtils: globals.iosSimulatorUtils,
+          featureFlags: featureFlags,
+          fileSystem: fileSystem,
+          iosWorkflow: globals.iosWorkflow,
+          artifacts: globals.artifacts,
+          flutterVersion: globals.flutterVersion,
+          androidWorkflow: androidWorkflow,
+          fuchsiaWorkflow: fuchsiaWorkflow,
+          xcDevice: globals.xcdevice,
+          userMessages: globals.userMessages,
+          windowsWorkflow: windowsWorkflow,
+          macOSWorkflow: context.get<MacOSWorkflow>(),
+          operatingSystemUtils: globals.os,
+          terminal: globals.terminal,
+          customDevicesConfig: CustomDevicesConfig(
+            fileSystem: fileSystem,
+            logger: logger,
+            platform: platform,
+          ),
+          uwptool: UwpTool(
+            artifacts: globals.artifacts,
+            logger: globals.logger,
+            processManager: globals.processManager,
+          ),
+        );
+
+  final TizenDeviceDiscovery _tizenDeviceDiscovery;
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[
+        ...super.deviceDiscoverers,
+        _tizenDeviceDiscovery,
+      ];
+}

--- a/lib/tizen_device_manager.dart
+++ b/lib/tizen_device_manager.dart
@@ -24,6 +24,7 @@ import 'package:process/process.dart';
 
 import 'tizen_device_discovery.dart';
 import 'tizen_doctor.dart';
+import 'tizen_sdk.dart';
 
 /// An extended [FlutterDeviceManager] for managing Tizen devices.
 class TizenDeviceManager extends FlutterDeviceManager {
@@ -34,6 +35,7 @@ class TizenDeviceManager extends FlutterDeviceManager {
     @required Platform platform,
     @required ProcessManager processManager,
   })  : _tizenDeviceDiscovery = TizenDeviceDiscovery(
+          tizenSdk: tizenSdk,
           tizenWorkflow: tizenWorkflow,
           logger: logger,
           fileSystem: fileSystem,


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/flutter-tizen/issues/286.

`TizenDeviceManager` cannot be migrated to null safety right now so has been moved to a new file `tizen_device_manager.dart`.