### PR TITLE
Copy plugin resource files to app TPK

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -120,6 +120,10 @@ class DotnetTpk extends TizenPackage {
     if (pluginsLib.existsSync()) {
       pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
     }
+    final Directory pluginsResDir = pluginsDir.childDirectory('res');
+    if (pluginsResDir.existsSync()) {
+      copyDirectory(pluginsResDir, resDir);
+    }
     final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
     if (pluginsUserLibDir.existsSync()) {
       pluginsUserLibDir.listSync().whereType<File>().forEach(

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -89,6 +89,8 @@ class NativePlugins extends Target {
       ..createSync(recursive: true);
     final Directory includeDir = rootDir.childDirectory('include')
       ..createSync(recursive: true);
+    final Directory resDir = rootDir.childDirectory('res')
+      ..createSync(recursive: true);
     final Directory libDir = rootDir.childDirectory('lib')
       ..createSync(recursive: true);
 
@@ -176,6 +178,17 @@ class NativePlugins extends Target {
             .listSync(recursive: true)
             .whereType<File>()
             .forEach(inputs.add);
+      }
+      final Directory pluginResDir = plugin.directory.childDirectory('res');
+      if (pluginResDir.existsSync()) {
+        copyDirectory(pluginResDir, resDir.childDirectory(plugin.name));
+        pluginResDir
+            .listSync(recursive: true)
+            .whereType<File>()
+            .forEach((File file) {
+          inputs.add(file);
+          outputs.add(file);
+        });
       }
 
       // Copy user libs for later linking.

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -179,16 +179,18 @@ class NativePlugins extends Target {
             .whereType<File>()
             .forEach(inputs.add);
       }
+
+      // Copy resource files.
       final Directory pluginResDir = plugin.directory.childDirectory('res');
       if (pluginResDir.existsSync()) {
-        copyDirectory(pluginResDir, resDir.childDirectory(plugin.name));
-        pluginResDir
-            .listSync(recursive: true)
-            .whereType<File>()
-            .forEach((File file) {
-          inputs.add(file);
-          outputs.add(file);
-        });
+        copyDirectory(
+          pluginResDir,
+          resDir.childDirectory(plugin.name),
+          onFileCopied: (File srcFile, File destFile) {
+            inputs.add(srcFile);
+            outputs.add(destFile);
+          },
+        );
       }
 
       // Copy user libs for later linking.

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -135,6 +135,32 @@ dependencies:
     TizenSdk: () => FakeTizenSdk(fileSystem),
   });
 
+  testUsingContext('Copies resource files recursively', () async {
+    final Environment environment = Environment.test(
+      projectDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+    pluginDir.childFile('tizen/res/a/b.txt').createSync(recursive: true);
+
+    await NativePlugins(const TizenBuildInfo(
+      BuildInfo.release,
+      targetArch: 'arm',
+      deviceProfile: 'common',
+    )).build(environment);
+
+    final Directory outputResDir = environment.buildDir
+        .childDirectory('tizen_plugins/res/some_native_plugin');
+    expect(outputResDir.childFile('a/b.txt'), exists);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Cache: () => cache,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+  });
+
   testUsingContext('Can link to user libraries', () async {
     final Environment environment = Environment.test(
       projectDir,


### PR DESCRIPTION
Copy a plugin's `res` directory to `res/[plugin_name]` in the output TPK during app build.

This feature has been requested by @xiaowei-guan. He wants to selectively dlopen a shared library (bundled with a plugin) depending on the current platform version at runtime.

**Known issue:** The incremental build may fail (plugins do not rebuild) if a new lib or res file has been added after an initial build without modification to any other source file. Possible solutions include:

1. Always force rebuild plugins (this affects the overall build time), or
2. Support the "sharedLib" plugin type (which has been deprecated as of https://github.com/flutter-tizen/flutter-tizen/pull/98) and let the user explicitly specify lib names in `project_def.prop`. (This is a partial solution since res files are not listed by `project_def.prop`.)