### PR TITLE
Simplify tizen_emulator.dart and add tests

### DIFF
--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -27,6 +27,7 @@ class TizenEmulatorManager extends EmulatorManager {
     required FileSystem fileSystem,
     required Logger logger,
     required ProcessManager processManager,
+    AndroidWorkflow? dummyAndroidWorkflow,
   })  : _processUtils =
             ProcessUtils(logger: logger, processManager: processManager),
         _tizenSdk = tizenSdk,
@@ -38,7 +39,7 @@ class TizenEmulatorManager extends EmulatorManager {
         ),
         super(
           androidSdk: null,
-          androidWorkflow: androidWorkflow!,
+          androidWorkflow: dummyAndroidWorkflow ?? androidWorkflow!,
           fileSystem: fileSystem,
           logger: logger,
           processManager: processManager,
@@ -281,7 +282,7 @@ class TizenEmulators extends EmulatorDiscovery {
 class TizenEmulator extends Emulator {
   TizenEmulator(
     String id, {
-    required Map<String, String> properties,
+    Map<String, String> properties = const <String, String>{},
     required Logger logger,
     required ProcessManager processManager,
     required TizenSdk? tizenSdk,

--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -267,11 +267,11 @@ class TizenEmulator extends Emulator {
 }
 
 @visibleForTesting
-Map<String, Map<String, String>> parseEmCliOutput(String output) {
+Map<String, Map<String, String>> parseEmCliOutput(String lines) {
   final Map<String, Map<String, String>> result =
       <String, Map<String, String>>{};
   String? lastId;
-  for (final String line in LineSplitter.split(output)) {
+  for (final String line in LineSplitter.split(lines)) {
     if (line.trim().isEmpty) {
       continue;
     } else if (!line.startsWith('  ')) {

--- a/test/general/tizen_emulator_test.dart
+++ b/test/general/tizen_emulator_test.dart
@@ -147,4 +147,26 @@ image_name
       expect(logger.statusText, contains('emulator_id is already running.'));
     });
   });
+
+  group('parseEmCliOutput', () {
+    testWithoutContext('Parses multiple entries', () async {
+      final Map<String, Map<String, String>> parsed = parseEmCliOutput('''
+entry_1
+  key_1    : value_1
+  key_2    : value_2
+
+entry_2
+  key_1    : value_3
+  key_2    : value_4
+
+entry_3
+''');
+      expect(parsed.length, equals(3));
+      expect(parsed.keys.first, equals('entry_1'));
+
+      final Map<String, String> first = parsed['entry_1'];
+      expect(first.length, equals(2));
+      expect(first['key_1'], equals('value_1'));
+    });
+  });
 }

--- a/test/general/tizen_emulator_test.dart
+++ b/test/general/tizen_emulator_test.dart
@@ -1,0 +1,136 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/tizen_doctor.dart';
+import 'package:flutter_tizen/tizen_emulator.dart';
+import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/emulator.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_tizen_sdk.dart';
+import '../src/fakes.dart';
+
+void main() {
+  FileSystem fileSystem;
+  FakeProcessManager processManager;
+  FakeTizenSdk tizenSdk;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.empty();
+    tizenSdk = FakeTizenSdk(fileSystem);
+  });
+
+  group('TizenEmulatorManager', () {
+    TizenEmulatorManager manager;
+
+    setUp(() {
+      manager = TizenEmulatorManager(
+        tizenSdk: tizenSdk,
+        tizenWorkflow: TizenWorkflow(
+          tizenSdk: tizenSdk,
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+        ),
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        processManager: processManager,
+        dummyAndroidWorkflow: AndroidWorkflow(
+          androidSdk: null,
+          featureFlags: TestFeatureFlags(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+        ),
+      );
+    });
+
+    testWithoutContext('Cannot create emulator if no image found', () async {
+      final CreateEmulatorResult result = await manager.createEmulator();
+      expect(result.success, isFalse);
+      expect(result.error,
+          contains('No suitable Tizen platform images are available.'));
+    });
+
+    testWithoutContext('Can create emulator without name', () async {
+      final File imageInfo = tizenSdk.platformsDirectory
+          .childFile('tizen-1.0/common/emulator-images/image_name/info.ini');
+      imageInfo
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+[Platform]
+profile=common
+version=1.0
+type=default
+name=image_name
+''');
+      processManager.addCommand(const FakeCommand(command: <String>[
+        '/tizen-studio/tools/emulator/bin/em-cli',
+        'create',
+        '-n',
+        'flutter_emulator',
+        '-p',
+        'image_name',
+      ]));
+
+      final CreateEmulatorResult result = await manager.createEmulator();
+      expect(result.success, isTrue);
+      expect(result.emulatorName, equals('flutter_emulator'));
+    });
+
+    testWithoutContext('Can list emulators', () async {
+      final File vmConfig = tizenSdk.sdkDataDirectory
+          .childFile('emulator/vms/emulator_id/vm_config.xml');
+      vmConfig
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="utf-8"?>
+<EmulatorConfiguration xmlns="http://www.tizen.org/em">
+    <baseInformation>
+        <deviceTemplate name="emulator_name" version="1.0"/>
+        <diskImage profile="common" type="standard" version="9.9"/>
+    </baseInformation>
+</EmulatorConfiguration>
+''');
+
+      final List<Emulator> emulators = await manager.getAllAvailableEmulators();
+      expect(emulators, isNotEmpty);
+      expect(emulators.first.id, equals('emulator_id'));
+      expect(emulators.first.name, equals('emulator_name'));
+    });
+  });
+
+  group('TizenEmulator', () {
+    testWithoutContext('Can launch only once', () async {
+      final BufferLogger logger = BufferLogger.test();
+      final TizenEmulator emulator = TizenEmulator(
+        'emulator_id',
+        logger: logger,
+        processManager: processManager,
+        tizenSdk: tizenSdk,
+      );
+
+      const List<String> launchCommand = <String>[
+        '/tizen-studio/tools/emulator/bin/em-cli',
+        'launch',
+        '--name',
+        'emulator_id',
+      ];
+      processManager.addCommand(const FakeCommand(command: launchCommand));
+      processManager.addCommand(FakeCommand(
+        command: launchCommand,
+        exitCode: 1,
+        stdout: '${emulator.id} is running now...',
+      ));
+
+      await emulator.launch();
+      await emulator.launch();
+
+      expect(logger.statusText, contains('emulator_id is already running.'));
+    });
+  });
+}

--- a/test/general/tizen_emulator_test.dart
+++ b/test/general/tizen_emulator_test.dart
@@ -53,6 +53,13 @@ void main() {
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/tizen-studio/tools/emulator/bin/em-cli',
+          'list-vm',
+          '-d',
+        ],
+      ));
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
           'list-platform',
           '-d',
         ],
