### PR TITLE
Remove PackageBuilder and use a unified BuildSystem

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -54,7 +54,7 @@ abstract class TizenAssetBundle extends Target {
       throw MissingDefineException(kBuildMode, name);
     }
     final BuildMode buildMode = getBuildModeForName(buildModeEnvironment);
-    final Directory outputDirectory = environment.outputDir
+    final Directory outputDirectory = environment.buildDir
         .childDirectory('flutter_assets')
       ..createSync(recursive: true);
 

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -40,7 +40,6 @@ import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:path/path.dart';
 
-import 'build_targets/package.dart';
 import 'commands/build.dart';
 import 'commands/clean.dart';
 import 'commands/create.dart';
@@ -213,7 +212,6 @@ Future<void> main(List<String> args) async {
             tizenSdk: tizenSdk,
             operatingSystemUtils: globals.os,
           ),
-      PackageBuilder: () => const PackageBuilder(),
       Pub: () => TizenPub(
             fileSystem: globals.fs,
             logger: globals.logger,

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -25,7 +25,6 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/linux/build_linux.dart';
 import 'package:flutter_tools/src/project.dart';
 
-import 'build_targets/application.dart';
 import 'build_targets/package.dart';
 import 'tizen_build_info.dart';
 import 'tizen_project.dart';
@@ -94,9 +93,9 @@ class TizenBuilder {
       generateDartPluginRegistry: false,
     );
 
-    final Target target = buildInfo.isDebug
-        ? DebugTizenApplication(tizenBuildInfo)
-        : ReleaseTizenApplication(tizenBuildInfo);
+    final Target target = tizenProject.isDotnet
+        ? DotnetTpk(tizenBuildInfo)
+        : NativeTpk(tizenBuildInfo);
 
     final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(
@@ -111,12 +110,6 @@ class TizenBuilder {
         }
         throwToolExit('The build failed.');
       }
-
-      // The packaging step must not be skipped even if there's no code change.
-      final Package package = tizenProject.isDotnet
-          ? DotnetTpk(tizenBuildInfo)
-          : NativeTpk(tizenBuildInfo);
-      await packageBuilder!.build(package, environment);
 
       if (buildInfo.performanceMeasurementFile != null) {
         final File outFile =

--- a/test/general/build_targets/application_test.dart
+++ b/test/general/build_targets/application_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tizen/build_targets/application.dart';
 import 'package:flutter_tizen/tizen_build_info.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -54,10 +55,11 @@ void main() {
       deviceProfile: 'wearable',
     )).build(environment);
 
-    final Directory bundleDir = fileSystem.directory('flutter_assets');
-    expect(bundleDir.childFile('vm_snapshot_data').existsSync(), isTrue);
-    expect(bundleDir.childFile('isolate_snapshot_data').existsSync(), isTrue);
-    expect(bundleDir.childFile('kernel_blob.bin').existsSync(), isTrue);
+    final Directory bundleDir =
+        environment.buildDir.childDirectory('flutter_assets');
+    expect(bundleDir.childFile('vm_snapshot_data'), exists);
+    expect(bundleDir.childFile('isolate_snapshot_data'), exists);
+    expect(bundleDir.childFile('kernel_blob.bin'), exists);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -73,7 +73,9 @@ void main() {
         artifacts: artifacts,
         processManager: processManager,
       );
-      outputDir.childDirectory('flutter_assets').createSync(recursive: true);
+      environment.buildDir
+          .childDirectory('flutter_assets')
+          .createSync(recursive: true);
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir
           .childFile('tizen_plugins/libflutter_plugins.so')
@@ -148,7 +150,9 @@ void main() {
         artifacts: artifacts,
         processManager: processManager,
       );
-      outputDir.childDirectory('flutter_assets').createSync(recursive: true);
+      environment.buildDir
+          .childDirectory('flutter_assets')
+          .createSync(recursive: true);
 
       processManager.addCommand(FakeCommand(
         command: <String>[
@@ -213,7 +217,9 @@ type = app
         artifacts: artifacts,
         processManager: processManager,
       );
-      outputDir.childDirectory('flutter_assets').createSync(recursive: true);
+      environment.buildDir
+          .childDirectory('flutter_assets')
+          .createSync(recursive: true);
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir
           .childFile('tizen_plugins/libflutter_plugins.so')
@@ -267,7 +273,9 @@ type = app
         artifacts: artifacts,
         processManager: processManager,
       );
-      outputDir.childDirectory('flutter_assets').createSync(recursive: true);
+      environment.buildDir
+          .childDirectory('flutter_assets')
+          .createSync(recursive: true);
 
       await expectLater(
         () => NativeTpk(const TizenBuildInfo(


### PR DESCRIPTION
- Generate the asset bundle (`flutter_assets`) in `buildDir` instead of `outputDir` to deal with the issue described in https://github.com/flutter-tizen/flutter-tizen/pull/51.
- Remove `PackageBuilder` and add `DebugTizenApplication`/`ReleaseTizenApplication` to dependencies of `DotnetTpk`/`NativeTpk`.
- Rename the target `Package` to `TizenPackage` and make it always unskippable.
