### PR TITLE
Build NativeEmbedding separately from NativeTpk

### DIFF
--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -1,0 +1,125 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/depfile.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/project.dart';
+
+import '../tizen_build_info.dart';
+import '../tizen_project.dart';
+import '../tizen_sdk.dart';
+import '../tizen_tpk.dart';
+import 'utils.dart';
+
+class NativeEmbedding extends Target {
+  NativeEmbedding(this.buildInfo);
+
+  final TizenBuildInfo buildInfo;
+
+  @override
+  String get name => 'tizen_cpp_embedding';
+
+  @override
+  List<Source> get inputs => const <Source>[
+        Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/embedding.dart'),
+      ];
+
+  @override
+  List<Source> get outputs => const <Source>[];
+
+  @override
+  List<String> get depfiles => <String>[
+        'tizen_embedding.d',
+      ];
+
+  @override
+  List<Target> get dependencies => const <Target>[];
+
+  @override
+  Future<void> build(Environment environment) async {
+    final List<File> inputs = <File>[];
+    final List<File> outputs = <File>[];
+    final DepfileService depfileService = DepfileService(
+      fileSystem: environment.fileSystem,
+      logger: environment.logger,
+    );
+
+    final FlutterProject project =
+        FlutterProject.fromDirectory(environment.projectDir);
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    final Directory outputDir = environment.buildDir
+        .childDirectory('tizen_embedding')
+      ..createSync(recursive: true);
+    final Directory embeddingDir = environment.fileSystem
+        .directory(Cache.flutterRoot)
+        .parent
+        .childDirectory('embedding')
+        .childDirectory('cpp');
+    copyDirectory(
+      embeddingDir.childDirectory('include'),
+      outputDir.childDirectory('include'),
+      onFileCopied: (File srcFile, File destFile) {
+        inputs.add(srcFile);
+        outputs.add(destFile);
+      },
+    );
+
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final String buildConfig = getBuildConfig(buildMode);
+
+    assert(tizenSdk != null);
+    String? apiVersion;
+    if (tizenProject.manifestFile.existsSync()) {
+      final TizenManifest tizenManifest =
+          TizenManifest.parseFromXml(tizenProject.manifestFile);
+      apiVersion = tizenManifest.apiVersion;
+      inputs.add(tizenProject.manifestFile);
+    }
+    final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
+      profile: buildInfo.deviceProfile,
+      apiVersion: apiVersion,
+      arch: buildInfo.targetArch,
+    );
+
+    final Directory buildDir = embeddingDir.childDirectory(buildConfig);
+    if (buildDir.existsSync()) {
+      buildDir.deleteSync(recursive: true);
+    }
+    final RunResult result = await tizenSdk!.buildNative(
+      embeddingDir.path,
+      configuration: buildConfig,
+      arch: getTizenCliArch(buildInfo.targetArch),
+      predefines: <String>[
+        '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+      ],
+      extraOptions: <String>['-fPIC'],
+      rootstrap: rootstrap.id,
+    );
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to build C++ embedding:\n$result');
+    }
+
+    final File outputLib = buildDir.childFile('libembedding_cpp.a');
+    if (!outputLib.existsSync()) {
+      throwToolExit(
+        'Build succeeded but the file ${outputLib.path} is not found:\n'
+        '${result.stdout}',
+      );
+    }
+    outputs
+        .add(outputLib.copySync(outputDir.childFile(outputLib.basename).path));
+
+    depfileService.writeToFile(
+      Depfile(inputs, outputs),
+      environment.buildDir.childFile('tizen_embedding.d'),
+    );
+  }
+}

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -113,7 +113,7 @@ class NativePlugins extends Target {
     final TizenManifest tizenManifest =
         TizenManifest.parseFromXml(tizenProject.manifestFile);
     final String profile = buildInfo.deviceProfile;
-    final String apiVersion = tizenManifest.apiVersion;
+    final String? apiVersion = tizenManifest.apiVersion;
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
       profile: profile,
       apiVersion: apiVersion,
@@ -275,15 +275,14 @@ USER_LIBS = pthread ${userLibs.join(' ')}
       throwToolExit('Failed to build native plugins:\n$result');
     }
 
-    File outputLib = buildDir.childFile('libflutter_plugins.so');
+    final File outputLib = buildDir.childFile('libflutter_plugins.so');
     if (!outputLib.existsSync()) {
       throwToolExit(
         'Build succeeded but the file ${outputLib.path} is not found:\n'
         '${result.stdout}',
       );
     }