@@ -65,6 +72,13 @@ void main() {
     });
 
     testWithoutContext('Can create emulator without name', () async {
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
+          'list-vm',
+          '-d',
+        ],
+      ));
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/tizen-studio/tools/emulator/bin/em-cli',
@@ -97,19 +111,20 @@ image_name
     });
 
     testWithoutContext('Can list emulators', () async {
-      final File vmConfig = tizenSdk.sdkDataDirectory
-          .childFile('emulator/vms/emulator_id/vm_config.xml');
-      vmConfig
-        ..createSync(recursive: true)
-        ..writeAsStringSync('''
-<?xml version="1.0" encoding="utf-8"?>
-<EmulatorConfiguration xmlns="http://www.tizen.org/em">
-    <baseInformation>
-        <deviceTemplate name="emulator_name" version="1.0"/>
-        <diskImage profile="common" type="standard" version="9.9"/>
-    </baseInformation>
-</EmulatorConfiguration>
-''');
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
+          'list-vm',
+          '-d',
+        ],
+        stdout: '''
+emulator_id
+  Platform          : image_name
+  Template          : emulator_name
+  Type              : standard
+  CPU Arch          : x86
+''',
+      ));
 
       final List<Emulator> emulators = await manager.getAllAvailableEmulators();
       expect(emulators, isNotEmpty);

