### PR TITLE
Add a --dart-entrypoint-args flag to flutter run to pass through Dart entrypoint arguments

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -411,6 +411,10 @@ class TizenDevice extends Device {
         if (debuggingOptions.useTestFonts) '--use-test-fonts',
         if (debuggingOptions.verboseSystemLogs) '--verbose-logging',
       ],
+      if (debuggingOptions.dartEntrypointArgs.isNotEmpty) ...<String>[
+        '--dart-entrypoint-args',
+        ...debuggingOptions.dartEntrypointArgs,
+      ],
       if (logReader is ForwardingLogReader) ...<String>[
         '--tizen-logging-port',
         logReader.hostPort.toString(),


### PR DESCRIPTION
Arguments added to --dart-entrypoint--args are added to engineArgs.

I referenced this https://github.com/flutter/flutter/pull/69607