### PR TITLE
Use native UI toolkit APIs for manipulation of view

### DIFF
--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -51,12 +51,7 @@ void ElmFlutterView::SetEngine(std::unique_ptr<FlutterEngine> engine) {
 void ElmFlutterView::Resize(int32_t width, int32_t height) {
   assert(IsRunning());
 
-  int32_t view_width = width, view_height = height;
-  evas_object_geometry_get(evas_object_, nullptr, nullptr, &view_width,
-                           &view_height);
-  if (view_width != width || view_height != height) {
-    FlutterDesktopViewResize(view_, width, height);
-  }
+  evas_object_resize(evas_object_, width, height);
 }
 
 int32_t ElmFlutterView::GetWidth() {


### PR DESCRIPTION
* If you can get the native handle from the view,
  and the manipulation for the handle is open to you,
  the view should respond appropriately to the manipulation.
  therefore, we don't need a view's resize API.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>