### PR TITLE
Add tests for tizen_plugins.dart

### DIFF
--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 // ignore: import_of_legacy_library_into_null_safe
@@ -115,8 +116,12 @@ mixin DartPluginRegistry on FlutterCommand {
 /// from [dartFile] and returns their names.
 List<String> _findDartEntrypoints(File dartFile) {
   final String path = dartFile.absolute.path;
-  final AnalysisContextCollection collection =
-      AnalysisContextCollection(includedPaths: <String>[path]);
+  final FileSystemEntity dartSdk =
+      globals.artifacts!.getHostArtifact(HostArtifact.engineDartSdkPath);
+  final AnalysisContextCollection collection = AnalysisContextCollection(
+    includedPaths: <String>[path],
+    sdkPath: dartSdk.absolute.path,
+  );
   final AnalysisContext context = collection.contextFor(path);
   final SomeParsedUnitResult parsed =
       context.currentSession.getParsedUnit(path);
@@ -223,12 +228,9 @@ void {{name}}(List<String> args) {
 /// https://github.com/flutter-tizen/plugins
 const List<String> _kKnownPlugins = <String>[
   'audioplayers',
-  'battery',
   'battery_plus',
   'camera',
-  'connectivity',
   'connectivity_plus',
-  'device_info',
   'device_info_plus',
   'flutter_tts',
   'geolocator',
@@ -236,20 +238,17 @@ const List<String> _kKnownPlugins = <String>[
   'image_picker',
   'integration_test',
   'network_info_plus',
-  'package_info',
   'package_info_plus',
   'path_provider',
   'permission_handler',
-  'sensors',
   'sensors_plus',
-  'share',
   'share_plus',
   'shared_preferences',
+  'sqflite',
   'url_launcher',
   'video_player',
   'wakelock',
   'webview_flutter',
-  'wifi_info_flutter',
 ];
 
 /// This function is expected to be called whenever

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -77,7 +77,7 @@ dependencies:
   "configVersion": 2,
   "packages": [
     {
-      "name": "some_dart_plugin",
+      "name": "some_native_plugin",
       "rootUri": "${pluginDir.uri}",
       "packageUri": "lib/",
       "languageVersion": "2.12"

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -1,0 +1,181 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tizen/tizen_plugins.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  FlutterProject project;
+  File pubspecFile;
+  File packageConfigFile;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+
+    pubspecFile = fileSystem.file('pubspec.yaml')..createSync(recursive: true);
+    packageConfigFile = fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true);
+    fileSystem.file('lib/main.dart').createSync(recursive: true);
+    fileSystem.file('tizen/tizen-manifest.xml').createSync(recursive: true);
+  });
+
+  testUsingContext('Generates Dart plugin registrant', () async {
+    final _DummyFlutterCommand command = _DummyFlutterCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    final Directory pluginDir = fileSystem.directory('/some_dart_plugin');
+    pluginDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+flutter:
+  plugin:
+    platforms:
+      tizen:
+        dartPluginClass: SomeDartPlugin
+        fileName: some_dart_plugin.dart
+''');
+    pubspecFile.writeAsStringSync('''
+dependencies:
+  some_dart_plugin:
+    path: ${pluginDir.path}
+''');
+    packageConfigFile.writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "some_dart_plugin",
+      "rootUri": "${pluginDir.uri}",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ]
+}
+''');
+    await runner.run(<String>['dummy']);
+
+    final File generatedMain =
+        fileSystem.file('tizen/flutter/generated_main.dart');
+    expect(generatedMain, exists);
+    expect(generatedMain.readAsStringSync(), contains('''
+import 'package:some_dart_plugin/some_dart_plugin.dart';
+
+@pragma('vm:entry-point')
+class _PluginRegistrant {
+  @pragma('vm:entry-point')
+  static void register() {
+    SomeDartPlugin.register();
+  }
+}
+'''));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('Generates native plugin registrants', () async {
+    final Directory pluginDir = fileSystem.directory('/some_native_plugin');
+    pluginDir.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+flutter:
+  plugin:
+    platforms:
+      tizen:
+        pluginClass: SomeNativePlugin
+        fileName: some_native_plugin.h
+''');
+    pubspecFile.writeAsStringSync('''
+dependencies:
+  some_native_plugin:
+    path: ${pluginDir.path}
+''');
+    packageConfigFile.writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "some_native_plugin",
+      "rootUri": "${pluginDir.uri}",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ]
+}
+''');
+    await injectTizenPlugins(project);
+
+    final File cppPluginRegistrant =
+        fileSystem.file('tizen/flutter/generated_plugin_registrant.h');
+    expect(cppPluginRegistrant, exists);
+    expect(cppPluginRegistrant.readAsStringSync(), contains('''
+#include "some_native_plugin.h"
+
+// Registers Flutter plugins.
+void RegisterPlugins(flutter::PluginRegistry *registry) {
+  SomeNativePluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SomeNativePlugin"));
+}
+'''));
+
+    final File csharpPluginRegistrant =
+        fileSystem.file('tizen/flutter/GeneratedPluginRegistrant.cs');
+    expect(csharpPluginRegistrant, exists);
+    expect(csharpPluginRegistrant.readAsStringSync(), contains('''
+namespace Runner
+{
+    internal class GeneratedPluginRegistrant
+    {
+        [DllImport("flutter_plugins.so")]
+        public static extern void SomeNativePluginRegisterWithRegistrar(
+            FlutterDesktopPluginRegistrar registrar);
+
+        public static void RegisterPlugins(IPluginRegistry registry)
+        {
+            SomeNativePluginRegisterWithRegistrar(
+                registry.GetRegistrarForPlugin("SomeNativePlugin"));
+        }
+    }
+}
+'''));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+}
+
+class _DummyFlutterCommand extends FlutterCommand with DartPluginRegistry {
+  _DummyFlutterCommand() {
+    usesTargetOption();
+  }
+
+  @override
+  String name = 'dummy';
+
+  @override
+  String description;
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    return const FlutterCommandResult(ExitStatus.success);
+  }
+}

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -90,7 +90,7 @@ class _PluginRegistrant {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-  });
+  }, testOn: 'posix');
 
   testUsingContext('Generates native plugin registrants', () async {
     final Directory pluginDir = fileSystem.directory('/some_native_plugin');
@@ -160,7 +160,7 @@ namespace Runner
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
-  });
+  }, testOn: 'posix');
 }
 
 class _DummyFlutterCommand extends FlutterCommand with DartPluginRegistry {


### PR DESCRIPTION
- Specify the argument `sdkPath` for `AnalysisContextCollection` to allow the Dart analyzer to resolve the SDK path correctly during tests.
- Update the known plugins list.
- Add `tizen_plugins_test.dart` to verify Dart and C++/C# plugin registrants generation.