### PR TITLE
Support flexible dotnet project name

### DIFF
--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -37,8 +37,7 @@ class TizenProject extends FlutterProjectPlatform {
   Directory get ephemeralDirectory =>
       managedDirectory.childDirectory('ephemeral');
 
-  bool get isDotnet =>
-      editableDirectory.childFile('Runner.csproj').existsSync();
+  bool get isDotnet => projectFile.path.endsWith('.csproj');
 
   bool get isMultiApp =>
       uiAppDirectory.existsSync() && serviceAppDirectory.existsSync();
@@ -55,6 +54,14 @@ class TizenProject extends FlutterProjectPlatform {
       ? uiManifestFile
       : editableDirectory.childFile('tizen-manifest.xml');
 
+  File get projectFile => editableDirectory
+      .listSync()
+      .whereType<File>()
+      .firstWhere((File file) => file.path.endsWith('.csproj'),
+          orElse: () => isMultiApp
+              ? uiAppDirectory.childFile('project_def.prop')
+              : editableDirectory.childFile('project_def.prop'));
+
   @override
   bool existsSync() => isMultiApp
       ? uiManifestFile.existsSync() && serviceManifestFile.existsSync()
@@ -69,8 +76,12 @@ class TizenProject extends FlutterProjectPlatform {
     if (!existsSync() || !isDotnet) {
       return;
     }
+    updateDotnetUserProjectFile();
+  }
 
-    final File userFile = editableDirectory.childFile('Runner.csproj.user');
+  void updateDotnetUserProjectFile() {
+    final File userFile =
+        editableDirectory.childFile('${projectFile.basename}.user');
     const String initialXmlContent = '''
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -54,13 +54,16 @@ class TizenProject extends FlutterProjectPlatform {
       ? uiManifestFile
       : editableDirectory.childFile('tizen-manifest.xml');
 
-  File get projectFile => editableDirectory
-      .listSync()
-      .whereType<File>()
-      .firstWhere((File file) => file.path.endsWith('.csproj'),
-          orElse: () => isMultiApp
-              ? uiAppDirectory.childFile('project_def.prop')
-              : editableDirectory.childFile('project_def.prop'));
+  File get projectFile {
+    for (final File file in editableDirectory.listSync().whereType<File>()) {
+      if (file.path.endsWith('.csproj')) {
+        return file;
+      }
+    }
+    return isMultiApp
+        ? uiAppDirectory.childFile('project_def.prop')
+        : editableDirectory.childFile('project_def.prop');
+  }
 
   @override
   bool existsSync() => isMultiApp
@@ -76,10 +79,10 @@ class TizenProject extends FlutterProjectPlatform {
     if (!existsSync() || !isDotnet) {
       return;
     }
-    updateDotnetUserProjectFile();
+    _updateDotnetUserProjectFile();
   }
 
-  void updateDotnetUserProjectFile() {
+  void _updateDotnetUserProjectFile() {
     final File userFile =
         editableDirectory.childFile('${projectFile.basename}.user');
     const String initialXmlContent = '''


### PR DESCRIPTION
- User can modify the c# application project name, not the fixed name `Runner.csproj`.
- This is a necessary modification to obtain the name of the Plugin project later.