### PR TITLE
Change the linking order in TizenPlugins

### DIFF
--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -253,9 +253,9 @@ USER_LIBS = pthread ${userLibs.join(' ')}
         extraOptions: <String>[
           '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
           '-I${publicDir.path.toPosixPath()}',
-          '-l${getLibNameForFileName(embedder.basename)}',
-          '-L${engineDir.path.toPosixPath()}',
           embeddingLib.path.toPosixPath(),
+          '-L${engineDir.path.toPosixPath()}',
+          '-l${getLibNameForFileName(embedder.basename)}',
           '-L${libDir.path.toPosixPath()}',
           // Forces plugin entrypoints to be exported, because unreferenced
           // objects are not included in the output shared object by default.


### PR DESCRIPTION
The embedding lib must come before the embedder lib in the compiler options as we've done in 940c43a8a2577f6efe395f565e061ffd21120d10. Otherwise some projects (such as [this](https://github.sec.samsung.net/f-project/flutter-webrtc/tree/main/packages/flutter-webrtc/tizen)) generate an error.