### PR TITLE
Do not display the TV SDK not found warning

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -285,8 +285,7 @@ class TizenSdk {
 
     Rootstrap rootstrap = getRootstrap(profile, apiVersion, type);
     if (!rootstrap.isValid && profile == 'tv-samsung') {
-      _logger.printStatus(
-          'TV SDK could not be found. Trying with Wearable SDK...');
+      _logger.printTrace('TV SDK could not be found.');
       profile = 'wearable';
       rootstrap = getRootstrap(profile, apiVersion, type);
     }

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -227,7 +227,7 @@ void main() {
     expect(rootstrap.id, equals('wearable-4.0-device.flutter'));
     expect(rootstrap.isValid, isTrue);
 
-    expect(logger.statusText, contains('TV SDK could not be found.'));
+    expect(logger.traceText, contains('TV SDK could not be found.'));
   });
 
   testWithoutContext('SecurityProfiles.parseFromXml can detect active profile',


### PR DESCRIPTION
Resolves https://github.com/flutter-tizen/flutter-tizen/issues/410.

The warning is shown in the console output and often confuses the user.