### PR TITLE
Add the C# implementation of ElmFlutterView

### DIFF
--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -12,8 +12,6 @@
 ElmFlutterView::~ElmFlutterView() {
   if (view_) {
     FlutterDesktopViewDestroy(view_);
-    engine_ = nullptr;
-    view_ = nullptr;
   }
 }
 

--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -12,6 +12,7 @@
 ElmFlutterView::~ElmFlutterView() {
   if (view_) {
     FlutterDesktopViewDestroy(view_);
+    view_ = nullptr;
   }
 }
 

--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -12,6 +12,7 @@
 ElmFlutterView::~ElmFlutterView() {
   if (view_) {
     FlutterDesktopViewDestroy(view_);
+    engine_ = nullptr;
     view_ = nullptr;
   }
 }

--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -16,6 +16,7 @@ bool FlutterApp::OnCreate() {
     TizenLog::Error("Could not create a Flutter engine.");
     return false;
   }
+
 #ifdef WEARABLE_PROFILE
   if (renderer_type_ == FlutterRendererType::kEGL) {
     TizenLog::Error(
@@ -56,7 +57,6 @@ void FlutterApp::OnPause() {
 
 void FlutterApp::OnTerminate() {
   assert(IsRunning());
-  TizenLog::Debug("Shutting down the application...");
   FlutterDesktopViewDestroy(view_);
   engine_ = nullptr;
   view_ = nullptr;

--- a/embedding/cpp/flutter_service_app.cc
+++ b/embedding/cpp/flutter_service_app.cc
@@ -26,7 +26,6 @@ bool FlutterServiceApp::OnCreate() {
 
 void FlutterServiceApp::OnTerminate() {
   assert(IsRunning());
-  TizenLog::Debug("Shutting down the service application...");
   engine_ = nullptr;
 }
 

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -54,14 +54,15 @@ class FlutterApp : public flutter::PluginRegistry {
 
   virtual int Run(int argc, char **argv);
 
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string &plugin_name) override;
-
   bool IsRunning() { return view_ != nullptr; }
 
   void SetDartEntrypoint(const std::string &entrypoint) {
     dart_entrypoint_ = entrypoint;
   }
+
+  // |flutter::PluginRegistry|
+  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string &plugin_name) override;
 
  protected:
   // The x-coordinate of the top left corner of the window.

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -57,7 +57,7 @@ class FlutterApp : public flutter::PluginRegistry {
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string &plugin_name) override;
 
-  bool IsRunning() { return engine_ != nullptr; }
+  bool IsRunning() { return view_ != nullptr; }
 
   void SetDartEntrypoint(const std::string &entrypoint) {
     dart_entrypoint_ = entrypoint;

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -32,28 +32,43 @@ class FlutterApp : public flutter::PluginRegistry {
   }
   virtual ~FlutterApp() {}
 
+  // Called when the app is starting.
+  //
+  // Invoking this method implicitly initializes |engine_| and |view_|.
+  // Any method that overrides this method must invoke this method.
   virtual bool OnCreate();
 
+  // Called when the app becomes visible to the user.
   virtual void OnResume();
 
+  // Called when the app becomes invisible to the user.
   virtual void OnPause();
 
+  // Called when the app is terminating.
   virtual void OnTerminate();
 
+  // Called when an app control message has been received.
   virtual void OnAppControlReceived(app_control_h app_control);
 
+  // Called when the system is running out of memory.
   virtual void OnLowMemory(app_event_info_h event_info);
 
+  // Called when the device is running out of battery.
   virtual void OnLowBattery(app_event_info_h event_info) {}
 
+  // Called when the system language has changed.
   virtual void OnLanguageChanged(app_event_info_h event_info);
 
+  // Called when the system region format has changed.
   virtual void OnRegionFormatChanged(app_event_info_h event_info);
 
+  // Called when the device orientation has changed.
   virtual void OnDeviceOrientationChanged(app_event_info_h event_info) {}
 
+  // Runs the main loop of the app.
   virtual int Run(int argc, char **argv);
 
+  // Whether the app has started.
   bool IsRunning() { return view_ != nullptr; }
 
   void SetDartEntrypoint(const std::string &entrypoint) {

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -70,6 +70,7 @@ class FlutterEngine : public flutter::PluginRegistry {
   // Gives up ownership of |engine_|, but keeps a weak reference to it.
   FlutterDesktopEngineRef RelinquishEngine();
 
+  // |flutter::PluginRegistry|
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string& plugin_name) override;
 

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -62,7 +62,7 @@ class FlutterEngine : public flutter::PluginRegistry {
   // "system channel".
   void NotifyLowMemoryWarning();
 
-  // Notifies that the locale has changed.
+  // Notifies that the system locale has changed.
   //
   // This method sends a "locale change" message to Flutter.
   void NotifyLocaleChange();

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -39,14 +39,15 @@ class FlutterServiceApp : public flutter::PluginRegistry {
 
   virtual int Run(int argc, char **argv);
 
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string &plugin_name) override;
-
   bool IsRunning() { return engine_ != nullptr; }
 
   void SetDartEntrypoint(const std::string &entrypoint) {
     dart_entrypoint_ = entrypoint;
   }
+
+  // |flutter::PluginRegistry|
+  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string &plugin_name) override;
 
  private:
   // The optional entrypoint in the Dart project.

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -21,24 +21,34 @@ class FlutterServiceApp : public flutter::PluginRegistry {
   explicit FlutterServiceApp() {}
   virtual ~FlutterServiceApp() {}
 
+  // Called when the app is starting.
+  //
+  // Invoking this method implicitly initializes |engine_|.
+  // Any method that overrides this method must invoke this method.
   virtual bool OnCreate();
 
+  // Called when the app is terminating.
   virtual void OnTerminate();
 
+  // Called when an app control message has been received.
   virtual void OnAppControlReceived(app_control_h app_control);
 
+  // Called when the system is running out of memory.
   virtual void OnLowMemory(app_event_info_h event_info);
 
+  // Called when the device is running out of battery.
   virtual void OnLowBattery(app_event_info_h event_info) {}
 
+  // Called when the system language has changed.
   virtual void OnLanguageChanged(app_event_info_h event_info);
 
+  // Called when the system region format has changed.
   virtual void OnRegionFormatChanged(app_event_info_h event_info);
 
-  virtual void OnDeviceOrientationChanged(app_event_info_h event_info) {}
-
+  // Runs the main loop of the app.
   virtual int Run(int argc, char **argv);
 
+  // Whether the app has started.
   bool IsRunning() { return engine_ != nullptr; }
 
   void SetDartEntrypoint(const std::string &entrypoint) {

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -17,10 +17,6 @@ namespace Tizen.Flutter.Embedding
 
         protected override IntPtr CreateHandle(EvasObject parent)
         {
-            if (Handle == IntPtr.Zero)
-            {
-                throw new InvalidOperationException("The handle cannot be created again.");
-            }
             return Handle;
         }
     }
@@ -60,6 +56,9 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         private int InitialHeight { get; set; } = 0;
 
+        /// <summary>
+        /// Whether the view is running.
+        /// </summary>
         public bool IsRunning => !View.IsInvalid;
 
         /// <summary>
@@ -100,6 +99,9 @@ namespace Tizen.Flutter.Embedding
             InitialHeight = initialHeight;
         }
 
+        /// <summary>
+        /// Starts running the view with the associated engine, creating if not set.
+        /// </summary>
         public bool RunEngine()
         {
             if (Parent == null)
@@ -141,11 +143,17 @@ namespace Tizen.Flutter.Embedding
             return true;
         }
 
+        /// <summary>
+        /// Sets an engine associated with this view.
+        /// </summary>
         public void SetEngine(FlutterEngine engine)
         {
             Engine = engine;
         }
 
+        /// <summary>
+        /// Terminates the running view and the associated engine.
+        /// </summary>
         public void Destroy()
         {
             if (IsRunning)
@@ -155,6 +163,9 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
+        /// <summary>
+        /// Resizes the view.
+        /// </summary>
         public void Resize(int width, int height)
         {
             Debug.Assert(IsRunning);
@@ -165,10 +176,6 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
-        /// <summary>
-        /// Returns the plugin registrar handle for the plugin with the given name.
-        /// The name must be unique across the application.
-        /// </summary>
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
             if (Engine.IsValid)

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -5,11 +5,9 @@ using static Tizen.Flutter.Embedding.Interop;
 
 namespace Tizen.Flutter.Embedding
 {
-    // TODO: Revisit EvasObject.cs implementation.
-    // TODO: consider renaming EvasObjectImpl.
-    // TODO: Add documentation.
-    // TODO(another PR): Format the C# code.
-    // TODO: Runner.csproj: nuget or ProjectReference.
+    /// <summary>
+    /// Represents an <see cref="EvasObject"/> instance created by the embedder.
+    /// </summary>
     class EvasObjectImpl : EvasObject
     {
         public EvasObjectImpl(EvasObject parent, IntPtr handle) : base(parent)
@@ -19,26 +17,54 @@ namespace Tizen.Flutter.Embedding
 
         protected override IntPtr CreateHandle(EvasObject parent)
         {
+            if (Handle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("The handle cannot be created again.");
+            }
             return Handle;
         }
     }
 
+    /// <summary>
+    /// Displays a Flutter screen in a Tizen application.
+    /// </summary>
     public class ElmFlutterView : IPluginRegistry
     {
+        /// <summary>
+        /// The Flutter engine instance.
+        /// </summary>
         private FlutterEngine Engine { get; set; } = null;
 
+        /// <summary>
+        /// The Flutter view instance handle.
+        /// </summary>
         private FlutterDesktopView View { get; set; } = new FlutterDesktopView();
 
+        /// <summary>
+        /// The backing Evas object for this view.
+        /// </summary>
         public EvasObject EvasObject { get; private set; } = null;
 
+        /// <summary>
+        /// The parent of <see cref="EvasObject"/>.
+        /// </summary>
         private EvasObject Parent { get; set; } = null;
 
+        /// <summary>
+        /// The initial width of the view. Defaults to the parent width if the value is zero.
+        /// </summary>
         private int InitialWidth { get; set; } = 0;
 
+        /// <summary>
+        /// The initial height of the view. Defaults to the parent height if the value is zero.
+        /// </summary>
         private int InitialHeight { get; set; } = 0;
 
         public bool IsRunning => !View.IsInvalid;
 
+        /// <summary>
+        /// The current width of the view.
+        /// </summary>
         public int Width
         {
             get
@@ -49,6 +75,9 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
+        /// <summary>
+        /// The current height of the view.
+        /// </summary>
         public int Height
         {
             get

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -159,6 +159,7 @@ namespace Tizen.Flutter.Embedding
             if (IsRunning)
             {
                 FlutterDesktopViewDestroy(View);
+                Engine = null;
                 View = new FlutterDesktopView();
             }
         }
@@ -178,7 +179,7 @@ namespace Tizen.Flutter.Embedding
 
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
-            if (Engine.IsValid)
+            if (IsRunning)
             {
                 return Engine.GetRegistrarForPlugin(pluginName);
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using System;
 using System.Diagnostics;
 using ElmSharp;
 using static Tizen.Flutter.Embedding.Interop;
@@ -24,12 +28,12 @@ namespace Tizen.Flutter.Embedding
     /// <summary>
     /// Displays a Flutter screen in a Tizen application.
     /// </summary>
-    public class ElmFlutterView : IPluginRegistry
+    public class ElmFlutterView
     {
         /// <summary>
         /// The Flutter engine instance.
         /// </summary>
-        private FlutterEngine Engine { get; set; } = null;
+        public FlutterEngine Engine { get; set; } = null;
 
         /// <summary>
         /// The Flutter view instance handle.
@@ -102,8 +106,18 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// Starts running the view with the associated engine, creating if not set.
         /// </summary>
+        /// <remarks>
+        /// <see cref="Engine"/> must not be set again after this call.
+        /// <see cref="Destroy"/> must be called if the view is no longer used.
+        /// </remarks>
         public bool RunEngine()
         {
+            if (IsRunning)
+            {
+                TizenLog.Error("The engine is already running.");
+                return false;
+            }
+
             if (Parent == null)
             {
                 TizenLog.Error("The parent object is invalid.");
@@ -117,7 +131,8 @@ namespace Tizen.Flutter.Embedding
 
             if (!Engine.IsValid)
             {
-                throw new Exception("Could not create a Flutter engine.");
+                TizenLog.Error("Could not create a Flutter engine.");
+                return false;
             }
 
             var viewProperties = new FlutterDesktopViewProperties
@@ -144,14 +159,6 @@ namespace Tizen.Flutter.Embedding
         }
 
         /// <summary>
-        /// Sets an engine associated with this view.
-        /// </summary>
-        public void SetEngine(FlutterEngine engine)
-        {
-            Engine = engine;
-        }
-
-        /// <summary>
         /// Terminates the running view and the associated engine.
         /// </summary>
         public void Destroy()
@@ -175,15 +182,6 @@ namespace Tizen.Flutter.Embedding
             {
                 FlutterDesktopViewResize(View, width, height);
             }
-        }
-
-        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
-        {
-            if (IsRunning)
-            {
-                return Engine.GetRegistrarForPlugin(pluginName);
-            }
-            return new FlutterDesktopPluginRegistrar();
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -9,6 +9,7 @@ namespace Tizen.Flutter.Embedding
     // TODO: consider renaming EvasObjectImpl.
     // TODO: Add documentation.
     // TODO(another PR): Format the C# code.
+    // TODO: Runner.csproj: nuget or ProjectReference.
     class EvasObjectImpl : EvasObject
     {
         public EvasObjectImpl(EvasObject parent, IntPtr handle) : base(parent)
@@ -83,6 +84,11 @@ namespace Tizen.Flutter.Embedding
                 Engine = new FlutterEngine();
             }
 
+            if (!Engine.IsValid)
+            {
+                throw new Exception("Could not create a Flutter engine.");
+            }
+
             var viewProperties = new FlutterDesktopViewProperties
             {
                 width = InitialWidth,
@@ -109,6 +115,15 @@ namespace Tizen.Flutter.Embedding
         public void SetEngine(FlutterEngine engine)
         {
             Engine = engine;
+        }
+
+        public void Destroy()
+        {
+            if (IsRunning)
+            {
+                FlutterDesktopViewDestroy(View);
+                View = new FlutterDesktopView();
+            }
         }
 
         public void Resize(int width, int height)

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Diagnostics;
+using ElmSharp;
+using static Tizen.Flutter.Embedding.Interop;
+
+namespace Tizen.Flutter.Embedding
+{
+    // TODO: Revisit EvasObject.cs implementation.
+    // TODO: consider renaming EvasObjectImpl.
+    // TODO: Add documentation.
+    // TODO(another PR): Format the C# code.
+    class EvasObjectImpl : EvasObject
+    {
+        public EvasObjectImpl(EvasObject parent, IntPtr handle) : base(parent)
+        {
+            Handle = handle;
+        }
+
+        protected override IntPtr CreateHandle(EvasObject parent)
+        {
+            return Handle;
+        }
+    }
+
+    public class ElmFlutterView : IPluginRegistry
+    {
+        private FlutterEngine Engine { get; set; } = null;
+
+        private FlutterDesktopView View { get; set; } = new FlutterDesktopView();
+
+        public EvasObject EvasObject { get; private set; } = null;
+
+        private EvasObject Parent { get; set; } = null;
+
+        private int InitialWidth { get; set; } = 0;
+
+        private int InitialHeight { get; set; } = 0;
+
+        public bool IsRunning => !View.IsInvalid;
+
+        public int Width
+        {
+            get
+            {
+                Debug.Assert(IsRunning);
+
+                return EvasObject.Geometry.Width;
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                Debug.Assert(IsRunning);
+
+                return EvasObject.Geometry.Height;
+            }
+        }
+
+        public ElmFlutterView(EvasObject parent)
+        {
+            Parent = parent;
+        }
+
+        public ElmFlutterView(EvasObject parent, int initialWidth, int initialHeight)
+        {
+            Parent = parent;
+            InitialWidth = initialWidth;
+            InitialHeight = initialHeight;
+        }
+
+        public bool RunEngine()
+        {
+            if (Parent == null)
+            {
+                TizenLog.Error("The parent object is invalid.");
+                return false;
+            }
+
+            if (Engine == null)
+            {
+                Engine = new FlutterEngine();
+            }
+
+            var viewProperties = new FlutterDesktopViewProperties
+            {
+                width = InitialWidth,
+                height = InitialHeight,
+            };
+
+            View = FlutterDesktopViewCreateFromElmParent(ref viewProperties, Engine.Engine, Parent);
+            if (View.IsInvalid)
+            {
+                TizenLog.Error("Could not launch a Flutter view.");
+                return false;
+            }
+
+            EvasObject = new EvasObjectImpl(Parent, FlutterDesktopViewGetEvasObject(View));
+            if (!EvasObject.IsRealized)
+            {
+                TizenLog.Error("Could not get an Evas object.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public void SetEngine(FlutterEngine engine)
+        {
+            Engine = engine;
+        }
+
+        public void Resize(int width, int height)
+        {
+            Debug.Assert(IsRunning);
+
+            if (EvasObject.Geometry.Width != width || EvasObject.Geometry.Height != height)
+            {
+                FlutterDesktopViewResize(View, width, height);
+            }
+        }
+
+        /// <summary>
+        /// Returns the plugin registrar handle for the plugin with the given name.
+        /// The name must be unique across the application.
+        /// </summary>
+        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
+        {
+            if (Engine.IsValid)
+            {
+                return Engine.GetRegistrarForPlugin(pluginName);
+            }
+            return new FlutterDesktopPluginRegistrar();
+        }
+    }
+}

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -148,7 +148,7 @@ namespace Tizen.Flutter.Embedding
                 return false;
             }
 
-            EvasObject = new EvasObjectImpl(Parent, FlutterDesktopViewGetEvasObject(View));
+            EvasObject = new EvasObjectImpl(Parent, FlutterDesktopViewGetNativeHandle(View));
             if (!EvasObject.IsRealized)
             {
                 TizenLog.Error("Could not get an Evas object.");

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -101,6 +101,11 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         protected internal FlutterDesktopView View { get; private set; } = new FlutterDesktopView();
 
+        /// <summary>
+        /// Whether the app has started.
+        /// </summary>
+        public bool IsRunning => View != null;
+
         public override void Run(string[] args)
         {
             // Log any unhandled exception.
@@ -152,7 +157,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnResume();
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyAppIsResumed();
         }
@@ -161,7 +166,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnPause();
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyAppIsPaused();
         }
@@ -170,7 +175,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnTerminate();
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             DotnetPluginRegistry.Instance.RemoveAllPlugins();
             FlutterDesktopViewDestroy(View);
@@ -180,7 +185,7 @@ namespace Tizen.Flutter.Embedding
 
         protected override void OnAppControlReceived(AppControlReceivedEventArgs e)
         {
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyAppControl(e.ReceivedAppControl);
         }
@@ -189,7 +194,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnLowMemory(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLowMemoryWarning();
         }
@@ -198,7 +203,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnLocaleChanged(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
         }
@@ -207,14 +212,14 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnRegionFormatChanged(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
         }
 
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
-            if (Engine.IsValid)
+            if (IsRunning)
             {
                 return Engine.GetRegistrarForPlugin(pluginName);
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -212,10 +212,6 @@ namespace Tizen.Flutter.Embedding
             Engine.NotifyLocaleChange();
         }
 
-        /// <summary>
-        /// Returns the plugin registrar handle for the plugin with the given name.
-        /// The name must be unique across the application.
-        /// </summary>
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
             if (Engine.IsValid)

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -25,14 +25,17 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         public bool IsValid => !Engine.IsInvalid;
 
-        public FlutterEngine(string dartEntrypoint, List<string> dartEntrypointArgs) : this(
-            "../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so", dartEntrypoint, dartEntrypointArgs)
+        public FlutterEngine(string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
+            : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so",
+                   dartEntrypoint, dartEntrypointArgs)
         {
         }
 
         public FlutterEngine(string assetsPath, string icuDataPath, string aotLibraryPath,
-            string dartEntrypoint, List<string> dartEntrypointArgs)
+                             string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
         {
+            dartEntrypointArgs = dartEntrypointArgs ?? new List<string>();
+
             using (var switches = new StringArray(ParseEngineArgs()))
             using (var entrypointArgs = new StringArray(dartEntrypointArgs))
             {

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -128,8 +128,8 @@ namespace Tizen.Flutter.Embedding
         }
 
         /// <summary>
-        /// Notifies that the locale has changed.
-        /// ThisThis method sends a "locale change" message to Flutter.
+        /// Notifies that the system locale has changed.
+        /// This method sends a "locale change" message to Flutter.
         /// </summary>
         public void NotifyLocaleChange()
         {

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -29,6 +29,11 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         internal FlutterEngine Engine { get; private set; } = null;
 
+        /// <summary>
+        /// Whether the app has started.
+        /// </summary>
+        public bool IsRunning => Engine != null;
+
         public override void Run(string[] args)
         {
             // Log any unhandled exception.
@@ -61,7 +66,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnTerminate();
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             DotnetPluginRegistry.Instance.RemoveAllPlugins();
 
@@ -71,7 +76,7 @@ namespace Tizen.Flutter.Embedding
 
         protected override void OnAppControlReceived(AppControlReceivedEventArgs e)
         {
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyAppControl(e.ReceivedAppControl);
         }
@@ -80,7 +85,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnLowMemory(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLowMemoryWarning();
         }
@@ -89,7 +94,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnLocaleChanged(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
         }
@@ -98,14 +103,14 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnRegionFormatChanged(e);
 
-            Debug.Assert(Engine.IsValid);
+            Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
         }
 
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
-            if (Engine.IsValid)
+            if (IsRunning)
             {
                 return Engine.GetRegistrarForPlugin(pluginName);
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -103,10 +103,6 @@ namespace Tizen.Flutter.Embedding
             Engine.NotifyLocaleChange();
         }
 
-        /// <summary>
-        /// Returns the plugin registrar handle for the plugin with the given name.
-        /// The name must be unique across the application.
-        /// </summary>
         public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
         {
             if (Engine.IsValid)

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -34,6 +34,13 @@ namespace Tizen.Flutter.Embedding
         }
 
         [StructLayout(LayoutKind.Sequential)]
+        public struct FlutterDesktopViewProperties
+        {
+            public int width;
+            public int height;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
         public struct FlutterDesktopEngineProperties
         {
             public string assets_path;
@@ -94,8 +101,24 @@ namespace Tizen.Flutter.Embedding
             FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
+        public static extern FlutterDesktopView FlutterDesktopViewCreateFromElmParent(
+            ref FlutterDesktopViewProperties view_properties,
+            FlutterDesktopEngine engine,
+            IntPtr parent);
+
+        [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopViewDestroy(
             FlutterDesktopView view);
+
+        [DllImport("flutter_tizen.so")]
+        public static extern IntPtr FlutterDesktopViewGetEvasObject(
+            FlutterDesktopView view);
+
+        [DllImport("flutter_tizen.so")]
+        public static extern void FlutterDesktopViewResize(
+            FlutterDesktopView view,
+            int width,
+            int height);
         #endregion
 
         #region flutter_messenger.h

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -111,7 +111,7 @@ namespace Tizen.Flutter.Embedding
             FlutterDesktopView view);
 
         [DllImport("flutter_tizen.so")]
-        public static extern IntPtr FlutterDesktopViewGetEvasObject(
+        public static extern IntPtr FlutterDesktopViewGetNativeHandle(
             FlutterDesktopView view);
 
         [DllImport("flutter_tizen.so")]

--- a/embedding/csharp/Tizen.Flutter.Embedding/Plugins/IPluginRegistry.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Plugins/IPluginRegistry.cs
@@ -8,6 +8,10 @@ namespace Tizen.Flutter.Embedding
 {
     public interface IPluginRegistry
     {
+        /// <summary>
+        /// Returns the plugin registrar handle for the plugin with the given name.
+        /// The name must be unique across the application.
+        /// </summary>
         FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName);
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/351.

Changes:
- Add the C# version of C++'s `ElmFlutterView` class.
- Add `IsRunning` to `FlutterApplication` and `FlutterServiceApplication` and replace `Engine.IsValid` with `IsRunning` (for overall consistency).
- Add missing documentation.
- Minor fixes and formatting.

Usage:
```csharp
var flutterView = new ElmFlutterView(box);
if (flutterView.RunEngine())
{
    GeneratedPluginRegistrant.RegisterPlugins(flutterView);
    box.PackEnd(flutterView.EvasObject);
}

...

if (flutterView.IsRunning)
{
    // The view must be explicitly destroyed by user.
    flutterView.Destroy();
}
```