### PR TITLE
Remove temporary workarounds in plugins.dart

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -226,7 +226,7 @@ class NativeTpk extends Package {
     );
 
     final BuildMode buildMode = buildInfo.buildInfo.mode;
-    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    final String buildConfig = getBuildConfig(buildMode);
     final Directory engineDir =
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -103,7 +103,7 @@ class NativePlugins extends Target {
       ..createSync(recursive: true);
 
     final BuildMode buildMode = buildInfo.buildInfo.mode;
-    final String buildConfig = buildMode.isPrecompiled ? 'Release' : 'Debug';
+    final String buildConfig = getBuildConfig(buildMode);
     final Directory engineDir =
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -46,6 +46,19 @@ class NativePlugins extends Target {
   @override
   List<Target> get dependencies => const <Target>[];
 
+  void _checkProjectType(TizenPlugin plugin) {
+    final Map<String, String> properties = parseIniFile(plugin.projectFile);
+    final String? type = properties['type'];
+    if (type != 'staticLib') {
+      throwToolExit(
+        'The project type of ${plugin.name} is "$type" which is not supported.\n'
+        'Make sure the package is up to date by running "flutter-tizen pub upgrade".\n\n'
+        'If you are the maintainer of the ${plugin.name} package, consider migrating the project to "staticLib" type.\n'
+        'Otherwise, you may modify the value of "type" in ${plugin.projectFile.path} to temporarily fix the problem.',
+      );
+    }
+  }
+
   @override
   Future<void> build(Environment environment) async {
     final List<File> inputs = <File>[];
@@ -110,6 +123,7 @@ class NativePlugins extends Target {
     final List<String> pluginClasses = <String>[];
 
     for (final TizenPlugin plugin in nativePlugins) {
+      _checkProjectType(plugin);
       inputs.add(plugin.projectFile);
 
       final Directory buildDir = plugin.directory.childDirectory(buildConfig);

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -25,6 +25,10 @@ extension PathUtils on String {
   }
 }
 
+String getBuildConfig(BuildMode buildMode) {
+  return buildMode == BuildMode.debug ? 'Debug' : 'Release';
+}
+
 /// See: [CachedArtifacts._getEngineArtifactsPath]
 Directory getEngineArtifactsDirectory(String arch, BuildMode mode) {
   return globals.cache

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -67,16 +67,6 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
   final String? dartPluginClass;
   final String? fileName;
 
-  TizenPlugin copyWith({Directory? directory}) {
-    return TizenPlugin(
-      name: name,
-      directory: directory ?? this.directory,
-      pluginClass: pluginClass,
-      dartPluginClass: dartPluginClass,
-      fileName: fileName,
-    );
-  }
-
   @override
   bool isNative() => pluginClass != null;
 

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -170,4 +170,31 @@ dependencies:
     Cache: () => cache,
     TizenSdk: () => FakeTizenSdk(fileSystem),
   });
+
+  testUsingContext('Building non-staticLib project fails', () async {
+    final Environment environment = Environment.test(
+      projectDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+    final File projectDef = pluginDir.childFile('tizen/project_def.prop');
+    projectDef.writeAsStringSync(
+        projectDef.readAsStringSync().replaceFirst('staticLib', 'sharedLib'));
+
+    await expectLater(
+      () => NativePlugins(const TizenBuildInfo(
+        BuildInfo.release,
+        targetArch: 'arm',
+        deviceProfile: 'common',
+      )).build(environment),
+      throwsToolExit(),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Cache: () => cache,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+  });
 }


### PR DESCRIPTION
- Revert https://github.com/flutter-tizen/flutter-tizen/pull/125, because the limitation has been relieved by https://github.com/flutter-tizen/flutter-tizen/pull/195 and the workaround is no longer necessary.
- Remove support for `sharedLib` plugin projects completely. The `sharedLib` project type has been deprecated for a while since https://github.com/flutter-tizen/flutter-tizen/pull/195 and it's time to remove support for it.

This change makes plugin code easily debuggable in VS Code (https://github.com/flutter-tizen/plugins/issues/295#issuecomment-999292257).