### PR TITLE
Try connecting to the device logger indefinitely

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   analyzer:
   archive:
+  fake_async:
   flutter_tools:
     path: flutter/packages/flutter_tools
   file:


### PR DESCRIPTION
Let `ForwardingLogReader` attempt to establish a logging service even after the designated time has elapsed.

This is useful when debugging Flutter modules that are not started immediately after app launch.