### PR TITLE
Add the build module command

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -43,6 +43,9 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
 
   # Build a TPK for emulator.
   flutter-tizen build tpk --device-profile wearable --debug --target-arch x86
+
+  # Build a Flutter module for adding to an existing Tizen app.
+  flutter-tizen build module --device-profile common
   ```
 
 - ### `clean`

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -446,6 +446,7 @@ class NativeModule extends TizenPackage {
 
     final File generatedPluginRegistrant = tizenProject.managedDirectory
         .childFile('generated_plugin_registrant.h');
+    assert(generatedPluginRegistrant.existsSync());
     generatedPluginRegistrant
         .copySync(incDir.childFile(generatedPluginRegistrant.basename).path);
 

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -79,7 +79,7 @@ class DotnetTpk extends TizenPackage {
     final Directory libDir = ephemeralDir.childDirectory('lib')
       ..createSync(recursive: true);
 
-    final Directory outputDir = environment.outputDir.childDirectory('tpk');
+    final Directory outputDir = environment.outputDir;
     if (outputDir.existsSync()) {
       outputDir.deleteSync(recursive: true);
     }
@@ -218,7 +218,7 @@ class NativeTpk extends TizenPackage {
     }
     libDir.createSync(recursive: true);
 
-    final Directory outputDir = environment.outputDir.childDirectory('tpk');
+    final Directory outputDir = environment.outputDir;
     if (outputDir.existsSync()) {
       outputDir.deleteSync(recursive: true);
     }
@@ -400,7 +400,7 @@ class NativeModule extends TizenPackage {
         FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
 
-    final Directory outputDir = environment.outputDir.childDirectory('module');
+    final Directory outputDir = environment.outputDir;
     if (outputDir.existsSync()) {
       outputDir.deleteSync(recursive: true);
     }

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -87,7 +87,17 @@ class BuildModuleCommand extends BuildSubCommand
     with DartPluginRegistry, TizenRequiredArtifacts {
   BuildModuleCommand({required bool verboseHelp})
       : super(verboseHelp: verboseHelp) {
-    addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
+    addBuildModeFlags(verboseHelp: verboseHelp);
+    addDartObfuscationOption();
+    addEnableExperimentation(hide: !verboseHelp);
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    addSplitDebugInfoOption();
+    addTreeShakeIconsFlag();
+    usesDartDefineOption();
+    usesExtraDartFlagOptions(verboseHelp: verboseHelp);
+    usesPubOption();
+    usesTargetOption();
+    usesTrackWidgetCreation(verboseHelp: verboseHelp);
     argParser.addOption(
       'target-arch',
       defaultsTo: 'arm',

--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -101,7 +101,11 @@ class BuildModuleCommand extends BuildSubCommand
       help: 'The type of device that the app will run on. Choose "wearable" '
           'for watch devices and "common" for IoT (Raspberry Pi) devices.',
     );
-    // TODO: --output-dir
+    argParser.addOption(
+      'output-dir',
+      help: 'The absolute path to the directory where the files are generated. '
+          'By default, this is "<current-directory>/build/tizen/module".',
+    );
   }
 
   @override
@@ -109,7 +113,7 @@ class BuildModuleCommand extends BuildSubCommand
 
   @override
   final String description =
-      'Build a module that can be embedded in your existing Tizen native app.';
+      'Build a module that can be embedded in your existing Tizen app.';
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -132,6 +136,7 @@ class BuildModuleCommand extends BuildSubCommand
       project: FlutterProject.current(),
       targetFile: targetFile,
       tizenBuildInfo: tizenBuildInfo,
+      outputDirectory: stringArg('output-dir'),
     );
     return FlutterCommandResult.success();
   }

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -58,8 +58,10 @@ class TizenBuilder {
       );
     }
 
-    final Directory outputDir =
-        project.directory.childDirectory('build').childDirectory('tizen');
+    final Directory outputDir = project.directory
+        .childDirectory('build')
+        .childDirectory('tizen')
+        .childDirectory('tpk');
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(
@@ -116,8 +118,7 @@ class TizenBuilder {
       status.stop();
     }
 
-    final Directory tpkDir = outputDir.childDirectory('tpk');
-    final File tpkFile = tpkDir.childFile(tizenProject.outputTpkName);
+    final File tpkFile = outputDir.childFile(tizenProject.outputTpkName);
     if (!tpkFile.existsSync()) {
       throwToolExit('The output TPK does not exist.');
     }
@@ -128,7 +129,7 @@ class TizenBuilder {
       color: TerminalColor.green,
     );
 
-    final Directory tpkrootDir = tpkDir.childDirectory('tpkroot');
+    final Directory tpkrootDir = outputDir.childDirectory('tpkroot');
     if (buildInfo.codeSizeDirectory != null && tpkrootDir.existsSync()) {
       sizeAnalyzer ??= SizeAnalyzer(
         fileSystem: globals.fs,
@@ -173,6 +174,7 @@ class TizenBuilder {
     required FlutterProject project,
     required TizenBuildInfo tizenBuildInfo,
     required String targetFile,
+    String? outputDirectory,
   }) async {
     // TODO: Add relevant tests.
 
@@ -189,8 +191,15 @@ class TizenBuilder {
       );
     }
 
-    final Directory outputDir =
-        project.directory.childDirectory('build').childDirectory('tizen');
+    Directory outputDir;
+    if (outputDirectory != null) {
+      outputDir = globals.fs.directory(outputDirectory);
+    } else {
+      outputDir = project.directory
+          .childDirectory('build')
+          .childDirectory('tizen')
+          .childDirectory('module');
+    }
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -63,7 +63,6 @@ class TizenBuilder {
         .childDirectory('tizen')
         .childDirectory('tpk');
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
-    // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(
         getTargetPlatformForArch(tizenBuildInfo.targetArch));
 
@@ -78,6 +77,7 @@ class TizenBuilder {
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
         kTargetFile: targetFile,
+        // Used by AotElfBase to generate an AOT snapshot.
         kTargetPlatform: targetPlatform,
         ...buildInfo.toBuildSystemEnvironment(),
         kDeviceProfile: tizenBuildInfo.deviceProfile,
@@ -176,10 +176,6 @@ class TizenBuilder {
     required String targetFile,
     String? outputDirectory,
   }) async {
-    // TODO: Add relevant tests.
-
-    // TODO: Minimize code duplication.
-    // TODO: Assert: tizenProject should always exist here.
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
     if (!tizenProject.existsSync()) {
       throwToolExit('This project is not configured for Tizen.');
@@ -201,7 +197,6 @@ class TizenBuilder {
           .childDirectory('module');
     }
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
-    // Used by AotElfBase to generate an AOT snapshot.
     final String targetPlatform = getNameForTargetPlatform(
         getTargetPlatformForArch(tizenBuildInfo.targetArch));
 
@@ -242,15 +237,14 @@ class TizenBuilder {
         }
         throwToolExit('The build failed.');
       }
-
-      if (buildInfo.performanceMeasurementFile != null) {
-        final File outFile =
-            globals.fs.file(buildInfo.performanceMeasurementFile);
-        // ignore: invalid_use_of_visible_for_testing_member
-        writePerformanceData(result.performance.values, outFile);
-      }
     } finally {
       status.stop();
     }
+
+    final String relativeOutPath = globals.fs.path.relative(outputDir.path);
+    globals.printStatus(
+      '${globals.logger.terminal.successMark} Built $relativeOutPath.',
+      color: TerminalColor.green,
+    );
   }
 }

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -223,11 +223,18 @@ class TizenBuilder {
       generateDartPluginRegistry: false,
     );
 
+    if (tizenProject.isDotnet) {
+      throwToolExit(
+        'Building a .NET module is currently not supported.\n'
+        'Delete the project and recreate with the "--tizen-language cpp" option.',
+      );
+    }
+    final Target target = NativeModule(tizenBuildInfo);
+
     final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(
         'Building a Tizen application in $buildModeName mode...');
     try {
-      final Target target = NativeModule(tizenBuildInfo);
       final BuildResult result =
           await globals.buildSystem.build(target, environment);
       if (!result.success) {

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -90,13 +90,13 @@ void main() {
           '-c',
           'Release',
           '-o',
-          '${outputDir.path}/tpk/',
+          '${outputDir.path}/',
           '/p:DefineConstants=COMMON_PROFILE',
           '${projectDir.path}/tizen',
         ],
         onRun: () {
           outputDir
-              .childFile('tpk/package_id-1.0.0.tpk')
+              .childFile('package_id-1.0.0.tpk')
               .createSync(recursive: true);
         },
       ));
@@ -160,13 +160,13 @@ void main() {
           '-c',
           'Debug',
           '-o',
-          '${outputDir.path}/tpk/',
+          '${outputDir.path}/',
           '/p:DefineConstants=COMMON_PROFILE',
           '${projectDir.path}/tizen',
         ],
         onRun: () {
           outputDir
-              .childFile('tpk/package_id-1.0.0.tpk')
+              .childFile('package_id-1.0.0.tpk')
               .createSync(recursive: true);
         },
       ));
@@ -227,7 +227,7 @@ type = app
         deviceProfile: 'common',
       )).build(environment);
 
-      final File outputTpk = outputDir.childFile('tpk/package_id-1.0.0.tpk');
+      final File outputTpk = outputDir.childFile('package_id-1.0.0.tpk');
       expect(outputTpk, exists);
 
       final Directory tizenDir = projectDir.childDirectory('tizen');

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -61,7 +61,7 @@ void main() {
     _installFakeEngineArtifacts(cache.getArtifactDirectory('engine'));
   });
 
-  group('.NET TPK', () {
+  group('DotnetTpk', () {
     testUsingContext('Build succeeds', () async {
       final Directory outputDir = projectDir.childDirectory('out');
       final Environment environment = Environment.test(
@@ -190,7 +190,7 @@ void main() {
     });
   });
 
-  group('Native TPK', () {
+  group('NativeTpk', () {
     setUp(() {
       projectDir.childFile('tizen/project_def.prop')
         ..createSync(recursive: true)
@@ -286,11 +286,75 @@ type = app
       TizenSdk: () => FakeTizenSdk(fileSystem),
     });
   });
+
+  group('NativeModule', () {
+    testUsingContext('Build succeeds', () async {
+      final Directory outputDir = projectDir.childDirectory('out');
+      final Environment environment = Environment.test(
+        projectDir,
+        outputDir: outputDir,
+        fileSystem: fileSystem,
+        logger: logger,
+        artifacts: artifacts,
+        processManager: processManager,
+      );
+      environment.buildDir
+          .childDirectory('flutter_assets')
+          .createSync(recursive: true);
+      environment.buildDir.childFile('app.so').createSync(recursive: true);
+      projectDir
+          .childFile('tizen/flutter/generated_plugin_registrant.h')
+          .createSync(recursive: true);
+      environment.buildDir
+          .childFile('tizen_plugins/libflutter_plugins.so')
+          .createSync(recursive: true);
+      environment.buildDir
+          .childFile('tizen_embedding/include/flutter.h')
+          .createSync(recursive: true);
+      environment.buildDir
+          .childFile('tizen_embedding/libembedding_cpp.a')
+          .createSync(recursive: true);
+
+      await NativeModule(const TizenBuildInfo(
+        BuildInfo.release,
+        targetArch: 'arm',
+        deviceProfile: 'common',
+      )).build(environment);
+
+      final Directory flutterAssetsDir =
+          outputDir.childDirectory('res/flutter_assets');
+      final File engineBinary = outputDir.childFile('lib/libflutter_engine.so');
+      final File embedder =
+          outputDir.childFile('lib/libflutter_tizen_common.so');
+      final File icuData = outputDir.childFile('res/icudtl.dat');
+      final File aotSnapshot = outputDir.childFile('lib/libapp.so');
+      final File generatedPluginRegistrant =
+          outputDir.childFile('inc/generated_plugin_registrant.h');
+      final File pluginsLib = outputDir.childFile('lib/libflutter_plugins.so');
+      final File embeddingHeader = outputDir.childFile('inc/flutter.h');
+      final File embeddingLib = outputDir.childFile('lib/libembedding_cpp.a');
+
+      expect(flutterAssetsDir, exists);
+      expect(engineBinary, exists);
+      expect(embedder, exists);
+      expect(icuData, exists);
+      expect(aotSnapshot, exists);
+      expect(generatedPluginRegistrant, exists);
+      expect(pluginsLib, exists);
+      expect(embeddingHeader, exists);
+      expect(embeddingLib, exists);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Cache: () => cache,
+      TizenSdk: () => FakeTizenSdk(fileSystem, securityProfile: 'test_profile'),
+    });
+  });
 }
 
 void _installFakeEngineArtifacts(Directory engineArtifactDir) {
   for (final String directory in <String>[
-    'tizen-common/cpp_client_wrapper',
+    'tizen-common/cpp_client_wrapper/include',
     'tizen-common/public',
   ]) {
     engineArtifactDir.childDirectory(directory).createSync(recursive: true);

--- a/test/general/tizen_builder_test.dart
+++ b/test/general/tizen_builder_test.dart
@@ -136,7 +136,7 @@ void main() {
           BuildResult(success: true),
           (Target target, Environment environment) {
             environment.outputDir
-                .childFile('tpk/package_id-1.0.0.tpk')
+                .childFile('package_id-1.0.0.tpk')
                 .createSync(recursive: true);
           },
         ),
@@ -180,10 +180,10 @@ void main() {
           BuildResult(success: true),
           (Target target, Environment environment) {
             environment.outputDir
-                .childDirectory('tpk/tpkroot')
+                .childDirectory('tpkroot')
                 .createSync(recursive: true);
             environment.outputDir
-                .childFile('tpk/package_id-1.0.0.tpk')
+                .childFile('package_id-1.0.0.tpk')
                 .createSync(recursive: true);
           },
         ),


### PR DESCRIPTION
Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/397.

Usage:
```sh
flutter-tizen build module -pmobile --debug --target-arch x86
```
By default, the following files are generated in the output directory. (The output directory can be specified with the `--output-dir` option.)

```sh
build/tizen/module/
├── inc
│   ├── elm_flutter_view.h
│   ├── flutter
│   │   ├── basic_message_channel.h
│   │   ├── binary_messenger.h
│   │   ├── byte_streams.h
│   │   ├── encodable_value.h
│   │   ├── ...
│   │   ├── plugin_registry.h
│   │   ├── standard_codec_serializer.h
│   │   ├── standard_message_codec.h
│   │   ├── standard_method_codec.h
│   │   └── texture_registrar.h
│   ├── flutter_app.h
│   ├── flutter_engine.h
│   ├── flutter_export.h
│   ├── flutter.h
│   ├── flutter_messenger.h
│   ├── flutter_platform_view.h
│   ├── flutter_plugin_registrar.h
│   ├── flutter_service_app.h
│   ├── flutter_texture_registrar.h
│   ├── flutter_tizen.h
│   └── generated_plugin_registrant.h
├── lib
│   ├── libapp.so                   # release build only
│   ├── libembedding_cpp.a
│   ├── libflutter_engine.so
│   ├── libflutter_plugins.so       # if any plugin built
│   └── libflutter_tizen_mobile.so
└── res
    ├── flutter_assets              # the contents may differ depending on apps
    │   ├── AssetManifest.json
    │   ├── FontManifest.json
    │   ├── fonts
    │   │   └── MaterialIcons-Regular.otf
    │   ├── isolate_snapshot_data   # debug build only
    │   ├── kernel_blob.bin         # debug build only
    │   ├── NOTICES.Z
    │   ├── packages
    │   │   └── cupertino_icons
    │   │       └── assets
    │   │           └── CupertinoIcons.ttf
    │   └── vm_snapshot_data        # debug build only
    └── icudtl.dat
```

The files (at least files under `lib` and `res`) must be copied to the container app's `inc`, `lib`, and `res`. The app's `project_def.prop` should be configured in this way:

```ini
APPNAME = module_app

type = app
profile = mobile-5.5

USER_SRCS = src/*.cc
USER_DEFS =
USER_INC_DIRS = inc
USER_OBJS =
USER_LIBS = embedding_cpp flutter_tizen_mobile flutter_plugins
USER_LIB_DIRS = lib
USER_LFLAGS = -Wl,--unresolved-symbols=ignore-in-shared-libs
USER_EDCS =
```

Make sure the `hw-acceleration="on"` attribute has been added to the app's `tizen-manifest.xml`:

```xml
<manifest>
  <ui-application ... hw-acceleration="on">
  </ui-application>
</manifest>
```

Then, you can build the app into a TPK using the following commands (debug x86 build).

```sh
$ tizen build-native -- .
$ tizen package -t tpk -- Debug/
```

The sample app code can be found at https://github.com/JSUYA/gallery/blob/test_flutterview/tizen/src/runner.cc.