-    outputLib = outputLib.copySync(rootDir.childFile(outputLib.basename).path);
-    outputs.add(outputLib);
+    outputs.add(outputLib.copySync(rootDir.childFile(outputLib.basename).path));
 
     // Remove intermediate files.
     for (final File lib in libDir

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -238,7 +238,7 @@ class TizenSdk {
 
   Rootstrap getFlutterRootstrap({
     required String profile,
-    required String apiVersion,
+    String? apiVersion,
     required String arch,
   }) {
     if (profile == 'common') {
@@ -249,6 +249,7 @@ class TizenSdk {
       // Note: The tv-samsung rootstrap is not publicly available.
       profile = 'tv-samsung';
     }
+    apiVersion ??= '4.0';
 
     double versionToDouble(String versionString) {
       final double? version = double.tryParse(versionString);

--- a/lib/tizen_tpk.dart
+++ b/lib/tizen_tpk.dart
@@ -132,7 +132,7 @@ class TizenManifest {
   String get version => _manifest.getAttribute('version')!;
 
   /// The target API version number.
-  String get apiVersion => _manifest.getAttribute('api-version') ?? '4.0';
+  String? get apiVersion => _manifest.getAttribute('api-version');
 
   late final XmlElement _profile = () {
     if (_manifest.findElements('profile').isEmpty) {

--- a/test/general/build_targets/embedding_test.dart
+++ b/test/general/build_targets/embedding_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tizen/build_targets/embedding.dart';
+import 'package:flutter_tizen/tizen_build_info.dart';
+import 'package:flutter_tizen/tizen_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fake_tizen_sdk.dart';
+
+void main() {
+  FileSystem fileSystem;
+  FakeProcessManager processManager;
+
+  setUpAll(() {
+    Cache.flutterRoot = 'flutter';
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.empty();
+
+    final Directory embeddingDir = fileSystem.directory('embedding/cpp');
+    embeddingDir.childFile('project_def.prop')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+APPNAME = embedding_cpp
+type = staticLib
+''');
+    embeddingDir.childFile('include/flutter.h').createSync(recursive: true);
+  });
+
+  testUsingContext('Build succeeds', () async {
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      artifacts: Artifacts.test(),
+      processManager: processManager,
+    );
+
+    await NativeEmbedding(const TizenBuildInfo(
+      BuildInfo.release,
+      targetArch: 'arm',
+      deviceProfile: 'common',
+    )).build(environment);
+
+    final Directory outputDir =
+        environment.buildDir.childDirectory('tizen_embedding');
+    expect(outputDir.childFile('include/flutter.h'), exists);
+    expect(outputDir.childFile('libembedding_cpp.a'), exists);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+  });
+}

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -67,7 +67,6 @@ void main() {
       final Environment environment = Environment.test(
         projectDir,
         outputDir: outputDir,
-        defines: <String, String>{kBuildMode: 'release'},
         fileSystem: fileSystem,
         logger: logger,
         artifacts: artifacts,
@@ -144,7 +143,6 @@ void main() {
       final Environment environment = Environment.test(
         projectDir,
         outputDir: outputDir,
-        defines: <String, String>{kBuildMode: 'debug'},
         fileSystem: fileSystem,
         logger: logger,
         artifacts: artifacts,
@@ -192,12 +190,6 @@ void main() {
 
   group('Native TPK', () {
     setUp(() {
-      fileSystem.directory('embedding/cpp').childFile('project_def.prop')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('''
-APPNAME = embedding_cpp
-type = staticLib
-''');
       projectDir.childFile('tizen/project_def.prop')
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -211,7 +203,6 @@ type = app
       final Environment environment = Environment.test(
         projectDir,
         outputDir: outputDir,
-        defines: <String, String>{kBuildMode: 'release'},
         fileSystem: fileSystem,
         logger: logger,
         artifacts: artifacts,
@@ -267,7 +258,6 @@ type = app
       final Environment environment = Environment.test(
         projectDir,
         outputDir: outputDir,
-        defines: <String, String>{kBuildMode: 'debug'},
         fileSystem: fileSystem,
         logger: logger,
         artifacts: artifacts,


### PR DESCRIPTION
- Extract `NativeEmbedding` from `NativeTpk` as a separate build target.
- Make `TizenManifest.apiVersion` nullable.

This change is a preparation for https://github.com/flutter-tizen/flutter-tizen/issues/397. This also reduces the total build time by up to 5 secs.