### PR TITLE
Add the debug-native command

### DIFF
--- a/lib/commands/debug_native.dart
+++ b/lib/commands/debug_native.dart
@@ -1,0 +1,240 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/signals.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:meta/meta.dart';
+
+import '../tizen_device.dart';
+import '../tizen_sdk.dart';
+import '../tizen_tpk.dart';
+import '../vscode_helper.dart';
+
+const String kWikiPageUrl =
+    "https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code";
+
+class DebugNativeCommand extends FlutterCommand {
+  DebugNativeCommand({
+    this.hidden = false,
+    @required Terminal terminal,
+    @required TizenSdk tizenSdk,
+  })  : _terminal = terminal,
+        _tizenSdk = tizenSdk {
+    requiresPubspecYaml();
+  }
+
+  @override
+  String get name => 'debug-native';
+
+  @override
+  List<String> get aliases => const <String>['debug_native'];
+
+  @override
+  String get description => 'Attach gdbserver to a running app (Tizen-only).';
+
+  @override
+  String get category => FlutterCommandCategory.tools;
+
+  @override
+  final bool hidden;
+
+  final Terminal _terminal;
+  final TizenSdk _tizenSdk;
+
+  TizenDevice _device;
+  FlutterProject _project;
+  TizenTpk _package;
+  StreamSubscription<void> _subscription;
+
+  @override
+  Future<void> validateCommand() async {
+    final Device device = await findTargetDevice();
+    if (device == null) {
+      throwToolExit('No target device found.');
+    }
+    if (device is! TizenDevice) {
+      throwToolExit('The selected device is not a Tizen device.');
+    }
+    _device = device as TizenDevice;
+    if (_device.usesSecureProtocol) {
+      throwToolExit('Not supported device.');
+    }
+    return super.validateCommand();
+  }
+
+  @override
+  Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
+    _project = FlutterProject.current();
+    _package = TizenTpk.fromProject(_project);
+    if (_package.isDotnet) {
+      throwToolExit(
+        'Not supported app language.\n\n'
+        'See $kWikiPageUrl for detailed usage.',
+      );
+    }
+    return super.verifyThenRunCommand(commandPath);
+  }
+
+  Future<void> _startGdbServer(
+    String applicationId,
+    int debugPort,
+    String processId,
+  ) async {
+    final List<String> command = _device.sdbCommand(<String>[
+      'launch',
+      '-a',
+      '"$applicationId"',
+      '-p',
+      '-e',
+      '-m',
+      'debug',
+      '-P',
+      '$debugPort',
+      '-attach',
+      processId,
+    ]);
+    final Process process = await globals.processManager.start(command);
+
+    final Completer<void> completer = Completer<void>();
+    final StreamSubscription<String> stdoutSubscription = process.stdout
+        .transform<String>(const Utf8Decoder())
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+      if (line.contains("Can't bind address") ||
+          line.contains('Cannot attach to process')) {
+        completer.completeError(line);
+      } else if (line.contains('Listening on port')) {
+        completer.complete();
+      } else {
+        // Remove this line when appropriate in the future.
+        globals.printStatus(line);
+      }
+    }, onDone: () {
+      // The process may exit without saying "Listening on port".
+      completer.complete();
+    });
+    final StreamSubscription<String> stderrSubscription = process.stderr
+        .transform<String>(const Utf8Decoder())
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+      completer.completeError(line);
+    });
+
+    try {
+      await completer.future.timeout(const Duration(seconds: 10));
+    } on Exception catch (error) {
+      throwToolExit('Could not start gdbserver: $error');
+    }
+    await stdoutSubscription.cancel();
+    await stderrSubscription.cancel();
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final File program = _project.directory
+        .childDirectory('build')
+        .childDirectory('tizen')
+        .childDirectory('tpk')
+        .childDirectory('tpkroot')
+        .childDirectory('bin')
+        .childFile('runner');
+    if (!program.existsSync()) {
+      throwToolExit(
+        'Could not find the runner executable.\n'
+        'Did you build and install the app to your device?',
+      );
+    }
+
+    // Forward a port to allow communication between gdb and gdbserver.
+    final int debugPort = await globals.os.findFreePort();
+    await _device.portForwarder.forward(debugPort, hostPort: debugPort);
+
+    // Find the running app's process ID.
+    final RunResult result =
+        await _device.runSdbAsync(<String>['shell', 'app_launcher', '-S']);
+    final RegExp pattern = RegExp('${_package.applicationId} \\(([0-9]+)\\)');
+    final Match match = pattern.firstMatch(result.stdout);
+    if (match == null) {
+      throwToolExit('The app is not running.');
+    }
+    final String processId = match.group(1);
+
+    if (!await _device.installGdbServer()) {
+      return FlutterCommandResult.fail();
+    }
+    await _startGdbServer(_package.applicationId, debugPort, processId);
+
+    final File gdb = _tizenSdk.getGdbExecutable(_device.architecture);
+    updateLaunchJsonWithRemoteDebuggingInfo(
+      _project,
+      program: program,
+      gdbPath: gdb.path,
+      debugPort: debugPort,
+    );
+
+    final String escapeCharacter = globals.platform.isWindows ? '`' : r'\';
+    globals.printStatus('''
+gdbserver is listening for a debug connection on port $debugPort.
+
+Keep this program running until your debug session is closed.
+
+GDB launch command:
+${gdb.path} $escapeCharacter
+  "${program.path}" $escapeCharacter
+  -ex "set auto-solib-add off" $escapeCharacter
+  -ex "target remote :$debugPort" $escapeCharacter
+  -ex "shared /opt/usr/globalapps"
+
+Using the VS Code debugger:
+1. Open the project folder in VS Code.
+2. Click the Run and Debug icon in the left menu bar, and make sure "$kConfigNameGdb" is selected.
+3. Click ▷ or press F5 to start debugging.
+
+For detailed instructions, see: $kWikiPageUrl
+''');
+
+    _registerSignalHandlers(_cleanUp);
+    _terminal.singleCharMode = true;
+
+    final Completer<void> finished = Completer<void>();
+    _subscription = _terminal.keystrokes.listen((String key) async {
+      switch (key) {
+        case 'q':
+        case 'Q':
+          globals.printStatus('Exiting');
+          await _cleanUp();
+          finished.complete();
+          break;
+      }
+    });
+    await finished.future;
+
+    return FlutterCommandResult.success();
+  }
+
+  void _registerSignalHandlers(SignalHandler onSignal) {
+    globals.signals.addHandler(ProcessSignal.sigint, onSignal);
+    globals.signals.addHandler(ProcessSignal.sigterm, onSignal);
+  }
+
+  Future<void> _cleanUp([ProcessSignal signal]) async {
+    _terminal.singleCharMode = false;
+    await _device?.dispose();
+    await _subscription?.cancel();
+  }
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -119,11 +119,7 @@ Future<void> main(List<String> args) async {
       ScreenshotCommand(),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       // Commands extended for Tizen.
-      DebugNativeCommand(
-        hidden: !verboseHelp,
-        terminal: globals.terminal,
-        tizenSdk: tizenSdk,
-      ),
+      DebugNativeCommand(hidden: !verboseHelp),
       TizenBuildCommand(verboseHelp: verboseHelp),
       TizenCleanCommand(verbose: verbose),
       TizenCreateCommand(verboseHelp: verboseHelp),

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -43,6 +43,7 @@ import 'build_targets/package.dart';
 import 'commands/build.dart';
 import 'commands/clean.dart';
 import 'commands/create.dart';
+import 'commands/debug_native.dart';
 import 'commands/drive.dart';
 import 'commands/precache.dart';
 import 'commands/run.dart';
@@ -118,6 +119,11 @@ Future<void> main(List<String> args) async {
       ScreenshotCommand(),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       // Commands extended for Tizen.
+      DebugNativeCommand(
+        hidden: !verboseHelp,
+        terminal: globals.terminal,
+        tizenSdk: tizenSdk,
+      ),
       TizenBuildCommand(verboseHelp: verboseHelp),
       TizenCleanCommand(verbose: verbose),
       TizenCreateCommand(verboseHelp: verboseHelp),

--- a/lib/forwarding_log_reader.dart
+++ b/lib/forwarding_log_reader.dart
@@ -136,15 +136,16 @@ class ForwardingLogReader extends DeviceLogReader {
     return socket;
   }
 
+  /// Starts receiving messages from the device logger.
+  ///
+  /// If [retry] is positive and the device logger is not yet ready, the
+  /// connection will be retried [retry] times.
   Future<void> start({int retry = 3}) async {
     if (_socket != null) {
       globals.printTrace('Already connected to the device logger.');
       return;
     }
 
-    // The host port is also used as a device port. This could result in a
-    // binding error if the port is already in use by another process on the
-    // device.
     // The forwarded port will be automatically unforwarded when portForwarder
     // is disposed.
     await _portForwarder.forward(hostPort, hostPort: hostPort);

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -79,10 +79,7 @@ class TizenBuilder {
   }) async {
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
     if (!tizenProject.existsSync()) {
-      throwToolExit(
-        'This project is not configured for Tizen.\n'
-        'To fix this problem, create a new project by running `flutter-tizen create <app-dir>`.',
-      );
+      throwToolExit('This project is not configured for Tizen.');
     }
     if (tizenSdk == null || !tizenSdk!.tizenCli.existsSync()) {
       throwToolExit(

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -539,10 +539,9 @@ class TizenDevice extends Device {
   }
 
   Future<bool> installGdbServer() async {
-    // gdbserver 8.3.1 is corrupted. Use gdbserver 7.8.1.
-    // Issue: https://github.com/flutter-tizen/plugins/issues/295
-    final String arch = getTizenBuildArch(architecture, Version(5, 5, 0));
-    final String tarName = 'gdbserver_7.8.1_$arch.tar';
+    final String buildArch = getTizenBuildArch(architecture, Version(5, 5, 0));
+    // gdbserver 8.3.1 is unstable. Default to gdbserver 7.8.1.
+    final String tarName = 'gdbserver_7.8.1_$buildArch.tar';
     final File tarArchive =
         _tizenSdk.toolsDirectory.childDirectory('on-demand').childFile(tarName);
     if (!tarArchive.existsSync()) {
@@ -577,7 +576,7 @@ class TizenDevice extends Device {
         '-xf',
         remoteArchivePath,
         '-C',
-        sdkToolsPath
+        sdkToolsPath,
       ]);
       if (extractResult.stdout.isNotEmpty) {
         extractResult.throwException(extractResult.stdout);

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
@@ -126,6 +127,21 @@ class TizenSdk {
   final String defaultNativeCompiler = 'llvm-10.0';
 
   final String defaultGccVersion = '9.2';
+
+  File getGdbExecutable(String arch) {
+    String targetTriple = 'arm-linux-gnueabi';
+    if (arch == 'arm64') {
+      targetTriple = 'aarch64-linux-gnu';
+    } else if (arch == 'x86') {
+      targetTriple = 'i586-linux-gnueabi';
+    }
+    return toolsDirectory
+        .childDirectory('$targetTriple-gdb-8.3.1')
+        .childDirectory('bin')
+        .childFile(_platform.isWindows
+            ? '$targetTriple-gdb.exe'
+            : '$targetTriple-gdb');
+  }
 
   /// On non-Windows, returns the PATH environment variable.
   ///
@@ -361,13 +377,16 @@ class Rootstrap {
 
 /// Converts [arch] to an arch name that corresponds to the `BUILD_ARCH`
 /// value used by the Tizen native builder.
-String getTizenBuildArch(String arch) {
+String getTizenBuildArch(String arch, [Version? platformVersion]) {
   switch (arch) {
     case 'arm':
       return 'armel';
     case 'arm64':
       return 'aarch64';
     case 'x86':
+      if (platformVersion != null && platformVersion < Version(6, 0, 0)) {
+        return 'i386';
+      }
       return 'i586';
     default:
       return arch;

--- a/lib/tizen_tpk.dart
+++ b/lib/tizen_tpk.dart
@@ -53,6 +53,9 @@ class TizenTpk extends ApplicationPackage {
 
   static TizenTpk fromProject(FlutterProject flutterProject) {
     final TizenProject project = TizenProject.fromFlutter(flutterProject);
+    if (!project.existsSync()) {
+      throwToolExit('This project is not configured for Tizen.');
+    }
 
     final File tpkFile = flutterProject.directory
         .childDirectory('build')

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -83,9 +83,10 @@ void main() {
           '/.tmp_rand0/rand0/$appId.rpm',
           '/home/owner/share/tmp/sdk_tools/$appId.rpm',
         ]),
+        stdout: '1 file(s) pushed.',
       ),
       FakeCommand(
-        command: _sdbCommand(<String>['shell', 'app_launcher', '-s', appId]),
+        command: _sdbCommand(<String>['shell', 'app_launcher', '-e', appId]),
         stdout: '... successfully launched pid = 123',
       ),
     ]);


### PR DESCRIPTION
Closes https://github.com/flutter-tizen/plugins/issues/295.

Changelog:
- Add a new command `debug-native` for native debugging support (especially plugin debugging). The command is experimental and hidden by default (thus not listed in [the main doc](https://github.com/flutter-tizen/flutter-tizen/blob/master/doc/commands.md)). You can find the detailed usage at [the wiki](https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code).
- Change the default app launch command from `app_launcher -s` to `app_launcher -e` (direct launch).
- Add the `updateLaunchJsonWithRemoteDebuggingInfo` method to `vscode_helper.dart`, which creates or updates a debug configuration in `launch.json` file.

Design considerations:
- At first I tried to add an optional switch `--debug-native` to the existing `run` command without implementing a new command, but it turned out that launching an app under gdbserver (i.e. [launch and debug](https://github.com/flutter-tizen/plugins/issues/295#issuecomment-998603229)) was too unstable and caused SIGABRT on some devices (Tizen 5.5 watch). Attaching gdbserver automatically after app launch was also not possible because it caused many bugs and inconsistent results (when is it safe to attach gdbserver to a fresh debuggee?).
- The current design requires the user to open at least two console windows for CLI debugging (one for running the `debug-native` command and the other for launching GDB). I tried to support launching GDB directly from the tool process (e.g. by pressing a key after running the `debug-native` command) and pipe their inputs and outputs (which can be easily done when I use Python), but failed after all because Dart had too limited support for child process manipulation and stream processing.

Tested on:
- Hosts: Ubuntu, Windows (PowerShell and WSL)
- Devices: Galaxy Watch Active, Wearable emulator, Mobile emulator

Please let me know if you have any suggestion or the command doesn't work as expected.