### PR TITLE
Cleanup Runner.csproj and Runner.csproj.user

### DIFF
--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -74,7 +74,6 @@ class TizenProject extends FlutterProjectPlatform {
     const String initialXmlContent = '''
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
 </Project>
 ''';
     if (!userFile.existsSync()) {
@@ -128,7 +127,6 @@ class TizenProject extends FlutterProjectPlatform {
     if (isDotnet) {
       _deleteFile(editableDirectory.childDirectory('bin'));
       _deleteFile(editableDirectory.childDirectory('obj'));
-      _deleteFile(editableDirectory.childFile('Runner.csproj.user'));
     } else {
       if (isMultiApp) {
         _deleteFile(uiAppDirectory.childDirectory('Debug'));

--- a/templates/service-app/csharp/Runner.csproj
+++ b/templates/service-app/csharp/Runner.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/ui-app/csharp/Runner.csproj
+++ b/templates/ui-app/csharp/Runner.csproj
@@ -1,15 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/general/tizen_project_test.dart
+++ b/test/general/tizen_project_test.dart
@@ -79,15 +79,11 @@ void main() {
       ..createSync(recursive: true);
     final Directory objDir = project.editableDirectory.childDirectory('obj')
       ..createSync(recursive: true);
-    final File userFile = project.editableDirectory
-        .childFile('Runner.csproj.user')
-      ..createSync(recursive: true);
 
     project.clean();
 
     expect(binDir, isNot(exists));
     expect(objDir, isNot(exists));
-    expect(userFile, isNot(exists));
   });
 
   testUsingContext('Can clean C++ project', () async {


### PR DESCRIPTION
- Bump to `Tizen.NET.Sdk` 1.1.7
- Remove unnecessary `DebugType` property from `Runner.csproj`. This setting is a remnant of Mono.
- Remove empty PropertyGroup element from initial `Runner.csproj.user` content.
- Exclude `Runner.csproj.user` file from the clean target because it can be used by other IDEs.