### PR TITLE
Let TizenAotElf respect the target platform

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -94,8 +94,9 @@ abstract class TizenAssetBundle extends Target {
 ///
 /// Source: [AotElfRelease] in `common.dart`
 class TizenAotElf extends AotElfBase {
-  TizenAotElf(this.buildMode);
+  TizenAotElf(this.targetPlatform, this.buildMode);
 
+  final TargetPlatform targetPlatform;
   final BuildMode buildMode;
 
   @override
@@ -106,7 +107,8 @@ class TizenAotElf extends AotElfBase {
         const Source.pattern('{BUILD_DIR}/app.dill'),
         const Source.hostArtifact(HostArtifact.engineDartBinary),
         const Source.artifact(Artifact.skyEnginePath),
-        Source.artifact(Artifact.genSnapshot, mode: buildMode),
+        Source.artifact(Artifact.genSnapshot,
+            platform: targetPlatform, mode: buildMode),
       ];
 
   @override
@@ -165,7 +167,8 @@ class ReleaseTizenApplication extends TizenAssetBundle {
   @override
   List<Target> get dependencies => <Target>[
         ...super.dependencies,
-        TizenAotElf(buildInfo.buildInfo.mode),
+        TizenAotElf(getTargetPlatformForArch(buildInfo.targetArch),
+            buildInfo.buildInfo.mode),
         NativePlugins(buildInfo),
       ];
 }

--- a/lib/tizen_artifacts.dart
+++ b/lib/tizen_artifacts.dart
@@ -9,6 +9,8 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 
+import 'tizen_build_info.dart';
+
 class TizenArtifacts extends CachedArtifacts {
   TizenArtifacts({
     required FileSystem fileSystem,
@@ -46,7 +48,7 @@ class TizenArtifacts extends CachedArtifacts {
       assert(mode != null, 'Need to specify a build mode.');
       assert(mode != BuildMode.debug,
           'Artifact $artifact only available in non-debug mode.');
-      final String arch = _getArchForTargetPlatform(platform);
+      final String arch = getArchForTargetPlatform(platform);
       final HostPlatform hostPlatform = getCurrentHostPlatform();
       assert(hostPlatform != HostPlatform.linux_arm64,
           'Artifact $artifact not available on Linux arm64.');
@@ -56,16 +58,5 @@ class TizenArtifacts extends CachedArtifacts {
           .path;
     }
     return super.getArtifactPath(artifact, platform: platform, mode: mode);
-  }
-}
-
-/// See: [getNameForTargetPlatform] in `build_info.dart`
-String _getArchForTargetPlatform(TargetPlatform platform) {
-  if (platform == TargetPlatform.android_arm64) {
-    return 'arm64';
-  } else if (platform == TargetPlatform.android_x86) {
-    return 'x86';
-  } else {
-    return 'arm';
   }
 }

--- a/lib/tizen_build_info.dart
+++ b/lib/tizen_build_info.dart
@@ -18,3 +18,26 @@ class TizenBuildInfo {
   final String deviceProfile;
   final String? securityProfile;
 }
+
+/// See: [getNameForTargetPlatform] in `build_info.dart`
+String getArchForTargetPlatform(TargetPlatform platform) {
+  if (platform == TargetPlatform.android_arm64) {
+    return 'arm64';
+  } else if (platform == TargetPlatform.android_x86) {
+    return 'x86';
+  } else {
+    return 'arm';
+  }
+}
+
+/// See: [getTargetPlatformForName] in `build_info.dart`
+TargetPlatform getTargetPlatformForArch(String arch) {
+  switch (arch) {
+    case 'arm64':
+      return TargetPlatform.android_arm64;
+    case 'x86':
+      return TargetPlatform.android_x86;
+    default:
+      return TargetPlatform.android_arm;
+  }
+}

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -98,7 +98,7 @@ class TizenBuilder {
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(
-        _getTargetPlatformForArch(tizenBuildInfo.targetArch));
+        getTargetPlatformForArch(tizenBuildInfo.targetArch));
 
     final Environment environment = Environment(
       projectDir: project.directory,
@@ -227,17 +227,5 @@ class TizenBuilder {
     } else {
       updateManifestFile(project.manifestFile);
     }
-  }
-}
-
-/// See: [getTargetPlatformForName] in `build_info.dart`
-TargetPlatform _getTargetPlatformForArch(String arch) {
-  switch (arch) {
-    case 'arm64':
-      return TargetPlatform.android_arm64;
-    case 'x86':
-      return TargetPlatform.android_x86;
-    default:
-      return TargetPlatform.android_arm;
   }
 }

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -106,7 +106,9 @@ class TizenBuilder {
       buildDir: project.dartTool.childDirectory('flutter_build'),
       cacheDir: globals.cache.getRoot(),
       flutterRootDir: _fileSystem.directory(Cache.flutterRoot),
-      engineVersion: globals.flutterVersion.engineRevision,
+      engineVersion: _artifacts.isLocalEngine
+          ? null
+          : globals.flutterVersion.engineRevision,
       defines: <String, String>{
         kTargetFile: targetFile,
         kTargetPlatform: targetPlatform,


### PR DESCRIPTION
- Specify the `platform` argument of `Source.artifact(Artifact.genSnapshot)` so that a correct gen_snapshot artifact is resolved as a dependency of `TizenAotElf`.
- Set `environment.engineVersion` to null when a local engine is being used.
- (Refactoring) Move `getArchForTargetPlatform` and `getTargetPlatformForArch` into `tizen_build_info.dart`.

This change doesn't have any effect for normal users because source artifact paths are resolved only when using a local engine:
https://github.com/flutter/flutter/blob/2.8.1/packages/flutter_tools/lib/src/build_system/source.dart#L169-L183

Additional note (why we use both `TargetPlatform.tester` and `TargetPlatform.android*` in our code):
- `TargetPlatform.tester` is used to identify the device type (i.e. `Device.targetPlatform`).
- `TargetPlatform.android` and variants are used during the build process to represent the target architecture (arm, arm64, x86).