### PR TITLE
Support sharedLib type native plugins

### DIFF
--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -29,6 +29,7 @@ class NativeEmbedding extends Target {
   @override
   List<Source> get inputs => const <Source>[
         Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/embedding.dart'),
+        Source.pattern('{FLUTTER_ROOT}/../lib/tizen_sdk.dart'),
       ];
 
   @override

--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -74,6 +74,18 @@ class NativeEmbedding extends Target {
 
     final BuildMode buildMode = buildInfo.buildInfo.mode;
     final String buildConfig = getBuildConfig(buildMode);
+    final Directory engineDir =
+        getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
+    final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
+
+    final Directory clientWrapperDir =
+        commonDir.childDirectory('cpp_client_wrapper');
+    final Directory publicDir = commonDir.childDirectory('public');
+    clientWrapperDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .forEach(inputs.add);
+    publicDir.listSync(recursive: true).whereType<File>().forEach(inputs.add);
 
     assert(tizenSdk != null);
     String? apiVersion;

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -115,18 +115,13 @@ class DotnetTpk extends TizenPackage {
 
     final Directory pluginsDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    final File pluginsLib = pluginsDir.childFile('libflutter_plugins.so');
-    if (pluginsLib.existsSync()) {
-      pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
-    }
     final Directory pluginsResDir = pluginsDir.childDirectory('res');
     if (pluginsResDir.existsSync()) {
       copyDirectory(pluginsResDir, resDir);
     }
-    final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
-    if (pluginsUserLibDir.existsSync()) {
-      pluginsUserLibDir.listSync().whereType<File>().forEach(
-          (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
+    final Directory pluginsLibDir = pluginsDir.childDirectory('lib');
+    if (pluginsLibDir.existsSync()) {
+      copyDirectory(pluginsLibDir, libDir);
     }
 
     // Run the .NET build.
@@ -253,15 +248,15 @@ class NativeTpk extends TizenPackage {
 
     final Directory pluginsDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    final File pluginsLib = pluginsDir.childFile('libflutter_plugins.so');
-    if (pluginsLib.existsSync()) {
-      pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
+    final Directory pluginsResDir = pluginsDir.childDirectory('res');
+    if (pluginsResDir.existsSync()) {
+      copyDirectory(pluginsResDir, resDir);
     }
-    final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
-    if (pluginsUserLibDir.existsSync()) {
-      pluginsUserLibDir.listSync().whereType<File>().forEach(
-          (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
+    final Directory pluginsLibDir = pluginsDir.childDirectory('lib');
+    if (pluginsLibDir.existsSync()) {
+      copyDirectory(pluginsLibDir, libDir);
     }
+    final File pluginsLib = pluginsLibDir.childFile('libflutter_plugins.so');
 
     // Prepare for build.
     final Directory clientWrapperDir =

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -457,14 +457,13 @@ class NativeModule extends TizenPackage {
     if (pluginsIncludeDir.existsSync()) {
       copyDirectory(pluginsIncludeDir, incDir);
     }
-    final File pluginsLib = pluginsDir.childFile('libflutter_plugins.so');
-    if (pluginsLib.existsSync()) {
-      pluginsLib.copySync(libDir.childFile(pluginsLib.basename).path);
+    final Directory pluginsResDir = pluginsDir.childDirectory('res');
+    if (pluginsResDir.existsSync()) {
+      copyDirectory(pluginsResDir, resDir);
     }
-    final Directory pluginsUserLibDir = pluginsDir.childDirectory('lib');
-    if (pluginsUserLibDir.existsSync()) {
-      pluginsUserLibDir.listSync().whereType<File>().forEach(
-          (File lib) => lib.copySync(libDir.childFile(lib.basename).path));
+    final Directory pluginsLibDir = pluginsDir.childDirectory('lib');
+    if (pluginsLibDir.existsSync()) {
+      copyDirectory(pluginsLibDir, libDir);
     }
 
     final Directory clientWrapperDir =

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -253,10 +253,16 @@ class NativeTpk extends TizenPackage {
       copyDirectory(pluginsResDir, resDir);
     }
     final Directory pluginsLibDir = pluginsDir.childDirectory('lib');
+    final List<String> pluginLibs = <String>[];
     if (pluginsLibDir.existsSync()) {
-      copyDirectory(pluginsLibDir, libDir);
+      copyDirectory(
+        pluginsLibDir,
+        libDir,
+        onFileCopied: (File srcFile, File destFile) {
+          pluginLibs.add(getLibNameForFileName(srcFile.basename));
+        },
+      );
     }
-    final File pluginsLib = pluginsLibDir.childFile('libflutter_plugins.so');
 
     // Prepare for build.
     final Directory clientWrapperDir =
@@ -326,7 +332,7 @@ class NativeTpk extends TizenPackage {
       for (String lib in embeddingDependencies) '-l$lib',
       '-I${tizenProject.managedDirectory.path.toPosixPath()}',
       '-I${pluginsDir.childDirectory('include').path.toPosixPath()}',
-      if (pluginsLib.existsSync()) '-lflutter_plugins',
+      for (String lib in pluginLibs) '-l$lib',
     ];
 
     // Build the app.

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -23,6 +23,10 @@ extension PathUtils on String {
     }
     return encloseWith + path + encloseWith;
   }
+
+  String escapeSpaces() {
+    return replaceAll(' ', r'\ ');
+  }
 }
 
 String getBuildConfig(BuildMode buildMode) {

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -23,10 +23,6 @@ extension PathUtils on String {
     }
     return encloseWith + path + encloseWith;
   }
-
-  String escapeSpaces() {
-    return replaceAll(' ', r'\ ');
-  }
 }
 
 String getBuildConfig(BuildMode buildMode) {

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -24,6 +24,7 @@ import 'package:package_config/package_config.dart';
 import 'package:yaml/yaml.dart';
 
 import 'tizen_project.dart';
+import 'tizen_sdk.dart';
 
 /// Constant for 'namespace' key in plugin maps.
 const String kNamespace = 'namespace';
@@ -33,6 +34,9 @@ const String kFileName = 'fileName';
 
 /// Constant for 'filePath' key in plugin maps.
 const String kFilePath = 'filePath';
+
+/// Constant for 'libName' key in plugin maps.
+const String kLibName = 'libName';
 
 /// Contains the parameters to template a Tizen plugin.
 ///
@@ -99,10 +103,19 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
       if (dartPluginClass != null) kDartPluginClass: dartPluginClass,
       if (fileName != null) kFileName: fileName,
       if (fileName != null) kFilePath: directory.childFile(fileName!).path,
+      if (libName != null) kLibName: isStaticLib ? 'flutter_plugins' : libName,
     };
   }
 
   File get projectFile => directory.childFile('project_def.prop');
+
+  late final Map<String, String> _projectProperties = () {
+    return parseIniFile(projectFile);
+  }();
+
+  bool get isStaticLib => _projectProperties['type'] == 'staticLib';
+
+  String? get libName => _projectProperties['APPNAME']?.toLowerCase();
 }
 
 /// Any [FlutterCommand] that references [targetFile] should extend this mixin
@@ -461,7 +474,7 @@ namespace Runner
     internal class GeneratedPluginRegistrant
     {
       {{#cppPlugins}}
-        [DllImport("flutter_plugins.so")]
+        [DllImport("{{libName}}.so")]
         public static extern void {{pluginClass}}RegisterWithRegistrar(
             FlutterDesktopPluginRegistrar registrar);
 

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -103,7 +103,7 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
       if (dartPluginClass != null) kDartPluginClass: dartPluginClass,
       if (fileName != null) kFileName: fileName,
       if (fileName != null) kFilePath: directory.childFile(fileName!).path,
-      if (libName != null) kLibName: isStaticLib ? 'flutter_plugins' : libName,
+      if (libName != null) kLibName: isSharedLib ? libName : 'flutter_plugins',
     };
   }
 
@@ -113,7 +113,7 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
     return parseIniFile(projectFile);
   }();
 
-  bool get isStaticLib => _projectProperties['type'] == 'staticLib';
+  bool get isSharedLib => _projectProperties['type'] == 'sharedLib';
 
   String? get libName => _projectProperties['APPNAME']?.toLowerCase();
 }

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -77,7 +77,7 @@ void main() {
           .createSync(recursive: true);
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir
-          .childFile('tizen_plugins/libflutter_plugins.so')
+          .childFile('tizen_plugins/lib/libflutter_plugins.so')
           .createSync(recursive: true);
       environment.buildDir
           .childFile('tizen_plugins/lib/libshared.so')
@@ -215,7 +215,7 @@ type = app
           .createSync(recursive: true);
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir
-          .childFile('tizen_plugins/libflutter_plugins.so')
+          .childFile('tizen_plugins/lib/libflutter_plugins.so')
           .createSync(recursive: true);
       environment.buildDir
           .childFile('tizen_plugins/lib/libshared.so')

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -306,7 +306,7 @@ type = app
           .childFile('tizen/flutter/generated_plugin_registrant.h')
           .createSync(recursive: true);
       environment.buildDir
-          .childFile('tizen_plugins/libflutter_plugins.so')
+          .childFile('tizen_plugins/lib/libflutter_plugins.so')
           .createSync(recursive: true);
       environment.buildDir
           .childFile('tizen_embedding/include/flutter.h')

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -123,8 +123,8 @@ dependencies:
 
     final Directory outputDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    expect(outputDir.childFile('libflutter_plugins.so'), exists);
     expect(outputDir.childFile('include/some_native_plugin.h'), exists);
+    expect(outputDir.childFile('lib/libflutter_plugins.so'), exists);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -154,7 +154,7 @@ dependencies:
 
     final Directory outputDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    expect(outputDir.childFile('libflutter_plugins.so'), isNot(exists));
+    expect(outputDir.childFile('lib/libflutter_plugins.so'), isNot(exists));
     expect(outputDir.childFile('lib/libsome_native_plugin.so'), exists);
     expect(outputDir.childFile('lib/libshared.so'), exists);
   }, overrides: <Type, Generator>{

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -106,7 +106,7 @@ dependencies:
         .createSync(recursive: true);
   });
 
-  testUsingContext('Can build for debug x86', () async {
+  testUsingContext('Can build staticLib project', () async {
     final Environment environment = Environment.test(
       projectDir,
       fileSystem: fileSystem,
@@ -121,13 +121,42 @@ dependencies:
       deviceProfile: 'wearable',
     )).build(environment);
 
-    final File outputLib =
-        environment.buildDir.childFile('tizen_plugins/libflutter_plugins.so');
-    expect(outputLib, exists);
+    final Directory outputDir =
+        environment.buildDir.childDirectory('tizen_plugins');
+    expect(outputDir.childFile('libflutter_plugins.so'), exists);
+    expect(outputDir.childFile('include/some_native_plugin.h'), exists);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Cache: () => cache,
+    TizenSdk: () => FakeTizenSdk(fileSystem),
+  });
 
-    final File header = environment.buildDir
-        .childFile('tizen_plugins/include/some_native_plugin.h');
-    expect(header, exists);
+  testUsingContext('Can build sharedLib project', () async {
+    final File projectDef = pluginDir.childFile('tizen/project_def.prop');
+    projectDef.writeAsStringSync(
+        projectDef.readAsStringSync().replaceFirst('staticLib', 'sharedLib'));
+
+    final Environment environment = Environment.test(
+      projectDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+    pluginDir.childFile('tizen/lib/libshared.so').createSync(recursive: true);
+
+    await NativePlugins(const TizenBuildInfo(
+      BuildInfo.debug,
+      targetArch: 'x86',
+      deviceProfile: 'wearable',
+    )).build(environment);
+
+    final Directory outputDir =
+        environment.buildDir.childDirectory('tizen_plugins');
+    expect(outputDir.childFile('libflutter_plugins.so'), isNot(exists));
+    expect(outputDir.childFile('lib/libsome_native_plugin.so'), exists);
+    expect(outputDir.childFile('lib/libshared.so'), exists);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -178,43 +207,16 @@ dependencies:
       deviceProfile: 'common',
     )).build(environment);
 
-    final Directory rootDir =
+    final Directory outputDir =
         environment.buildDir.childDirectory('tizen_plugins');
-    expect(rootDir.childFile('lib/libstatic.a'), isNot(exists));
-    expect(rootDir.childFile('lib/libshared.so'), exists);
+    expect(outputDir.childFile('lib/libstatic.a'), isNot(exists));
+    expect(outputDir.childFile('lib/libshared.so'), exists);
 
     final Map<String, String> projectDef =
-        parseIniFile(rootDir.childFile('project_def.prop'));
+        parseIniFile(outputDir.childFile('project_def.prop'));
     expect(
       projectDef['USER_LIBS'],
       contains('some_native_plugin static shared'),
-    );
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => processManager,
-    Cache: () => cache,
-    TizenSdk: () => FakeTizenSdk(fileSystem),
-  });
-
-  testUsingContext('Building non-staticLib project fails', () async {
-    final Environment environment = Environment.test(
-      projectDir,
-      fileSystem: fileSystem,
-      logger: logger,
-      artifacts: artifacts,
-      processManager: processManager,
-    );
-    final File projectDef = pluginDir.childFile('tizen/project_def.prop');
-    projectDef.writeAsStringSync(
-        projectDef.readAsStringSync().replaceFirst('staticLib', 'sharedLib'));
-
-    await expectLater(
-      () => NativePlugins(const TizenBuildInfo(
-        BuildInfo.release,
-        targetArch: 'arm',
-        deviceProfile: 'common',
-      )).build(environment),
-      throwsToolExit(),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -154,6 +154,12 @@ flutter:
         pluginClass: SomeNativePlugin
         fileName: some_native_plugin.h
 ''');
+    pluginDir.childFile('tizen/project_def.prop')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+APPNAME = some_native_plugin
+type = staticLib
+''');
     pubspecFile.writeAsStringSync('''
 dependencies:
   some_native_plugin:


### PR DESCRIPTION
Resolves https://github.com/flutter-tizen/plugins/issues/417. This is also an alternative solution of https://github.com/flutter-tizen/flutter-tizen/pull/392.

- Support both "staticLib" and "sharedLib" type plugins.
- "sharedLib" type plugins are built into individual shared objects (`lib{plugin_name}.so`). They can specify arbitrary linker options in their `project_def.prop`. In case of `webview_flutter_tizen`, for example:<p>
  ```ini
  USER_LIBS = pthread lightweight-web-engine.flutter tuv
  USER_LIB_DIRS = lib/${BUILD_ARCH}
  USER_LFLAGS =
  ```
- Let `TizenPlugins` depend on `NativeEmbedding` (whose build output contains compiled cpp_client_wrapper).
- Add missing input dependencies to `NativeEmbedding`.
- Change the output directory of `libflutter_plugins.so` from `{BUILD_ROOT}/tizen_plugins/` to `{BUILD_ROOT}/tizen_plugins/lib/`.


Deprecation notice: The "automatic user lib linking" support for "staticLib" type plugins will be removed in the future.

