### PR TITLE
Add tests for tizen_sdk.dart and organize plguins_test.dart

### DIFF
--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -144,9 +144,7 @@ class TizenEmulatorManager extends EmulatorManager {
         if (!infoFile.existsSync()) {
           continue;
         }
-        final Map<String, String> info =
-            // ignore: invalid_use_of_visible_for_testing_member
-            parseIniLines(infoFile.readAsLinesSync());
+        final Map<String, String> info = parseIniFile(infoFile);
         if (info.containsKey('name') &&
             info.containsKey('profile') &&
             info.containsKey('version')) {

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
@@ -78,8 +76,7 @@ class TizenSdk {
         'The sdk.info file could not be found. Tizen Studio is out of date or corrupted.',
       );
     }
-    // ignore: invalid_use_of_visible_for_testing_member
-    final Map<String, String> info = parseIniLines(sdkInfo.readAsLinesSync());
+    final Map<String, String> info = parseIniFile(sdkInfo);
     if (info.containsKey('TIZEN_SDK_DATA_PATH')) {
       return globals.fs.directory(info['TIZEN_SDK_DATA_PATH']);
     }
@@ -94,9 +91,7 @@ class TizenSdk {
     if (!versionFile.existsSync()) {
       return null;
     }
-    final Map<String, String> info =
-        // ignore: invalid_use_of_visible_for_testing_member
-        parseIniLines(versionFile.readAsLinesSync());
+    final Map<String, String> info = parseIniFile(versionFile);
     if (info.containsKey('TIZEN_SDK_VERSION')) {
       return info['TIZEN_SDK_VERSION'];
     }
@@ -433,4 +428,21 @@ class SecurityProfiles {
   final String? active;
 
   bool contains(String name) => profiles.contains(name);
+}
+
+Map<String, String> parseIniFile(File file) {
+  final Map<String, String> result = <String, String>{};
+  if (file.existsSync()) {
+    for (String line in file.readAsLinesSync()) {
+      line = line.trim();
+      if (line.isEmpty || line.startsWith('#') || !line.contains('=')) {
+        continue;
+      }
+      final int splitIndex = line.indexOf('=');
+      final String name = line.substring(0, splitIndex).trim();
+      final String value = line.substring(splitIndex + 1).trim();
+      result[name] = value;
+    }
+  }
+  return result;
 }

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -52,12 +52,17 @@ flutter:
         pluginClass: SomeNativePlugin
         fileName: some_native_plugin.h
 ''');
-    pluginDir.childFile('tizen/project_def.prop').createSync(recursive: true);
+    pluginDir.childFile('tizen/project_def.prop')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+APPNAME = some_native_plugin
+type = staticLib
+''');
     pluginDir
         .childFile('tizen/inc/some_native_plugin.h')
         .createSync(recursive: true);
 
-    projectDir = fileSystem.directory('/project');
+    projectDir = fileSystem.directory('/flutter_project');
     projectDir.childFile('pubspec.yaml')
       ..createSync(recursive: true)
       ..writeAsStringSync('''
@@ -111,42 +116,6 @@ dependencies:
       processManager: processManager,
     );
 
-    processManager.addCommand(FakeCommand(
-      command: _tizenBuildCommand(
-        'Debug',
-        'x86',
-        '/.tmp_rand0/rand0',
-        predefine: 'WEARABLE_PROFILE',
-        extraOptions: <String>[
-          '-fPIC',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include"',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
-        ],
-      ),
-      onRun: () {
-        fileSystem
-            .file('/.tmp_rand0/rand0/Debug/libsome_native_plugin.a')
-            .createSync(recursive: true);
-      },
-    ));
-    processManager.addCommand(FakeCommand(
-      command: _tizenBuildCommand(
-        'Debug',
-        'x86',
-        '/.tmp_rand0/rand1',
-        extraOptions: <String>[
-          '-lflutter_tizen_wearable',
-          '-L"cache/bin/cache/artifacts/engine/tizen-x86-debug"',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
-          '-L"/project/build/2ca1f4ebdc59348ffdc31d97a51a98d5/tizen_plugins/lib"',
-          '-Wl,--undefined=SomeNativePluginRegisterWithRegistrar',
-        ],
-      ),
-      onRun: () => fileSystem
-          .file('/.tmp_rand0/rand1/Debug/libflutter_plugins.so')
-          .createSync(recursive: true),
-    ));
-
     await NativePlugins(const TizenBuildInfo(
       BuildInfo.debug,
       targetArch: 'x86',
@@ -156,12 +125,15 @@ dependencies:
     final File outputLib =
         environment.buildDir.childFile('tizen_plugins/libflutter_plugins.so');
     expect(outputLib, exists);
-    expect(processManager, hasNoRemainingExpectations);
+
+    final File header = environment.buildDir
+        .childFile('tizen_plugins/include/some_native_plugin.h');
+    expect(header, exists);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Cache: () => cache,
-    TizenSdk: () => FakeTizenSdk(fileSystem, processManager: processManager),
+    TizenSdk: () => FakeTizenSdk(fileSystem),
   });
 
   testUsingContext('Can link to user libraries', () async {
@@ -172,45 +144,8 @@ dependencies:
       artifacts: artifacts,
       processManager: processManager,
     );
-
     pluginDir.childFile('tizen/lib/libstatic.a').createSync(recursive: true);
     pluginDir.childFile('tizen/lib/libshared.so').createSync(recursive: true);
-
-    processManager.addCommand(FakeCommand(
-      command: _tizenBuildCommand(
-        'Release',
-        'arm',
-        '/.tmp_rand0/rand0',
-        predefine: 'COMMON_PROFILE',
-        extraOptions: <String>[
-          '-fPIC',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include"',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
-        ],
-      ),
-      onRun: () {
-        fileSystem
-            .file('/.tmp_rand0/rand0/Release/libsome_native_plugin.a')
-            .createSync(recursive: true);
-      },
-    ));
-    processManager.addCommand(FakeCommand(
-      command: _tizenBuildCommand(
-        'Release',
-        'arm',
-        '/.tmp_rand0/rand1',
-        extraOptions: <String>[
-          '-lflutter_tizen_common',
-          '-L"cache/bin/cache/artifacts/engine/tizen-arm-release"',
-          '-I"cache/bin/cache/artifacts/engine/tizen-common/public"',
-          '-L"/project/build/2ca1f4ebdc59348ffdc31d97a51a98d5/tizen_plugins/lib"',
-          '-Wl,--undefined=SomeNativePluginRegisterWithRegistrar',
-        ],
-      ),
-      onRun: () => fileSystem
-          .file('/.tmp_rand0/rand1/Release/libflutter_plugins.so')
-          .createSync(recursive: true),
-    ));
 
     await NativePlugins(const TizenBuildInfo(
       BuildInfo.release,
@@ -220,42 +155,19 @@ dependencies:
 
     final Directory rootDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    expect(
-      rootDir.childFile('project_def.prop').readAsStringSync(),
-      contains('USER_LIBS = pthread some_native_plugin static shared'),
-    );
     expect(rootDir.childFile('lib/libstatic.a'), isNot(exists));
     expect(rootDir.childFile('lib/libshared.so'), exists);
-    expect(processManager, hasNoRemainingExpectations);
+
+    final Map<String, String> projectDef =
+        parseIniFile(rootDir.childFile('project_def.prop'));
+    expect(
+      projectDef['USER_LIBS'],
+      contains('some_native_plugin static shared'),
+    );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
     Cache: () => cache,
-    TizenSdk: () => FakeTizenSdk(fileSystem, processManager: processManager),
+    TizenSdk: () => FakeTizenSdk(fileSystem),
   });
-}
-
-List<String> _tizenBuildCommand(
-  String buildMode,
-  String arch,
-  String workingDir, {
-  String predefine,
-  List<String> extraOptions,
-}) {
-  return <String>[
-    '/tizen-studio/tools/ide/bin/tizen',
-    'build-native',
-    '-C',
-    buildMode,
-    '-a',
-    arch,
-    '-c',
-    'llvm-10.0',
-    if (predefine != null) ...<String>['-d', predefine],
-    if (extraOptions.isNotEmpty) ...<String>['-e', extraOptions.join(' ')],
-    '-r',
-    'rootstrap',
-    '--',
-    workingDir,
-  ];
 }

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -1,0 +1,118 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_process_manager.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  FakeProcessManager processManager;
+  TizenSdk tizenSdk;
+  Directory projectDir;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.empty();
+    tizenSdk = TizenSdk(
+      fileSystem.directory('/tizen-studio'),
+      logger: BufferLogger.test(),
+      platform: FakePlatform(),
+      processManager: processManager,
+    );
+    projectDir = fileSystem.currentDirectory;
+  });
+
+  testWithoutContext('Build native app', () async {
+    processManager.addCommand(FakeCommand(
+      command: <String>[
+        '/tizen-studio/tools/ide/bin/tizen',
+        'build-app',
+        '-b',
+        'name: "test_build", methods: ["test_method"], targets: ["test_target"]',
+        '-m',
+        'name: "test_method", configs: ["Debug"], compiler: "test_compiler", predefines: ["ABC"], extraoption: ["def", "ghi"], rootstraps: [{name: "test_rootstrap", arch: "arm"}]',
+        '-o',
+        'output',
+        '-p',
+        'name: "test_package", targets: ["test_build"]',
+        '-s',
+        'test_profile',
+        '--',
+        projectDir.path,
+      ],
+    ));
+
+    await tizenSdk.buildApp(
+      projectDir.path,
+      build: <String, Object>{
+        'name': 'test_build',
+        'methods': <String>['test_method'],
+        'targets': <String>['test_target'],
+      },
+      method: <String, Object>{
+        'name': 'test_method',
+        'configs': <String>['Debug'],
+        'compiler': 'test_compiler',
+        'predefines': <String>['ABC'],
+        'extraoption': <String>['def', 'ghi'],
+        'rootstraps': <Map<String, String>>[
+          <String, String>{'name': 'test_rootstrap', 'arch': 'arm'},
+        ],
+      },
+      output: 'output',
+      package: <String, Object>{
+        'name': 'test_package',
+        'targets': <String>['test_build'],
+      },
+      sign: 'test_profile',
+    );
+
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testWithoutContext('Build native library', () async {
+    processManager.addCommand(FakeCommand(
+      command: <String>[
+        '/tizen-studio/tools/ide/bin/tizen',
+        'build-native',
+        '-C',
+        'Debug',
+        '-a',
+        'arm',
+        '-c',
+        'test_compiler',
+        '-d',
+        'ABC',
+        '-e',
+        'def ghi',
+        '-r',
+        'test_rootstrap',
+        '--',
+        projectDir.path,
+      ],
+    ));
+
+    await tizenSdk.buildNative(
+      projectDir.path,
+      configuration: 'Debug',
+      arch: 'arm',
+      compiler: 'test_compiler',
+      predefines: <String>['ABC'],
+      extraOptions: <String>['def', 'ghi'],
+      rootstrap: 'test_rootstrap',
+    );
+
+    expect(processManager, hasNoRemainingExpectations);
+  });
+}

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -18,22 +18,24 @@ import '../src/test_flutter_command_runner.dart';
 void main() {
   FileSystem fileSystem;
   FakeProcessManager processManager;
-  TizenSdk tizenSdk;
   Directory projectDir;
+  TizenSdk tizenSdk;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     processManager = FakeProcessManager.empty();
+    projectDir = fileSystem.currentDirectory;
+
     tizenSdk = TizenSdk(
       fileSystem.directory('/tizen-studio'),
       logger: BufferLogger.test(),
       platform: FakePlatform(),
       processManager: processManager,
     );
-    projectDir = fileSystem.currentDirectory;
   });
 
-  testWithoutContext('Build native app', () async {
+  testWithoutContext('TizenSdk.buildApp invokes the build-app command',
+      () async {
     processManager.addCommand(FakeCommand(
       command: <String>[
         '/tizen-studio/tools/ide/bin/tizen',
@@ -81,7 +83,8 @@ void main() {
     expect(processManager, hasNoRemainingExpectations);
   });
 
-  testWithoutContext('Build native library', () async {
+  testWithoutContext('TizenSdk.buildNative invokes the build-native command',
+      () async {
     processManager.addCommand(FakeCommand(
       command: <String>[
         '/tizen-studio/tools/ide/bin/tizen',
@@ -114,5 +117,21 @@ void main() {
     );
 
     expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testWithoutContext('parseIniFile can parse properties from file', () async {
+    final File file = fileSystem.file('test_file.ini');
+    file.writeAsStringSync('''
+AAA=aaa
+ BBB = bbb
+CCC=ccc=ccc
+#DDD=ddd
+''');
+    final Map<String, String> properties = parseIniFile(file);
+
+    expect(properties['AAA'], equals('aaa'));
+    expect(properties['BBB'], equals('bbb'));
+    expect(properties['CCC'], equals('ccc=ccc'));
+    expect(properties['DDD'], isNull);
   });
 }


### PR DESCRIPTION
- Implement `parseIniFile` as a replacement for `parseIniLines` to avoid linter warnings.
- Add `tizen_sdk_test.dart` and simplify `plguins_test.dart` in favor of it. (More tests will be added to `tizen_sdk_test.dart` later.)
- `FakeTizenSdk.buildNative` generates a dummy output lib based on the project's `project_def.prop`.