### PR TITLE
ElmFlutterView: Destory view instance

### DIFF
--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -9,6 +9,12 @@
 #include "include/flutter_engine.h"
 #include "tizen_log.h"
 
+ElmFlutterView::~ElmFlutterView() {
+  if (view_) {
+    FlutterDesktopViewDestroy(view_);
+  }
+}
+
 bool ElmFlutterView::RunEngine() {
   if (!parent_) {
     TizenLog::Error("The parent object is invalid.");
@@ -38,9 +44,10 @@ bool ElmFlutterView::RunEngine() {
   evas_object_ =
       static_cast<Evas_Object *>(FlutterDesktopViewGetEvasObject(view_));
   if (!evas_object_) {
-    TizenLog::Error("Could not get an Evas object");
+    TizenLog::Error("Could not get an Evas object.");
     return false;
   }
+
   return true;
 }
 

--- a/embedding/cpp/include/elm_flutter_view.h
+++ b/embedding/cpp/include/elm_flutter_view.h
@@ -24,7 +24,7 @@ class ElmFlutterView : public flutter::PluginRegistry {
       : parent_(parent),
         initial_width_(initial_width),
         initial_height_(initial_height) {}
-  virtual ~ElmFlutterView() {}
+  virtual ~ElmFlutterView();
 
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string &plugin_name) override;


### PR DESCRIPTION
When ElmFlutterView is deleted, view_ is no longer used, so destory it.