### PR TITLE
Symbolic links fix in linking process.

### DIFF
--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -199,9 +199,9 @@ class NativePlugins extends Target {
               if (userLibs.contains(libName)) {
                 continue;
               }
-              lib.copySync(libDir.childFile(lib.basename).path);
               userLibs.add(libName);
             }
+            lib.copySync(libDir.childFile(lib.basename).path);
 
             inputs.add(lib);
             if (isSharedLib) {

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -188,15 +188,20 @@ class NativePlugins extends Target {
       for (final Directory directory
           in pluginLibDirs.where((Directory d) => d.existsSync())) {
         for (final File lib in directory.listSync().whereType<File>()) {
-          final bool isSharedLib = lib.basename.endsWith('.so');
+          final bool isSharedLib =
+              lib.basename.contains(RegExp(r'(\.so)((\..*)|$)'));
           final bool isStaticLib = lib.basename.endsWith('.a');
+
           if (isSharedLib || isStaticLib) {
-            final String libName = getLibNameForFileName(lib.basename);
-            if (userLibs.contains(libName)) {
-              continue;
+            final bool isLinkableSharedLib = lib.basename.endsWith('.so');
+            if (isLinkableSharedLib || isStaticLib) {
+              final String libName = getLibNameForFileName(lib.basename);
+              if (userLibs.contains(libName)) {
+                continue;
+              }
+              lib.copySync(libDir.childFile(lib.basename).path);
+              userLibs.add(libName);
             }
-            lib.copySync(libDir.childFile(lib.basename).path);
-            userLibs.add(libName);
 
             inputs.add(lib);
             if (isSharedLib) {


### PR DESCRIPTION
This PR fix the issue with symlinks being included into linking with their names corrupted. 
Files such as `libprotobuf-lite.so.25.0.0` were added to linking with `-lprotobuf-lite.so.25.0` - after the last dot everything was deleted and they could not be found. 
Now the symlinks are copied, but are not added into linking.