### PR TITLE
Fix outputs paths of the DebugTizenApplication target

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -142,10 +142,10 @@ class DebugTizenApplication extends TizenAssetBundle {
   @override
   List<Source> get outputs => <Source>[
         ...super.outputs,
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/vm_snapshot_data'),
+        const Source.pattern('{BUILD_DIR}/flutter_assets/vm_snapshot_data'),
         const Source.pattern(
-            '{OUTPUT_DIR}/flutter_assets/isolate_snapshot_data'),
-        const Source.pattern('{OUTPUT_DIR}/flutter_assets/kernel_blob.bin'),
+            '{BUILD_DIR}/flutter_assets/isolate_snapshot_data'),
+        const Source.pattern('{BUILD_DIR}/flutter_assets/kernel_blob.bin'),
       ];
 
   @override


### PR DESCRIPTION
This change was not included in https://github.com/flutter-tizen/flutter-tizen/pull/349 and, in turn, the build system always complains about missing output files.