### PR TITLE
Support downloading engine and embedder symbols

### DIFF
--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -291,40 +291,36 @@ def find_parent_project(project_dir: Path):
     return None
 
 
-def print_launch_json(project_dir: Path, program: Path, debugger: Path, port):
+def print_launch_json(project_dir: Path, program: Path, debugger: Path, port, load_all_symbols):
     if find_parent_project(project_dir):
         project_dir = find_parent_project(project_dir)
 
-    launch_json = '''
-{
+    launch_json = f'''
+{{
     "version": "0.2.0",
     "configurations": [
-        {
+        {{
             "name": "flutter-tizen: gdb",
             "request": "launch",
             "type": "cppdbg",
             "externalConsole": false,
             "MIMode": "gdb",
-            "symbolLoadInfo": {
-                "loadAll": false,
-                "exceptionList": "libc.so;libflutter*"
-            },
-            "cwd": "CWD",
-            "program": "PROGRAM",
-            "miDebuggerPath": "DEBUGGER",
-            "miDebuggerServerAddress": ":PORT"
-        }
+            "symbolLoadInfo": {{
+                "loadAll": {'true' if load_all_symbols else 'false'},
+                "exceptionList": "{'' if load_all_symbols else 'libc.so;libflutter*'}"
+            }},
+            "cwd": "{project_dir.as_posix()}",
+            "program": "{program.as_posix()}",
+            "miDebuggerPath": "{debugger.as_posix()}",
+            "miDebuggerServerAddress": ":{str(port)}"
+        }}
     ]
-}
+}}
 '''
-    print(launch_json
-          .replace('CWD', project_dir.as_posix())
-          .replace('PROGRAM', program.as_posix())
-          .replace('DEBUGGER', debugger.as_posix())
-          .replace('PORT', str(port)))
+    print(launch_json)
 
 
-def run(device: TizenDevice):
+def run(device: TizenDevice, debug_port=None):
     tizen_sdk_dir = locate_tizen_sdk()
     gdb_path = get_gdb_path(tizen_sdk_dir, device.get_architecture())
 
@@ -334,22 +330,24 @@ def run(device: TizenDevice):
         sys.exit('Could not find the runner executable.\n'
                  'Make sure the app has been built and installed to your device.')
 
-    debug_port = find_free_port()
-    device.forward_port(debug_port, debug_port)
+    already_running = debug_port is not None
+    if not already_running:
+        debug_port = find_free_port()
+        device.forward_port(debug_port, debug_port)
 
-    app_id = find_app_id(project_dir)
-    pid = find_pid(device, app_id)
-    if not pid:
-        sys.exit('The app is not running.')
+        app_id = find_app_id(project_dir)
+        pid = find_pid(device, app_id)
+        if not pid:
+            sys.exit('The app is not running.')
 
-    install_gdb_server(device, tizen_sdk_dir)
+        install_gdb_server(device, tizen_sdk_dir)
 
-    launched = threading.Event()
-    server_thread = threading.Thread(
-        target=start_gdb_server,
-        args=[device, app_id, debug_port, pid, launched], daemon=True)
-    server_thread.start()
-    launched.wait()
+        launched = threading.Event()
+        server_thread = threading.Thread(
+            target=start_gdb_server,
+            args=[device, app_id, debug_port, pid, launched], daemon=True)
+        server_thread.start()
+        launched.wait()
 
     print(f'gdbserver is listening for debug connection on port {debug_port}.')
     print_help()
@@ -360,14 +358,18 @@ def run(device: TizenDevice):
         if choice == 'h' or choice == 'H' or choice == '?':
             print_help()
         elif choice == 'r' or choice == 'R':
-            args = ['-ex', 'set auto-solib-add off',
-                    '-ex', f'target remote :{debug_port}',
-                    '-ex', 'share libc.so',
-                    '-ex', 'share libflutter*']
+            if already_running:
+                args = ['-ex', f'target remote :{debug_port}']
+            else:
+                args = ['-ex', 'set auto-solib-add off',
+                        '-ex', f'target remote :{debug_port}',
+                        '-ex', 'share libc.so',
+                        '-ex', 'share libflutter*']
             run_gdb_client(gdb_path, program, args)
             break
         elif choice == 'p' or choice == 'P':
-            print_launch_json(project_dir, program, gdb_path, debug_port)
+            print_launch_json(project_dir, program, gdb_path,
+                              debug_port, already_running)
         elif choice == 'v' or choice == 'V':
             if find_parent_project(project_dir):
                 subprocess.run(['code', '..'])
@@ -418,8 +420,8 @@ def download_symbols(device: TizenDevice):
         location = Path('symbols') / f'tizen-{device_arch}-{mode}'
         location.mkdir(parents=True, exist_ok=True)
 
-        basename = f'tizen-{device_arch}-{mode}_symbols.zip'
-        url = f'{base_url}/download/{short_version}/{basename}'
+        basename = f'tizen-{device_arch}-{mode}_symbols'
+        url = f'{base_url}/download/{short_version}/{basename}.zip'
 
         try:
             download_archive(f'Downloading {basename}...', url, location)
@@ -433,9 +435,11 @@ def main():
     parser = argparse.ArgumentParser(
         description='Tool for starting GDB server and client to debug a native app on a Tizen device.')
     parser.add_argument('-d', '--device-id', metavar='SERIAL', type=str,
-                        help='Target device ID')
+                        help='Target device ID.')
+    parser.add_argument('-p', '--debug-port', metavar='PORT', type=int,
+                        help='Connects to an already running gdbserver on the specified port.')
     parser.add_argument('--download-symbols', action='store_true',
-                        help='Downloads engine and embedder debug symbols')
+                        help='Downloads engine and embedder debug symbols.')
     args = parser.parse_args()
 
     try:
@@ -453,7 +457,7 @@ def main():
             if args.download_symbols:
                 download_symbols(device)
             else:
-                run(device)
+                run(device, args.debug_port)
     except (ProcessLookupError, KeyboardInterrupt):
         print()
 

--- a/bin/flutter-tizen-gdb
+++ b/bin/flutter-tizen-gdb
@@ -15,6 +15,8 @@ import sys
 import tarfile
 import tempfile
 import threading
+import urllib.request
+import zipfile
 from contextlib import closing
 from pathlib import Path
 from traceback import format_exc
@@ -375,16 +377,70 @@ def run(device: TizenDevice):
             break
 
 
+def download_archive(message: str, url: str, location: Path):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file = Path(temp_dir) / f'{location.name}.zip'
+        with urllib.request.urlopen(url) as context, temp_file.open(mode='wb') as file:
+            length = context.getheader('content-length')
+            total = f' of {int(length) / 1024 / 1024:.1f}' if length else ''
+            received = 0
+            while True:
+                buffer = context.read(64 * 1024)
+                if not buffer:
+                    break
+                received += file.write(buffer)
+                print(f'{message} {received / 1024 / 1024:.1f}{total} MB\r', end='')
+            print(f'{message} Done' + ' ' * 20)
+
+        with zipfile.ZipFile(temp_file, 'r') as archive:
+            archive.extractall(location)
+
+
+def download_symbols(device: TizenDevice):
+    version_file = Path(__file__).parent / 'internal' / 'engine.version'
+    with version_file.open() as file:
+        short_version = file.readline()[:7]
+    if len(short_version) != 7:
+        sys.exit('The engine version file is invalid.')
+
+    base_url = os.getenv('TIZEN_ENGINE_BASE_URL')
+    if not base_url:
+        base_url = 'https://github.com/flutter-tizen/engine/releases'
+
+    device_arch = device.get_architecture()
+    if device_arch == 'x86':
+        modes = ['debug']
+    else:
+        modes = ['debug', 'release']
+
+    for mode in modes:
+        # Any existing files will be overwritten.
+        location = Path('symbols') / f'tizen-{device_arch}-{mode}'
+        location.mkdir(parents=True, exist_ok=True)
+
+        basename = f'tizen-{device_arch}-{mode}_symbols.zip'
+        url = f'{base_url}/download/{short_version}/{basename}'
+
+        try:
+            download_archive(f'Downloading {basename}...', url, location)
+        except:
+            sys.exit(f'Failed to download a file from: {url}')
+
+    print('The downloaded symbols can be found at "symbols/".')
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Tool for starting GDB server and client to debug a native app on a Tizen device.')
-    parser.add_argument('-d', '--device', metavar='SERIAL', type=str,
-                        help='serial number of the target device')
+    parser.add_argument('-d', '--device-id', metavar='SERIAL', type=str,
+                        help='Target device ID')
+    parser.add_argument('--download-symbols', action='store_true',
+                        help='Downloads engine and embedder debug symbols')
     args = parser.parse_args()
 
     try:
-        if args.device:
-            device = TizenDevice(args.device)
+        if args.device_id:
+            device = TizenDevice(args.device_id)
         else:
             device = find_target_device()
 
@@ -394,7 +450,10 @@ def main():
             sys.exit('Not supported device.')
 
         with device:
-            run(device)
+            if args.download_symbols:
+                download_symbols(device)
+            else:
+                run(device)
     except (ProcessLookupError, KeyboardInterrupt):
         print()
 


### PR DESCRIPTION
Add the `--download-symbols` command to `flutter-tizen-gdb` to support downloading right debug symbols for the user device architecture and the target engine version.

The following command will download two zip files and extract them to `symbols/` in the current directory.

```sh
$ flutter-tizen-gdb --download-symbols
Downloading tizen-arm-debug_symbols.zip... Done
Downloading tizen-arm-release_symbols.zip... Done
The downloaded symbols can be found at "symbols/".
```

The detailed instruction on how to use the symbols can be found at:
https://github.com/flutter-tizen/flutter-tizen/wiki/Debugging-app's-native-code#resolving-engine-and-embedder-symbols