### PR TITLE
Support native debugging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,9 @@
 *.props.tmpl      text eol=crlf
 *.vcxproj.tmpl    text eol=crlf
 
+# Make sure that these files always have LF line endings in checkout
+gdbserver         text eol=lf
+
 # Never perform LF normalization on these files
 *.ico    binary
 *.jar    binary

--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import os
+import re
+import select
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+from contextlib import closing
+from pathlib import Path
+from traceback import format_exc
+
+
+class TizenDevice:
+    def __init__(self, id, model=''):
+        self.id = id
+        self.model = model
+        self.forwarded_ports = set()
+        self.capabilities = dict()
+
+        raw = self.sdb_run(['capability']).stdout
+        for line in raw.splitlines():
+            if ':' in line:
+                tuple = line.strip().partition(':')
+                self.capabilities[tuple[0]] = tuple[-1]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        for port in self.forwarded_ports.copy():
+            self.unforward_port(port)
+
+    def sdb_run(self, args, checked=True):
+        return subprocess.run(
+            ['sdb', '-s', self.id] + args, encoding='utf-8',
+            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            check=checked)
+
+    def sdb_start(self, args):
+        return subprocess.Popen(
+            ['sdb', '-s', self.id] + args, encoding='utf-8',
+            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def uses_secure_protocol(self):
+        return self.capabilities.get('secure_protocol') == 'enabled'
+
+    def forward_port(self, host_port, device_port):
+        self.sdb_run(['forward', f'tcp:{host_port}', f'tcp:{device_port}'])
+        self.forwarded_ports.add(host_port)
+
+    def unforward_port(self, host_port):
+        self.sdb_run(['forward', '--remove', f'tcp:{host_port}'])
+        self.forwarded_ports.remove(host_port)
+
+    def get_architecture(self):
+        cpu_arch = self.capabilities.get('cpu_arch')
+        if cpu_arch == 'x86':
+            return 'x86'
+        elif self.uses_secure_protocol():
+            return 'arm' if cpu_arch == 'armv7l' else 'arm64'
+        else:
+            raw = self.sdb_run(['shell', 'ls', '/usr/lib64']).stdout
+            return 'arm' if 'No such file or directory' in raw else 'arm64'
+
+
+def find_target_device():
+    raw = subprocess.run(['sdb', 'devices'], encoding='utf-8',
+                         stdout=subprocess.PIPE).stdout
+    lines = [line for line in raw.splitlines() if not line.startswith('* ')]
+    if len(lines) <= 1:
+        return None
+
+    devices = []
+    for line in lines[1:]:
+        split = re.split(r'\s{2,}|\t', line.strip())
+        if len(split) < 3 or split[1] != 'device':
+            continue
+        id = split[0]
+        state = split[1]
+        model = split[2]
+        if state == 'device':
+            devices.append(TizenDevice(id, model))
+
+    if len(devices) == 1:
+        return devices[0]
+
+    print('Multiple devices found:')
+    for index in range(len(devices)):
+        device = devices[index]
+        print(f'[{index + 1}] {device.id} - {device.model}')
+    choice = input(f'Choose a device [1-{len(devices)}]: ')
+
+    if choice.isdigit() and int(choice) <= len(devices):
+        return devices[int(choice) - 1]
+    return None
+
+
+def locate_tizen_sdk():
+    if 'TIZEN_SDK' in os.environ:
+        return Path(os.environ['TIZEN_SDK'])
+    sdb_path = shutil.which('sdb')
+    if sdb_path and os.path.dirname(sdb_path) == 'tools':
+        return Path(sdb_path).parent.parent
+    if os.name == 'nt':
+        sdk_dir = Path(os.environ['SystemDrive']) / 'tizen-studio'
+    else:
+        sdk_dir = Path.home() / 'tizen-studio'
+    if sdk_dir.is_dir():
+        return sdk_dir
+    sys.exit('Unable to locate Tizen SDK.')
+
+
+def get_gdb_path(tizen_sdk_dir: Path, arch):
+    if arch == 'arm':
+        target_triple = 'arm-linux-gnueabi'
+    elif arch == 'arm64':
+        target_triple = 'aarch64-linux-gnu'
+    else:
+        target_triple = 'i586-linux-gnueabi'
+    gdb_name = f'{target_triple}-gdb'
+    gdb_path = tizen_sdk_dir / 'tools' / f'{gdb_name}-8.3.1' / 'bin' / gdb_name
+    if os.name == 'nt':
+        gdb_path = gdb_path.with_suffix('.exe')
+    assert gdb_path.is_file(), f'{gdb_path} does not exist.'
+    return gdb_path
+
+
+def find_project():
+    current_dir = Path.cwd()
+    if not (current_dir / 'pubspec.yaml').is_file():
+        sys.exit('No pubspec.yaml file found.')
+    tizen_dir = current_dir / 'tizen'
+    if not (tizen_dir / 'tizen-manifest.xml').is_file():
+        sys.exit('This project is not configured for Tizen.')
+    if not (tizen_dir / 'project_def.prop').is_file():
+        sys.exit('Not supported app language.')
+    return current_dir
+
+
+def find_free_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(('', 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return sock.getsockname()[1]
+
+
+def find_app_id(project_dir: Path):
+    # Assume that the app ID is identical to the package ID.
+    tpk_name = None
+    tpk_dir = project_dir / 'build' / 'tizen' / 'tpk'
+    for child in tpk_dir.iterdir():
+        if child.suffix == '.tpk':
+            tpk_name = child.stem
+    if not tpk_name:
+        sys.exit('TPK file not found.')
+    return tpk_name.rpartition('-')[0]
+
+
+def find_pid(device: TizenDevice, app_id):
+    raw = device.sdb_run(['shell', 'app_launcher', '-S']).stdout
+    for line in raw.splitlines():
+        match = re.match(app_id + r' \(([0-9]+)\)', line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def install_gdb_server(device: TizenDevice, tizen_sdk_dir: Path):
+    device_arch = device.get_architecture()
+    if device_arch == 'arm':
+        arch = 'armel'
+    elif device_arch == 'arm64':
+        arch = 'aarch64'
+    else:
+        arch = 'i386'
+    # gdbserver 8.3.1 is unstable on arm. Default to gdbserver 7.8.1.
+    tar_name = f'gdbserver_7.8.1_{arch}.tar'
+    tar_path = tizen_sdk_dir / 'tools' / 'on-demand' / tar_name
+    assert tar_path.is_file(), f'{tar_path} does not exist.'
+
+    remote_dir = '/home/owner/share/tmp/sdk_tools/gdbserver'
+    result = device.sdb_run(['shell', 'mkdir', '-p', remote_dir]).stdout
+    assert not result.strip(), result
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tarfile.open(tar_path) as tar_file:
+            tar_file.extractall(path=temp_dir)
+        real_gdbserver = Path(temp_dir) / 'gdbserver' / 'gdbserver'
+        real_gdbserver = real_gdbserver.rename(
+            real_gdbserver.parent / 'gdbserver_real')
+        result = device.sdb_run(['push', real_gdbserver, remote_dir]).stdout
+        assert 'file(s) pushed' in result, result
+
+    # This fake gdbserver script terminates any running gdbserver before
+    # invoking the real gdbserver.
+    fake_gdbserver = Path(__file__).parent / 'internal' / 'gdbserver'
+    result = device.sdb_run(['push', fake_gdbserver, remote_dir]).stdout
+    assert 'file(s) pushed' in result, result
+
+
+def readline_from(proc: subprocess.Popen):
+    if os.name == 'nt':
+        # select() is not supported on Windows.
+        line = proc.stdout.readline()
+    else:
+        fds = [proc.stdout.fileno(), proc.stderr.fileno()]
+        fd = select.select(fds, [], [])[0][0]
+        if fd == proc.stdout.fileno():
+            line = proc.stdout.readline()
+        else:
+            line = proc.stderr.readline()
+            if not proc.poll():
+                raise Exception(line)
+    return line.strip()
+
+
+def start_gdb_server(device: TizenDevice, app_id, debug_port, pid, launched: threading.Event):
+    args = [
+        'shell', 'launch_debug', app_id,
+        '__AUL_SDK__', 'ATTACH',
+        '__LAUNCH_APP_MODE__', 'SYNC',
+        '__DLP_GDBSERVER_PATH__', '/home/owner/share/tmp/sdk_tools/gdbserver/gdbserver',
+        '__DLP_ATTACH_ARG__', f'--attach,:{debug_port},{pid}']
+    try:
+        with device.sdb_start(args) as proc:
+            while not proc.poll():
+                line = readline_from(proc)
+                print(line)
+                if 'Listening on port' in line:
+                    launched.set()
+                elif line.startswith((
+                        'Detaching from process', 'GDBserver exiting')):
+                    os.kill(os.getpid(), signal.SIGINT)
+                    break
+                elif line.startswith((
+                        'Failed to send launch request', "Can't bind address",
+                        'Cannot attach to process')):
+                    if not proc.poll():
+                        proc.terminate()
+                    raise Exception(line)
+    except Exception:
+        sys.stderr.write(format_exc())
+        os.kill(os.getpid(), signal.SIGINT)
+
+
+def print_help():
+    print('''
+Available commands:
+
+r Run GDB client
+p Print launch.json configuration
+v Open this project in VS Code
+q Quit
+
+For detailed usage, see: https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code
+''')
+
+
+def launch_gdb(gdb_path: Path, program: Path, args):
+    # Temporarily disable the SIGINT handler.
+    sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    subprocess.run(' '.join([str(gdb_path), str(program)] + args), shell=True)
+
+    # Restore the handler.
+    signal.signal(signal.SIGINT, sigint_handler)
+
+
+def find_parent_project(project_dir: Path):
+    if project_dir.name == 'example':
+        parent_dir = project_dir.parent
+        if (parent_dir / 'pubspec.yaml').is_file():
+            return parent_dir
+    return None
+
+
+def print_launch_json(project_dir: Path, program: Path, debugger: Path, port):
+    if find_parent_project(project_dir):
+        project_dir = find_parent_project(project_dir)
+
+    launch_json = '''
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "flutter-tizen: gdb",
+            "request": "launch",
+            "type": "cppdbg",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "symbolLoadInfo": {
+                "loadAll": false,
+                "exceptionList": "libflutter*.so"
+            },
+            "cwd": "CWD",
+            "program": "PROGRAM",
+            "miDebuggerPath": "DEBUGGER",
+            "miDebuggerServerAddress": ":PORT"
+        }
+    ]
+}
+'''
+    print(launch_json
+          .replace('CWD', project_dir.as_posix())
+          .replace('PROGRAM', program.as_posix())
+          .replace('DEBUGGER', debugger.as_posix())
+          .replace('PORT', str(port)))
+
+
+def run(device: TizenDevice):
+    tizen_sdk_dir = locate_tizen_sdk()
+    gdb_path = get_gdb_path(tizen_sdk_dir, device.get_architecture())
+
+    project_dir = find_project()
+    program = project_dir / 'build' / 'tizen' / 'tpk' / 'tpkroot' / 'bin' / 'runner'
+    if not program.is_file():
+        sys.exit('Could not find the runner executable.\n'
+                 'Make sure the app has been built and installed to your device.')
+
+    debug_port = find_free_port()
+    device.forward_port(debug_port, debug_port)
+
+    app_id = find_app_id(project_dir)
+    pid = find_pid(device, app_id)
+    if not pid:
+        sys.exit('The app is not running.')
+
+    install_gdb_server(device, tizen_sdk_dir)
+
+    launched = threading.Event()
+    server_thread = threading.Thread(
+        target=start_gdb_server,
+        args=[device, app_id, debug_port, pid, launched], daemon=True)
+    server_thread.start()
+    launched.wait()
+
+    print_help()
+
+    while True:
+        choice = input('Enter a command: ')
+
+        if choice == 'h' or choice == 'H' or choice == '?':
+            print_help()
+        elif choice == 'r' or choice == 'R':
+            args = ['-ex "set auto-solib-add off"',
+                    f'-ex "target remote :{debug_port}"',
+                    '-ex "shared /opt/usr/globalapps"']
+            launch_gdb(gdb_path, program, args)
+            break
+        elif choice == 'p' or choice == 'P':
+            print_launch_json(project_dir, program, gdb_path, debug_port)
+        elif choice == 'v' or choice == 'V':
+            if find_parent_project(project_dir):
+                subprocess.run(['code', '..'])
+            else:
+                subprocess.run(['code', '.'])
+        elif choice == 'q' or choice == 'Q':
+            break
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Tool for starting GDB server and client to debug a native app on a Tizen device.')
+    parser.add_argument('-d', '--device', metavar='SERIAL', type=str,
+                        help='serial number of the target device')
+    args = parser.parse_args()
+
+    try:
+        if args.device:
+            device = TizenDevice(args.device)
+        else:
+            device = find_target_device()
+
+        if not device:
+            sys.exit('No target device found.')
+        elif device.uses_secure_protocol():
+            sys.exit('Not supported device.')
+
+        with device:
+            run(device)
+    except (ProcessLookupError, KeyboardInterrupt):
+        print()
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -305,7 +305,7 @@ def print_launch_json(project_dir: Path, program: Path, debugger: Path, port):
             "MIMode": "gdb",
             "symbolLoadInfo": {
                 "loadAll": false,
-                "exceptionList": "libflutter*.so"
+                "exceptionList": "libc.so;libflutter*"
             },
             "cwd": "CWD",
             "program": "PROGRAM",
@@ -360,7 +360,8 @@ def run(device: TizenDevice):
         elif choice == 'r' or choice == 'R':
             args = ['-ex', 'set auto-solib-add off',
                     '-ex', f'target remote :{debug_port}',
-                    '-ex', 'shared /opt/usr/globalapps']
+                    '-ex', 'share libc.so',
+                    '-ex', 'share libflutter*']
             run_gdb_client(gdb_path, program, args)
             break
         elif choice == 'p' or choice == 'P':

--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -349,6 +349,7 @@ def run(device: TizenDevice):
     server_thread.start()
     launched.wait()
 
+    print(f'gdbserver is listening for debug connection on port {debug_port}.')
     print_help()
 
     while True:

--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -83,7 +83,7 @@ def find_target_device():
     devices = []
     for line in lines[1:]:
         split = re.split(r'\s{2,}|\t', line.strip())
-        if len(split) < 3 or split[1] != 'device':
+        if len(split) < 3:
             continue
         id = split[0]
         state = split[1]
@@ -109,7 +109,7 @@ def locate_tizen_sdk():
     if 'TIZEN_SDK' in os.environ:
         return Path(os.environ['TIZEN_SDK'])
     sdb_path = shutil.which('sdb')
-    if sdb_path and os.path.dirname(sdb_path) == 'tools':
+    if sdb_path and Path(sdb_path).parent.name == 'tools':
         return Path(sdb_path).parent.parent
     if os.name == 'nt':
         sdk_dir = Path(os.environ['SystemDrive']) / 'tizen-studio'
@@ -235,11 +235,14 @@ def start_gdb_server(device: TizenDevice, app_id, debug_port, pid, launched: thr
         with device.sdb_start(args) as proc:
             while not proc.poll():
                 line = readline_from(proc)
+                if not line:
+                    continue
                 print(line)
                 if 'Listening on port' in line:
                     launched.set()
                 elif line.startswith((
-                        'Detaching from process', 'GDBserver exiting')):
+                        'Detaching from process', 'GDBserver exiting',
+                        'No program to debug.')):
                     os.kill(os.getpid(), signal.SIGINT)
                     break
                 elif line.startswith((
@@ -266,11 +269,13 @@ For detailed usage, see: https://github.com/flutter-tizen/flutter-tizen/wiki/Deb
 ''')
 
 
-def launch_gdb(gdb_path: Path, program: Path, args):
+def run_gdb_client(gdb_path: Path, program: Path, args):
     # Temporarily disable the SIGINT handler.
     sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    subprocess.run(' '.join([str(gdb_path), str(program)] + args), shell=True)
+    # os.execv() and subprocess.run(list) are not portable.
+    command = [str(gdb_path), str(program)] + args
+    subprocess.run(' '.join([f'"{arg}"' for arg in command]), shell=True)
 
     # Restore the handler.
     signal.signal(signal.SIGINT, sigint_handler)
@@ -352,10 +357,10 @@ def run(device: TizenDevice):
         if choice == 'h' or choice == 'H' or choice == '?':
             print_help()
         elif choice == 'r' or choice == 'R':
-            args = ['-ex "set auto-solib-add off"',
-                    f'-ex "target remote :{debug_port}"',
-                    '-ex "shared /opt/usr/globalapps"']
-            launch_gdb(gdb_path, program, args)
+            args = ['-ex', 'set auto-solib-add off',
+                    '-ex', f'target remote :{debug_port}',
+                    '-ex', 'shared /opt/usr/globalapps']
+            run_gdb_client(gdb_path, program, args)
             break
         elif choice == 'p' or choice == 'P':
             print_launch_json(project_dir, program, gdb_path, debug_port)

--- a/bin/internal/gdbserver
+++ b/bin/internal/gdbserver
@@ -1,0 +1,25 @@
+#!/usr/bin/bash
+# Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+function kill_gdbserver_if_running() {
+  local current_attr="$(cat /proc/self/attr/current)"
+  if [[ "$current_attr" != "User::Pkg::"* ]]; then
+    return 0
+  fi
+  ps -eZ | grep "$current_attr" | while read -r line; do
+    local pid="$(echo "$line" | awk '{print $2}')"
+    local command="$(echo "$line" | awk '{print $NF}')"
+    if [[ "$command" == "<defunct>" || "$command" == "gdbserver_real" ]]; then
+      kill $pid
+    fi
+  done
+}
+
+kill_gdbserver_if_running
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+"$SCRIPT_DIR/gdbserver_real" "$@"

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -423,7 +423,7 @@ class TizenDevice extends Device {
 
     final List<String> command = usesSecureProtocol
         ? <String>['shell', '0', 'execute', package.applicationId]
-        : <String>['shell', 'app_launcher', '-s', package.applicationId];
+        : <String>['shell', 'app_launcher', '-e', package.applicationId];
     final String stdout = (await runSdbAsync(command)).stdout;
     if (!stdout.contains('successfully launched')) {
       _logger.printError(stdout.trim());

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -85,7 +85,7 @@ void main() {
         ]),
       ),
       FakeCommand(
-        command: _sdbCommand(<String>['shell', 'app_launcher', '-s', appId]),
+        command: _sdbCommand(<String>['shell', 'app_launcher', '-e', appId]),
         stdout: '... successfully launched pid = 123',
       ),
     ]);


### PR DESCRIPTION
Replaces the previous PR https://github.com/flutter-tizen/flutter-tizen/pull/312. Resolves https://github.com/flutter-tizen/plugins/issues/295.

Adds the `flutter-tizen-gdb` script for native debugging support. The script by default starts `gdbserver` on a connected device and waits for user input to perform additional operations.

Example:
```sh
$ cd my_app
$ sdb root off
$ sdb shell app_launcher -k com.example.my_app
$ sdb shell app_launcher -e com.example.my_app
$ flutter-tizen-gdb
pkg api_version: 4.0
Attached; pid = 6115
Listening on port 37375

Available commands:

r Run GDB client
p Print launch.json configuration
v Open this project in VS Code
q Quit

For detailed usage, see: https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code

Enter a command:
```

Entering `r` will directly launch GDB client from the command line (this was not possible with Dart in the previous PR). You can also press `p` and copy-paste the debug configuration to debug the app in VS Code. The detailed usage will be updated on [the wiki](https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code).

Somes parts of the script were derived from the flutter-tizen tool (such as the `TizenDevice` class and `locate_tizen_sdk`).

To run on a Windows host (not officially supported), you can use

```sh
python3 [path to flutter-tizen-gdb]
```