### PR TITLE
build_targets: Remove --whole-archive flag and realign libs

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -332,14 +332,12 @@ class NativeTpk extends TizenPackage {
       // The extra quotation marks ("") for linker flags are required due to
       // https://github.com/flutter-tizen/flutter-tizen/issues/218.
       '"-Wl,--unresolved-symbols=ignore-in-shared-libs"',
-      '-lflutter_tizen_${buildInfo.deviceProfile}',
-      '-L${libDir.path.toPosixPath()}',
       '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
       '-I${publicDir.path.toPosixPath()}',
       '-I${embeddingDir.childDirectory('include').path.toPosixPath()}',
-      '"-Wl,--whole-archive"',
       embeddingLib.path.toPosixPath(),
-      '"-Wl,--no-whole-archive"',
+      '-L${libDir.path.toPosixPath()}',
+      '-lflutter_tizen_${buildInfo.deviceProfile}',
       for (String lib in embeddingDependencies) '-l$lib',
       '-I${pluginsDir.childDirectory('include').path.toPosixPath()}',
       if (pluginsLib.existsSync()) '-lflutter_plugins',


### PR DESCRIPTION
The target library that needs to be referenced must be located behind it.
So change the order, --whole-archive is not needed anymore.