--- a/test/general/tizen_emulator_test.dart
+++ b/test/general/tizen_emulator_test.dart
@@ -50,20 +50,16 @@ void main() {
     });
 
     testWithoutContext('Cannot create emulator if no image found', () async {
-      processManager.addCommand(const FakeCommand(
-        command: <String>[
-          '/tizen-studio/tools/emulator/bin/em-cli',
-          'list-vm',
-          '-d',
-        ],
-      ));
-      processManager.addCommand(const FakeCommand(
-        command: <String>[
-          '/tizen-studio/tools/emulator/bin/em-cli',
-          'list-platform',
-          '-d',
-        ],
-      ));
+      processManager.addCommand(const FakeCommand(command: <String>[
+        '/tizen-studio/tools/emulator/bin/em-cli',
+        'list-vm',
+        '-d',
+      ]));
+      processManager.addCommand(const FakeCommand(command: <String>[
+        '/tizen-studio/tools/emulator/bin/em-cli',
+        'list-platform',
+        '-d',
+      ]));
 
       final CreateEmulatorResult result = await manager.createEmulator();
       expect(result.success, isFalse);
@@ -72,13 +68,11 @@ void main() {
     });
 
     testWithoutContext('Can create emulator without name', () async {
-      processManager.addCommand(const FakeCommand(
-        command: <String>[
-          '/tizen-studio/tools/emulator/bin/em-cli',
-          'list-vm',
-          '-d',
-        ],
-      ));
+      processManager.addCommand(const FakeCommand(command: <String>[
+        '/tizen-studio/tools/emulator/bin/em-cli',
+        'list-vm',
+        '-d',
+      ]));
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/tizen-studio/tools/emulator/bin/em-cli',
@@ -86,7 +80,7 @@ void main() {
           '-d',
         ],
         stdout: '''
-image_name
+platform_name
   Profile           : wearable
   Version           : 6.0
   CPU Arch          : x86
@@ -100,7 +94,7 @@ image_name
           '-n',
           'flutter_emulator',
           '-p',
-          'image_name',
+          'platform_name',
         ],
         stdout: 'New virtual machine is created',
       ));
@@ -120,7 +114,7 @@ image_name
         stdout: '''
 emulator_id
   Platform          : image_name
-  Template          : emulator_name
+  Template          : template_name
   Type              : standard
   CPU Arch          : x86
 ''',
@@ -129,7 +123,7 @@ emulator_id
       final List<Emulator> emulators = await manager.getAllAvailableEmulators();
       expect(emulators, isNotEmpty);
       expect(emulators.first.id, equals('emulator_id'));
-      expect(emulators.first.name, equals('emulator_name'));
+      expect(emulators.first.name, equals('template_name'));
     });
   });
 
@@ -182,6 +176,14 @@ entry_3
       final Map<String, String> first = parsed['entry_1'];
       expect(first.length, equals(2));
       expect(first['key_1'], equals('value_1'));
+    });
+
+    testWithoutContext('Does not throw on corrupted input', () async {
+      final Map<String, Map<String, String>> parsed = parseEmCliOutput('''
+  key_1    : value_1
+  key_2    : value_2
+''');
+      expect(parsed, isEmpty);
     });
   });
 }

--- a/test/general/tizen_emulator_test.dart
+++ b/test/general/tizen_emulator_test.dart
@@ -50,6 +50,14 @@ void main() {
     });
 
     testWithoutContext('Cannot create emulator if no image found', () async {
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
+          'list-platform',
+          '-d',
+        ],
+      ));
+
       final CreateEmulatorResult result = await manager.createEmulator();
       expect(result.success, isFalse);
       expect(result.error,
@@ -57,25 +65,31 @@ void main() {
     });
 
     testWithoutContext('Can create emulator without name', () async {
-      final File imageInfo = tizenSdk.platformsDirectory
-          .childFile('tizen-1.0/common/emulator-images/image_name/info.ini');
-      imageInfo
-        ..createSync(recursive: true)
-        ..writeAsStringSync('''
-[Platform]
-profile=common
-version=1.0
-type=default
-name=image_name
-''');
-      processManager.addCommand(const FakeCommand(command: <String>[
-        '/tizen-studio/tools/emulator/bin/em-cli',
-        'create',
-        '-n',
-        'flutter_emulator',
-        '-p',
-        'image_name',
-      ]));
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
+          'list-platform',
+          '-d',
+        ],
+        stdout: '''
+image_name
+  Profile           : wearable
+  Version           : 6.0
+  CPU Arch          : x86
+  Skin shape        : circle
+''',
+      ));
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          '/tizen-studio/tools/emulator/bin/em-cli',
+          'create',
+          '-n',
+          'flutter_emulator',
+          '-p',
+          'image_name',
+        ],
+        stdout: 'New virtual machine is created',
+      ));
 
       final CreateEmulatorResult result = await manager.createEmulator();
       expect(result.success, isTrue);

--- a/test/src/fake_tizen_sdk.dart
+++ b/test/src/fake_tizen_sdk.dart
@@ -36,9 +36,6 @@ class FakeTizenSdk extends TizenSdk {
   final String _securityProfile;
 
   @override
-  Directory get sdkDataDirectory => _fileSystem.directory('/tizen-studio-data');
-
-  @override
   File get sdb => super.sdb..createSync(recursive: true);
 
   @override

--- a/test/src/fake_tizen_sdk.dart
+++ b/test/src/fake_tizen_sdk.dart
@@ -36,10 +36,16 @@ class FakeTizenSdk extends TizenSdk {
   final String _securityProfile;
 
   @override
+  Directory get sdkDataDirectory => _fileSystem.directory('/tizen-studio-data');
+
+  @override
   File get sdb => super.sdb..createSync(recursive: true);
 
   @override
   File get tizenCli => super.tizenCli..createSync(recursive: true);
+
+  @override
+  File get emCli => super.emCli..createSync(recursive: true);
 
   @override
   Future<RunResult> buildApp(


### PR DESCRIPTION
- Use `em-cli`'s `list-platform` and `list-vm` commands to obtain platform and emulator information and do not directly parse `.ini` and `.xml` files.
- Add tests for `TizenEmulatorManager`/`TizenEmulator` and the newly added function `parseEmCliOutput`.
- (minor change) `TizenEmulatorManager` accepts the `dummyAndroidWorkflow` argument to allow testing the class without context.