### PR TITLE
Do not shallow clone the Flutter repo

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -32,7 +32,7 @@ GOTO :EOF
 
   REM Clone flutter repo if not installed.
   IF NOT EXIST "%flutter_dir%" (
-    git clone --depth=1 "%flutter_repo%" "%flutter_dir%" || (
+    git clone "%flutter_repo%" "%flutter_dir%" || (
       ECHO Error: Failed to download the flutter repo from %flutter_repo%.
       EXIT /B
     )
@@ -47,7 +47,7 @@ GOTO :EOF
       IF !version! NEQ !revision! (
         git reset --hard
         git clean -xdf
-        git fetch --depth=1 "%flutter_repo%" "!version!"
+        git fetch "%flutter_repo%" "!version!"
         git checkout FETCH_HEAD
 
         REM Invalidate the cache.

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -37,7 +37,7 @@ function update_flutter() {
 
   # Clone flutter repo if not installed.
   if [[ ! -d "$FLUTTER_DIR" ]]; then
-    git clone --depth=1 "$FLUTTER_REPO" "$FLUTTER_DIR"
+    git clone "$FLUTTER_REPO" "$FLUTTER_DIR"
   fi
 
   # GIT_DIR and GIT_WORK_TREE are used in the git command.
@@ -49,7 +49,7 @@ function update_flutter() {
   if [[ "$version" != "$(git rev-parse HEAD)" ]]; then
     git reset --hard
     git clean -xdf
-    git fetch --depth=1 "$FLUTTER_REPO" "$version"
+    git fetch "$FLUTTER_REPO" "$version"
     git checkout FETCH_HEAD
 
     # Invalidate the cache.


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/flutter-tizen/issues/368.

Effectively there should be no regression in the total fetch time because `flutter --version` also fetches all tags by default. Actually `git clone --depth=1` + `git fetch --tags` takes longer than a single `git clone`.