### PR TITLE
Support dotnet plugin tooling

### DIFF
--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -74,7 +74,7 @@ class NativePlugins extends Target {
 
     // Check if there's anything to build.
     final List<TizenPlugin> nativePlugins =
-        await findTizenPlugins(project, nativeOnly: true);
+        await findTizenPlugins(project, cppOnly: true);
     if (nativePlugins.isEmpty) {
       depfileService.writeToFile(
         Depfile(inputs, outputs),

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -264,18 +264,18 @@ const List<String> _kKnownPlugins = <String>[
 ///
 /// See: [FlutterProject.ensureReadyForPlatformSpecificTooling] in `project.dart`
 Future<void> ensureReadyForTizenTooling(FlutterProject project) async {
-  if (!project.directory.existsSync() ||
-      project.hasExampleApp ||
-      project.isPlugin) {
-    return;
-  }
   final TizenProject tizenProject = TizenProject.fromFlutter(project);
   if (!tizenProject.existsSync()) {
     return;
   }
-  await tizenProject.ensureReadyForPlatformSpecificTooling();
-  await _ensurePluginsReadyForTizenTooling(project);
 
+  await tizenProject.ensureReadyForPlatformSpecificTooling();
+
+  if (project.hasExampleApp || project.isPlugin) {
+    return;
+  }
+
+  await _ensurePluginsReadyForTizenTooling(project);
   await injectTizenPlugins(project);
   await _informAvailableTizenPlugins(project);
 }

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -280,9 +280,7 @@ Future<void> ensureReadyForTizenTooling(FlutterProject project) async {
   await _informAvailableTizenPlugins(project);
 }
 
-Future<void> _ensurePluginsReadyForTizenTooling(
-  FlutterProject project,
-) async {
+Future<void> _ensurePluginsReadyForTizenTooling(FlutterProject project) async {
   final List<TizenPlugin> dotnetPlugins =
       await findTizenPlugins(project, dotnetOnly: true);
   for (final TizenPlugin plugin in dotnetPlugins) {

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -264,16 +264,16 @@ const List<String> _kKnownPlugins = <String>[
 ///
 /// See: [FlutterProject.ensureReadyForPlatformSpecificTooling] in `project.dart`
 Future<void> ensureReadyForTizenTooling(FlutterProject project) async {
+  if (!project.directory.existsSync() ||
+      project.hasExampleApp ||
+      project.isPlugin) {
+    return;
+  }
   final TizenProject tizenProject = TizenProject.fromFlutter(project);
   if (!tizenProject.existsSync()) {
     return;
   }
-
   await tizenProject.ensureReadyForPlatformSpecificTooling();
-
-  if (project.hasExampleApp || project.isPlugin) {
-    return;
-  }
 
   await _ensurePluginsReadyForTizenTooling(project);
   await injectTizenPlugins(project);

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -456,10 +456,8 @@ void _writeTizenPluginRegistrant(
   List<TizenPlugin> dotnetPlugins,
 ) {
   final Map<String, Object> context = <String, Object>{
-    'cppPlugins':
-        cppPlugins.map((TizenPlugin plugin) => plugin.toMap()).toList(),
-    'dotnetPlugins':
-        dotnetPlugins.map((TizenPlugin plugin) => plugin.toMap()).toList(),
+    'cppPlugins': cppPlugins.map((TizenPlugin plugin) => plugin.toMap()),
+    'dotnetPlugins': dotnetPlugins.map((TizenPlugin plugin) => plugin.toMap()),
   };
 
   if (project.isDotnet) {
@@ -501,8 +499,7 @@ void _writeIntermediateDotnetFiles(
 ) {
   final String projectFileName = project.projectFile.basename;
   final Map<String, Object> context = <String, Object>{
-    'dotnetPlugins':
-        dotnetPlugins.map((TizenPlugin plugin) => plugin.toMap()).toList(),
+    'dotnetPlugins': dotnetPlugins.map((TizenPlugin plugin) => plugin.toMap()),
   };
   renderTemplateToFile(
     _intermediateDotnetPropsTemplate,

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -103,7 +103,7 @@ mixin DartPluginRegistry on FlutterCommand {
   Future<FlutterCommandResult> verifyThenRunCommand(String? commandPath) async {
     final FlutterProject project = FlutterProject.current();
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
-    if (_usesTargetOption && tizenProject.isApplication) {
+    if (_usesTargetOption && tizenProject.existsSync() && !project.isPlugin) {
       final File mainDart = globals.fs.file(super.targetFile);
       final File generatedMainDart =
           tizenProject.managedDirectory.childFile('generated_main.dart');
@@ -286,11 +286,10 @@ Future<void> _ensurePluginsReadyForTizenTooling(
   final List<TizenPlugin> dotnetPlugins =
       await findTizenPlugins(project, dotnetOnly: true);
   for (final TizenPlugin plugin in dotnetPlugins) {
-    final TizenProject pluginProject =
-        TizenProject.fromFlutter(FlutterProject.fromDirectory(
-      plugin.directory.parent,
-    ));
-    await pluginProject.ensureReadyForPlatformSpecificTooling();
+    final File? projectFile = findDotnetProjectFile(plugin.directory);
+    if (projectFile != null) {
+      updateDotnetUserProjectFile(projectFile);
+    }
   }
 }
 

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -448,8 +448,8 @@ namespace Runner
         [DllImport("flutter_plugins.so")]
         public static extern void {{pluginClass}}RegisterWithRegistrar(
             FlutterDesktopPluginRegistrar registrar);
-      {{/cppPlugins}}
 
+      {{/cppPlugins}}
         public static void RegisterPlugins(IPluginRegistry registry)
         {
           {{#cppPlugins}}

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -37,6 +37,10 @@ class TizenProject extends FlutterProjectPlatform {
   Directory get ephemeralDirectory =>
       managedDirectory.childDirectory('ephemeral');
 
+  /// The intermediate output directory in the project that is managed by dotnet.
+  Directory get intermediateDirectory =>
+      editableDirectory.childDirectory('obj');
+
   bool get isDotnet => projectFile.path.endsWith('.csproj');
 
   bool get isMultiApp =>
@@ -66,9 +70,7 @@ class TizenProject extends FlutterProjectPlatform {
   }
 
   @override
-  bool existsSync() => isMultiApp
-      ? uiManifestFile.existsSync() && serviceManifestFile.existsSync()
-      : manifestFile.existsSync();
+  bool existsSync() => editableDirectory.existsSync();
 
   String get outputTpkName {
     final TizenManifest manifest = TizenManifest.parseFromXml(manifestFile);

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -41,8 +41,6 @@ class TizenProject extends FlutterProjectPlatform {
   Directory get intermediateDirectory =>
       editableDirectory.childDirectory('obj');
 
-  bool get isDotnet => projectFile.path.endsWith('.csproj');
-
   bool get isMultiApp =>
       uiAppDirectory.existsSync() && serviceAppDirectory.existsSync();
 
@@ -71,6 +69,10 @@ class TizenProject extends FlutterProjectPlatform {
 
   @override
   bool existsSync() => editableDirectory.existsSync();
+
+  bool get isDotnet => projectFile.path.endsWith('.csproj');
+
+  bool get isApplication => manifestFile.existsSync();
 
   String get outputTpkName {
     final TizenManifest manifest = TizenManifest.parseFromXml(manifestFile);


### PR DESCRIPTION
- A part of #333 
- Add `namespace` key in `pubspec.yaml` of the plugin.
- Add dotnet plugin registration code in `GeneratedPluginRegistrant.cs`.
- Generate `obj/Runner.csproj.flutter.props`, `obj/Runner.csproj.flutter.targets`  to refer the dotnet plugin projects at build time.
- Generate xxx.csproj.user files of dependent dotnet plugins.

### example plugin definition in pubspec.yaml ###
```yaml
flutter:
  plugin:
    platforms:
      tizen:
        namespace: Plugins.Tests
        pluginClass: HelloPlugin
        fileName: HelloPlugin.csproj
```

example plugin: https://github.com/WonyoungChoi/hello_plugin
