### PR TITLE
Minor cleanups for tizen_device.dart

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -64,8 +64,7 @@ class TizenDevice extends Device {
   DeviceLogReader? _logReader;
   DevicePortForwarder? _portForwarder;
 
-  /// Source: [AndroidDevice.adbCommandForDevice] in `android_device.dart`
-  List<String> sdbCommand(List<String> args) {
+  List<String> _sdbCommand(List<String> args) {
     return <String>[_tizenSdk.sdb.path, '-s', id, ...args];
   }
 
@@ -73,7 +72,7 @@ class TizenDevice extends Device {
     List<String> params, {
     bool checked = true,
   }) {
-    return _processUtils.runSync(sdbCommand(params), throwOnError: checked);
+    return _processUtils.runSync(_sdbCommand(params), throwOnError: checked);
   }
 
   /// See: [AndroidDevice.runAdbCheckedAsync] in `android_device.dart`
@@ -81,7 +80,7 @@ class TizenDevice extends Device {
     List<String> params, {
     bool checked = true,
   }) async {
-    return _processUtils.run(sdbCommand(params), throwOnError: checked);
+    return _processUtils.run(_sdbCommand(params), throwOnError: checked);
   }
 
   String getCapability(String name) {
@@ -256,13 +255,13 @@ class TizenDevice extends Device {
       return false;
     }
 
-    final Version? deviceVersion = Version.parse(_platformVersion);
+    final Version? platformVersion = Version.parse(_platformVersion);
     final Version? apiVersion = Version.parse(app.manifest.apiVersion);
-    if (deviceVersion != null &&
+    if (platformVersion != null &&
         apiVersion != null &&
-        apiVersion > deviceVersion) {
+        apiVersion > platformVersion) {
       _logger.printStatus(
-        'Warning: The package API version ($apiVersion) is greater than the device API version ($deviceVersion).\n'
+        'Warning: The package API version ($apiVersion) is greater than the device API version ($platformVersion).\n'
         'Check "tizen-manifest.xml" of your Tizen project to fix this problem.',
         color: TerminalColor.yellow,
       );
@@ -301,6 +300,21 @@ class TizenDevice extends Device {
       return false;
     }
     return true;
+  }
+
+  Future<void> _writeEngineArguments(
+    List<String> arguments,
+    String filename,
+  ) async {
+    final File localFile =
+        _fileSystem.systemTempDirectory.createTempSync().childFile(filename);
+    localFile.writeAsStringSync(arguments.join('\n'));
+    final String remotePath = '/home/owner/share/tmp/sdk_tools/$filename';
+    final RunResult result =
+        await runSdbAsync(<String>['push', localFile.path, remotePath]);
+    if (!result.stdout.contains('file(s) pushed')) {
+      _logger.printError('Failed to push a file: $result');
+    }
   }
 
   /// Source: [AndroidDevice.startApp] in `android_device.dart`
@@ -454,21 +468,6 @@ class TizenDevice extends Device {
     }
   }
 
-  Future<void> _writeEngineArguments(
-    List<String> arguments,
-    String filename,
-  ) async {
-    final File localFile =
-        _fileSystem.systemTempDirectory.createTempSync().childFile(filename);
-    localFile.writeAsStringSync(arguments.join('\n'));
-    final String remotePath = '/home/owner/share/tmp/sdk_tools/$filename';
-    final RunResult result =
-        await runSdbAsync(<String>['push', localFile.path, remotePath]);
-    if (!result.stdout.contains('file(s) pushed')) {
-      _logger.printError('Failed to push a file: $result');
-    }
-  }
-
   @override
   Future<bool> stopApp(TizenTpk app, {String? userIdentifier}) async {
     try {
@@ -519,16 +518,16 @@ class TizenDevice extends Device {
 
   @override
   bool isSupported() {
-    final Version? deviceVersion = Version.parse(_platformVersion);
-    if (deviceVersion == null) {
+    final Version? platformVersion = Version.parse(_platformVersion);
+    if (platformVersion == null) {
       return false;
     }
     if (deviceProfile == 'wearable') {
-      return deviceVersion >= Version(4, 0, 0);
+      return platformVersion >= Version(4, 0, 0);
     } else if (deviceProfile == 'tv') {
-      return deviceVersion >= Version(6, 0, 0);
+      return platformVersion >= Version(6, 0, 0);
     }
-    return deviceVersion >= Version(5, 5, 0);
+    return platformVersion >= Version(5, 5, 0);
   }
 
   @override

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -128,7 +128,7 @@ class TizenDevice extends Device {
     }
   }
 
-  String get _platformVersion {
+  late final String _platformVersion = () {
     final String version = getCapability('platform_version');
 
     // Truncate if the version string has more than 3 segments.
@@ -137,7 +137,7 @@ class TizenDevice extends Device {
       return segments.sublist(0, 3).join('.');
     }
     return version;
-  }
+  }();
 
   @override
   Future<String> get sdkNameAndVersion async => 'Tizen $_platformVersion';
@@ -149,7 +149,7 @@ class TizenDevice extends Device {
 
   bool get usesSecureProtocol => getCapability('secure_protocol') == 'enabled';
 
-  String get architecture {
+  late final String architecture = () {
     final String cpuArch = getCapability('cpu_arch');
     if (_isLocalEmulator) {
       return cpuArch;
@@ -163,7 +163,7 @@ class TizenDevice extends Device {
           runSdbSync(<String>['shell', 'ls', '/usr/lib64']).stdout;
       return stdout.contains('No such file or directory') ? 'arm' : 'arm64';
     }
-  }
+  }();
 
   /// See: [AndroidDevice.isAppInstalled] in `android_device.dart`
   @override


### PR DESCRIPTION
- Make `sdbCommand()` private.
- Rename variables `deviceVersion` to `platformVersion` for clarity.
- Make `_writeEngineArguments()` come before `startApp()`.