### PR TITLE
Pass command line arguments through to Dart code

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -72,7 +72,8 @@ void FlutterApp::OnRegionFormatChanged(app_event_info_h event_info) {
 }
 
 int FlutterApp::Run(int argc, char **argv) {
-  for (int i = 0; i < argc; i++) {
+  // Skip the first argument as it's the binary name.
+  for (int i = 1; i < argc; i++) {
     dart_entrypoint_args_.push_back(argv[i]);
   }
 

--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -72,6 +72,10 @@ void FlutterApp::OnRegionFormatChanged(app_event_info_h event_info) {
 }
 
 int FlutterApp::Run(int argc, char **argv) {
+  for (int i = 0; i < argc; i++) {
+    dart_entrypoint_args_.push_back(argv[i]);
+  }
+
   ui_app_lifecycle_callback_s lifecycle_cb = {};
   lifecycle_cb.create = [](void *data) -> bool {
     auto *app = reinterpret_cast<FlutterApp *>(data);

--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -96,7 +96,6 @@ FlutterEngine::FlutterEngine(
   for (const std::string& arg : dart_entrypoint_args) {
     entrypoint_args.push_back(arg.c_str());
   }
-
   engine_prop.dart_entrypoint_argc = entrypoint_args.size();
   engine_prop.dart_entrypoint_argv = entrypoint_args.data();
 

--- a/embedding/cpp/flutter_service_app.cc
+++ b/embedding/cpp/flutter_service_app.cc
@@ -51,7 +51,8 @@ void FlutterServiceApp::OnRegionFormatChanged(app_event_info_h event_info) {
 }
 
 int FlutterServiceApp::Run(int argc, char **argv) {
-  for (int i = 0; i < argc; i++) {
+  // Skip the first argument as it's the binary name.
+  for (int i = 1; i < argc; i++) {
     dart_entrypoint_args_.push_back(argv[i]);
   }
 

--- a/embedding/cpp/flutter_service_app.cc
+++ b/embedding/cpp/flutter_service_app.cc
@@ -51,6 +51,10 @@ void FlutterServiceApp::OnRegionFormatChanged(app_event_info_h event_info) {
 }
 
 int FlutterServiceApp::Run(int argc, char **argv) {
+  for (int i = 0; i < argc; i++) {
+    dart_entrypoint_args_.push_back(argv[i]);
+  }
+
   service_app_lifecycle_callback_s lifecycle_cb = {};
   lifecycle_cb.create = [](void *data) -> bool {
     auto *app = reinterpret_cast<FlutterServiceApp *>(data);

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -79,6 +79,8 @@ namespace Tizen.Flutter.Embedding
 
         public override void Run(string[] args)
         {
+            DartEntrypointArgs.AddRange(args);
+
             // Log any unhandled exception.
             AppDomain.CurrentDomain.UnhandledException += (s, e) =>
             {

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -37,6 +37,8 @@ namespace Tizen.Flutter.Embedding
         protected internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
         public override void Run(string[] args)
         {
+            DartEntrypointArgs.AddRange(args);
+
             // Log any unhandled exception.
             AppDomain.CurrentDomain.UnhandledException += (s, e) =>
             {


### PR DESCRIPTION
Add plumbing for command line arguments so that they are available inside Dart's `main`.

```dart
void main(List<String> args) {
  print(args);

  runApp(...);
}
```

Result:
```
flutter: [`zaybxcwdveuftgsh`, __AUL_TARGET_UID__, KAAAAAEEAAATAAAAX19BVUxfVEFSR0VUX1VJRF9fAAUAAAA1MDAxAA==, __AUL_STARTTIME__, MwAAAAEEAAASAAAAX19BVUxfU1RBUlRUSU1FX18AEQAAADM2OTY5MC81NDQzMjk3MDAA, __APP_SVC_PKG_NAME__, PAAAAAEEAAAVAAAAX19BUFBfU1ZDX1BLR19OQU1FX18AFwAAAGNvbS5leGFtcGxlLm5hdGl2ZV9hcHAA, __AUL_EX_CHECK_IS_WAS_APP, LQAAAAEEAAAaAAAAX19BVUxfRVhfQ0hFQ0tfSVNfV0FTX0FQUAADAAAATm8A, __AUL_CALLER_PID__, KQAAAAEEAAATAAAAX19BVUxfQ0FMTEVSX1BJRF9fAAYAAAAxODMzMgA=, __AUL_CALLER_UID__, KAAAAAEEAAATAAAAX19BVUxfQ0FMTEVSX1VJRF9fAAUAAAA1MDAxAA==, __AUL_HWACC__, IgAAAAEEAAAOAAAAX19BVUxfSFdBQ0NfXwAEAAAAVVNFAA==, __AUL_ROOT_PATH__, RwAAAAEEAAASAAAAX19BVUxfUk9PVF9QQVRIX18AJQAAAC9vcHQvdXNyL2FwcHMvY29tLmV4YW1wbGUubmF0aXZlX2FwcAA=, __AUL_INTERNAL_POOL__, LAAAAAEEAAAWAAAAX19BVUxfSU5URVJOQUxfUE9PTF9fAAYAAABmYWxzZQA=, __AUL_API_VERSION__, KAAAAAEEAAAUAAAAX19BVUxfQVBJX1ZFUlNJT05fXwAEAAAANC4wAA==, __AUL_IS_GLOBAL__, JwAAAAEEAAASAAAAX19BVUxfSVNfR0xPQkFMX18ABQAAAHRydWUA, __AUL_INSTALLED_STORAGE__, MwAAAAEEAAAaAAAAX19BVUxfSU5TVEFMTEVEX1NUT1JBR0VfXwAJAAAAaW50ZXJuYWwA, __AUL_LOADER_ID__, JAAAAAEEAAASAAAAX19BVUxfTE9BREVSX0lEX18AAgAAADEA]
```