### PR TITLE
Prepare for turning on use_super_parameters

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -55,7 +55,7 @@ abstract class TizenPackage extends Target {
 }
 
 class DotnetTpk extends TizenPackage {
-  DotnetTpk(TizenBuildInfo tizenBuildInfo) : super(tizenBuildInfo);
+  DotnetTpk(super.tizenBuildInfo);
 
   final ProcessUtils _processUtils = ProcessUtils(
       logger: globals.logger, processManager: globals.processManager);
@@ -184,7 +184,7 @@ class DotnetTpk extends TizenPackage {
 }
 
 class NativeTpk extends TizenPackage {
-  NativeTpk(TizenBuildInfo tizenBuildInfo) : super(tizenBuildInfo);
+  NativeTpk(super.tizenBuildInfo);
 
   @override
   String get name => 'native_tpk';

--- a/lib/commands/clean.dart
+++ b/lib/commands/clean.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/runner/flutter_command.dart';
 import '../tizen_project.dart';
 
 class TizenCleanCommand extends CleanCommand {
-  TizenCleanCommand({bool verbose = false}) : super(verbose: verbose);
+  TizenCleanCommand({super.verbose});
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/lib/tizen_application_package.dart
+++ b/lib/tizen_application_package.dart
@@ -3,32 +3,22 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/application_package.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/flutter_application_package.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:process/process.dart';
 
 import 'tizen_tpk.dart';
 
 /// [FlutterApplicationPackageFactory] extended for Tizen.
 class TizenApplicationPackageFactory extends FlutterApplicationPackageFactory {
   TizenApplicationPackageFactory({
-    required AndroidSdk androidSdk,
-    required ProcessManager processManager,
-    required Logger logger,
-    required UserMessages userMessages,
-    required FileSystem fileSystem,
-  }) : super(
-          androidSdk: androidSdk,
-          processManager: processManager,
-          logger: logger,
-          userMessages: userMessages,
-          fileSystem: fileSystem,
-        );
+    required super.androidSdk,
+    required super.processManager,
+    required super.logger,
+    required super.userMessages,
+    required super.fileSystem,
+  });
 
   @override
   Future<ApplicationPackage?> getPackageForPlatform(

--- a/lib/tizen_artifacts.dart
+++ b/lib/tizen_artifacts.dart
@@ -5,7 +5,6 @@
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/os.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 
@@ -13,17 +12,11 @@ import 'tizen_build_info.dart';
 
 class TizenArtifacts extends CachedArtifacts {
   TizenArtifacts({
-    required FileSystem fileSystem,
-    required Platform platform,
-    required Cache cache,
-    required OperatingSystemUtils operatingSystemUtils,
-  })  : _cache = cache,
-        super(
-          fileSystem: fileSystem,
-          platform: platform,
-          cache: cache,
-          operatingSystemUtils: operatingSystemUtils,
-        );
+    required super.fileSystem,
+    required super.platform,
+    required super.cache,
+    required super.operatingSystemUtils,
+  }) : _cache = cache;
 
   final Cache _cache;
 

--- a/lib/tizen_build_system.dart
+++ b/lib/tizen_build_system.dart
@@ -2,18 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/dart_plugin_registrant.dart';
 
 class TizenBuildSystem extends FlutterBuildSystem {
   TizenBuildSystem({
-    required FileSystem fileSystem,
-    required Platform platform,
-    required Logger logger,
-  }) : super(fileSystem: fileSystem, platform: platform, logger: logger);
+    required super.fileSystem,
+    required super.platform,
+    required super.logger,
+  });
 
   @override
   Future<BuildResult> buildIncremental(

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -35,7 +35,7 @@ import 'vscode_helper.dart';
 /// See: [AndroidDevice] in `android_device.dart`
 class TizenDevice extends Device {
   TizenDevice(
-    String id, {
+    super.id, {
     required String modelId,
     required Logger logger,
     required ProcessManager processManager,
@@ -47,10 +47,11 @@ class TizenDevice extends Device {
         _fileSystem = fileSystem,
         _processUtils =
             ProcessUtils(logger: logger, processManager: processManager),
-        super(id,
-            category: Category.mobile,
-            platformType: PlatformType.custom,
-            ephemeral: true);
+        super(
+          category: Category.mobile,
+          platformType: PlatformType.custom,
+          ephemeral: true,
+        );
 
   final String _modelId;
   final Logger _logger;

--- a/lib/tizen_emulator.dart
+++ b/lib/tizen_emulator.dart
@@ -25,9 +25,9 @@ class TizenEmulatorManager extends EmulatorManager {
   TizenEmulatorManager({
     required TizenSdk? tizenSdk,
     required TizenWorkflow tizenWorkflow,
-    required FileSystem fileSystem,
-    required Logger logger,
-    required ProcessManager processManager,
+    required super.fileSystem,
+    required super.logger,
+    required super.processManager,
     AndroidWorkflow? dummyAndroidWorkflow,
   })  : _processUtils =
             ProcessUtils(logger: logger, processManager: processManager),
@@ -41,9 +41,6 @@ class TizenEmulatorManager extends EmulatorManager {
         super(
           androidSdk: null,
           androidWorkflow: dummyAndroidWorkflow ?? androidWorkflow!,
-          fileSystem: fileSystem,
-          logger: logger,
-          processManager: processManager,
         );
 
   final ProcessUtils _processUtils;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter-tizen/flutter-tizen
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   analyzer:


### PR DESCRIPTION
`super` parameters was introduced as a new language feature in [Dart 2.17](https://medium.com/dartlang/dart-2-17-b216bfc80c5d).

The `use_super_parameters` linter rule will be enabled by default in the upstream analysis options in the future. This change is a preparation for that.