### PR TITLE
Remove NotifyAppIsInactive and NotifyAppIsDetached

### DIFF
--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -14,6 +14,7 @@ namespace {
 
 std::vector<std::string> ParseEngineArgs() {
   std::vector<std::string> engine_args;
+
   char* app_id;
   if (app_get_id(&app_id) != 0) {
     TizenLog::Warn("The app ID is not found.");

--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -131,21 +131,9 @@ void FlutterEngine::NotifyAppIsResumed() {
   }
 }
 
-void FlutterEngine::NotifyAppIsInactive() {
-  if (engine_) {
-    FlutterDesktopEngineNotifyAppIsInactive(engine_);
-  }
-}
-
 void FlutterEngine::NotifyAppIsPaused() {
   if (engine_) {
     FlutterDesktopEngineNotifyAppIsPaused(engine_);
-  }
-}
-
-void FlutterEngine::NotifyAppIsDetached() {
-  if (engine_) {
-    FlutterDesktopEngineNotifyAppIsDetached(engine_);
   }
 }
 

--- a/embedding/cpp/include/elm_flutter_view.h
+++ b/embedding/cpp/include/elm_flutter_view.h
@@ -15,7 +15,7 @@
 
 #include "flutter_engine.h"
 
-// The view class which creates and manages the Flutter engine instance.
+// Displays a Flutter screen in a Tizen application.
 class ElmFlutterView : public flutter::PluginRegistry {
  public:
   explicit ElmFlutterView(Evas_Object *parent) : parent_(parent) {}
@@ -56,10 +56,14 @@ class ElmFlutterView : public flutter::PluginRegistry {
   // The Evas object's parent instance handle.
   Evas_Object *parent_ = nullptr;
 
-  // The initial width of the view, or the maximum width if the value is zero.
+  // The initial width of the view.
+  //
+  // Defaults to the parent width if the value is zero.
   int32_t initial_width_ = 0;
 
-  // The initial height of the view, or the maximum height if the value is zero.
+  // The initial height of the view.
+  //
+  // Defaults to the parent height if the value is zero.
   int32_t initial_height_ = 0;
 };
 

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -15,7 +15,7 @@
 
 #include "flutter_engine.h"
 
-// The app base class which creates and manages the Flutter engine instance.
+// The app base class for headed Flutter execution.
 class FlutterApp : public flutter::PluginRegistry {
  public:
   explicit FlutterApp() {}
@@ -59,10 +59,14 @@ class FlutterApp : public flutter::PluginRegistry {
   // The y-coordinate of the top left corner of the window.
   int32_t window_offset_y_ = 0;
 
-  // The width of the window, or the maximum width if the value is zero.
+  // The width of the window.
+  //
+  // Defaults to the screen width if the value is zero.
   int32_t window_width_ = 0;
 
-  // The height of the window, or the maximum height if the value is zero.
+  // The height of the window.
+  //
+  // Defaults to the screen height if the value is zero.
   int32_t window_height_ = 0;
 
   // Whether the window should have a transparent background or not.
@@ -72,12 +76,15 @@ class FlutterApp : public flutter::PluginRegistry {
   bool is_window_focusable_ = true;
 
   // Whether the app should be displayed over other apps.
+  //
   // If true, the "http://tizen.org/privilege/window.priority.set" privilege
   // must be added to tizen-manifest.xml file.
   bool is_top_level_ = false;
 
-  // The optional entrypoint in the Dart project. If the value is empty,
-  // defaults to main().
+ private:
+  // The optional entrypoint in the Dart project.
+  //
+  // Defaults to main() if the value is empty.
   std::string dart_entrypoint_;
 
   // The list of Dart entrypoint arguments.

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -42,29 +42,17 @@ class FlutterEngine : public flutter::PluginRegistry {
   // Whether the engine is running.
   bool IsRunning() { return is_running_; }
 
-  // Resumes the engine.
+  // Notifies that the host app is visible and responding to user input.
   //
   // This method notifies the running Flutter app that it is "resumed" as per
   // the Flutter app lifecycle.
   void NotifyAppIsResumed();
 
-  // Pauses the engine.
-  //
-  // This method notifies the running Flutter app that it is "inactive" as per
-  // the Flutter app lifecycle.
-  void NotifyAppIsInactive();
-
-  // Stops the engine.
+  // Notifies that the host app is invisible and not responding to user input.
   //
   // This method notifies the running Flutter app that it is "paused" as per
   // the Flutter app lifecycle.
   void NotifyAppIsPaused();
-
-  // Detaches the engine.
-  //
-  // This method notifies the running Flutter app that it is "detached" as per
-  // the Flutter app lifecycle.
-  void NotifyAppIsDetached();
 
   // Notifies that the host app received an app control.
   //

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-// The engine for flutter execution.
+// The engine for Flutter execution.
 class FlutterEngine : public flutter::PluginRegistry {
  public:
   virtual ~FlutterEngine();

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -15,7 +15,7 @@
 
 #include "flutter_engine.h"
 
-// The app base class for headless execution.
+// The app base class for headless Flutter execution.
 class FlutterServiceApp : public flutter::PluginRegistry {
  public:
   explicit FlutterServiceApp() {}
@@ -48,9 +48,10 @@ class FlutterServiceApp : public flutter::PluginRegistry {
     dart_entrypoint_ = entrypoint;
   }
 
- protected:
-  // The optional entrypoint in the Dart project. If the value is empty,
-  // defaults to main().
+ private:
+  // The optional entrypoint in the Dart project.
+  //
+  // Defaults to main() if the value is empty.
   std::string dart_entrypoint_;
 
   // The list of Dart entrypoint arguments.

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -11,7 +11,7 @@ using static Tizen.Flutter.Embedding.Interop;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// The application base class which creates and manages the Flutter engine instance.
+    /// The app base class for headed Flutter execution.
     /// </summary>
     public class FlutterApplication : CoreUIApplication, IPluginRegistry
     {
@@ -26,12 +26,12 @@ namespace Tizen.Flutter.Embedding
         protected int WindowOffsetY { get; set; } = 0;
 
         /// <summary>
-        /// The width of the window, or the maximum width if the value is zero.
+        /// The width of the window. Defaults to the screen width if the value is zero.
         /// </summary>
         protected int WindowWidth { get; set; } = 0;
 
         /// <summary>
-        /// The height of the window, or the maximum height if the value is zero.
+        /// The height of the window. Defaults to the screen height if the value is zero.
         /// </summary>
         protected int WindowHeight { get; set; } = 0;
 
@@ -58,19 +58,19 @@ namespace Tizen.Flutter.Embedding
         protected List<string> EngineArgs { get; } = new List<string>();
 
         /// <summary>
-        /// The optional entrypoint in the Dart project. If the value is empty, defaults to main().
+        /// The optional entrypoint in the Dart project. Defaults to main() if the value is empty.
         /// </summary>
         public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
         /// The list of Dart entrypoint arguments.
         /// </summary>
-        protected List<string> DartEntrypointArgs { get; } = new List<string>();
+        private List<string> DartEntrypointArgs { get; } = new List<string>();
 
         /// <summary>
         /// The Flutter engine instance handle.
         /// </summary>
-        protected internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
+        internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
 
         /// <summary>
         /// The Flutter view instance handle.

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -11,7 +11,7 @@ using static Tizen.Flutter.Embedding.Interop;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// The <see cref="ServiceApplication"/> variant of <see cref="FlutterApplication"/>.
+    /// The app base class for headless Flutter execution.
     /// </summary>
     public class FlutterServiceApplication : ServiceApplication, IPluginRegistry
     {
@@ -22,19 +22,20 @@ namespace Tizen.Flutter.Embedding
         protected List<string> EngineArgs { get; } = new List<string>();
 
         /// <summary>
-        /// The optional entrypoint in the Dart project. If the value is empty, defaults to main().
+        /// The optional entrypoint in the Dart project. Defaults to main() if the value is empty.
         /// </summary>
         public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
         /// The list of Dart entrypoint arguments.
         /// </summary>
-        protected List<string> DartEntrypointArgs { get; } = new List<string>();
+        private List<string> DartEntrypointArgs { get; } = new List<string>();
 
         /// <summary>
         /// The Flutter engine instance handle.
         /// </summary>
-        protected internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
+        internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
+
         public override void Run(string[] args)
         {
             // Log any unhandled exception.


### PR DESCRIPTION
- Remove unused `NotifyAppIsInactive` and `NotifyAppIsDetached` from `FlutterEngine`.
- Switch access modifiers of some protected members of `FlutterApp`/`FlutterServiceApp` to private.
- Update stale documentation.