### PR TITLE
Add MethodChannel.SetMethodCallHanlder() for sync callback

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 
@@ -132,13 +133,23 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
         public class TheSetMethodCallHandlerMethod
         {
             [Fact]
-            public void Registers_Message_Handler()
+            public void Ensure_Handler_Is_Not_Null()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+
+                Assert.Throws<ArgumentNullException>(() => channel.SetMethodCallHandler(null as Func<MethodCall, Task<object>>));
+                Assert.Throws<ArgumentNullException>(() => channel.SetMethodCallHandler(null as Func<MethodCall, object>));
+            }
+
+            [Fact]
+            public void Registers_MethodCallHandler()
             {
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
                 channel.SetMethodCallHandler((call) =>
                 {
-                    return null;
+                    return string.Empty;
                 });
 
                 messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
@@ -146,11 +157,25 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
             }
 
             [Fact]
-            public void Unregisters_Message_Handler()
+            public void Registers_Async_MethodCallHandler()
             {
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
-                channel.SetMethodCallHandler(null);
+                channel.SetMethodCallHandler((call) =>
+                {
+                    return Task.FromResult<object>(string.Empty);
+                });
+
+                messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
+                                                       Arg.Any<BinaryMessageHandler>());
+            }
+
+            [Fact]
+            public void Unregisters_MethodCallHandler()
+            {
+                var messenger = Substitute.For<IBinaryMessenger>();
+                var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
+                channel.UnsetMethodCallHandler();
 
                 messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME), null);
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/MethodChannelTests.cs
@@ -147,10 +147,7 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
             {
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
-                channel.SetMethodCallHandler((call) =>
-                {
-                    return string.Empty;
-                });
+                channel.SetMethodCallHandler((call) => string.Empty);
 
                 messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
                                                        Arg.Any<BinaryMessageHandler>());
@@ -161,10 +158,7 @@ namespace Tizen.Flutter.Embedding.Tests.Channels
             {
                 var messenger = Substitute.For<IBinaryMessenger>();
                 var channel = new MethodChannel(TEST_CHANNEL_NAME, StandardMethodCodec.Instance, messenger);
-                channel.SetMethodCallHandler((call) =>
-                {
-                    return Task.FromResult<object>(string.Empty);
-                });
+                channel.SetMethodCallHandler((call) => Task.FromResult<object>(string.Empty));
 
                 messenger.Received().SetMessageHandler(Arg.Is<string>(x => x == TEST_CHANNEL_NAME),
                                                        Arg.Any<BinaryMessageHandler>());

--- a/templates/plugin/csharp/pluginClass.cs.tmpl
+++ b/templates/plugin/csharp/pluginClass.cs.tmpl
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Tizen.Flutter.Embedding;
 using Tizen.System;
 
@@ -17,11 +16,11 @@ namespace {{tizenNamespace}}
 
         public void OnDetachedFromEngine()
         {
-            _channel.SetMethodCallHandler(null);
+            _channel.UnsetMethodCallHandler();
             _channel = null;
         }
 
-        public async Task<object> HandleMethodCall(MethodCall call)
+        public object HandleMethodCall(MethodCall call)
         {
             if (call.Method == "getPlatformVersion")
             {


### PR DESCRIPTION
- Add a overloading of `MethodChannel.SetMethodCallHandler` for sync callback.
- Remove unnecessary delegate definition of `MethodCallHandler` to avoid hiding the callback method signature.
- Add `MethodChannel.UnsetMethodCallHandler()`. `ArgumentNullException` will be thrown if handler parameter of `SetMethodCallHandler()` is null.

### example:
```csharp
MethodChannel channel = new MethodChannel("foo");
channel.SetMethodCallHandler((call) => "bar");  // sync callback
channel.SetMethodCallHandler(async (call) => "bar"); // async callback
channel.SetMethodCallHandler((call) => Task.FromResult<object>("bar"));  // async callback
```