### PR TITLE
Add engine getter to ElmFlutterView

### DIFF
--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -16,6 +16,11 @@ ElmFlutterView::~ElmFlutterView() {
 }
 
 bool ElmFlutterView::RunEngine() {
+  if (IsRunning()) {
+    TizenLog::Error("The engine is already running.");
+    return false;
+  }
+
   if (!parent_) {
     TizenLog::Error("The parent object is invalid.");
     return false;

--- a/embedding/cpp/elm_flutter_view.cc
+++ b/embedding/cpp/elm_flutter_view.cc
@@ -51,10 +51,6 @@ bool ElmFlutterView::RunEngine() {
   return true;
 }
 
-void ElmFlutterView::SetEngine(std::unique_ptr<FlutterEngine> engine) {
-  engine_ = std::move(engine);
-}
-
 void ElmFlutterView::Resize(int32_t width, int32_t height) {
   assert(IsRunning());
 
@@ -80,12 +76,4 @@ int32_t ElmFlutterView::GetHeight() {
   int32_t height = 0;
   evas_object_geometry_get(evas_object_, nullptr, nullptr, nullptr, &height);
   return height;
-}
-
-FlutterDesktopPluginRegistrarRef ElmFlutterView::GetRegistrarForPlugin(
-    const std::string &plugin_name) {
-  if (engine_) {
-    return engine_->GetRegistrarForPlugin(plugin_name.c_str());
-  }
-  return nullptr;
 }

--- a/embedding/cpp/include/elm_flutter_view.h
+++ b/embedding/cpp/include/elm_flutter_view.h
@@ -16,32 +16,41 @@
 #include "flutter_engine.h"
 
 // Displays a Flutter screen in a Tizen application.
-class ElmFlutterView : public flutter::PluginRegistry {
+class ElmFlutterView {
  public:
   explicit ElmFlutterView(Evas_Object *parent) : parent_(parent) {}
+
   explicit ElmFlutterView(Evas_Object *parent, int32_t initial_width,
                           int32_t initial_height)
       : parent_(parent),
         initial_width_(initial_width),
         initial_height_(initial_height) {}
+
   virtual ~ElmFlutterView();
 
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string &plugin_name) override;
-
-  bool IsRunning() { return engine_ != nullptr; }
+  // Whether the view is running.
+  bool IsRunning() { return view_ != nullptr; }
 
   Evas_Object *evas_object() { return evas_object_; }
 
-  void Resize(int32_t width, int32_t height);
+  FlutterEngine *engine() { return engine_.get(); }
 
+  // Sets an engine associated with this view.
+  void SetEngine(std::unique_ptr<FlutterEngine> engine) {
+    engine_ = std::move(engine);
+  }
+
+  // Starts running the view with the associated engine, creating if not set.
   bool RunEngine();
 
+  // Resizes the view.
+  void Resize(int32_t width, int32_t height);
+
+  // The current width of the view.
   int32_t GetWidth();
 
+  // The current height of the view.
   int32_t GetHeight();
-
-  void SetEngine(std::unique_ptr<FlutterEngine> engine);
 
  private:
   // The Flutter engine instance.
@@ -50,10 +59,10 @@ class ElmFlutterView : public flutter::PluginRegistry {
   // The Flutter view instance handle.
   FlutterDesktopViewRef view_ = nullptr;
 
-  // The Evas object instance handle.
+  // The backing Evas object for this view.
   Evas_Object *evas_object_ = nullptr;
 
-  // The Evas object's parent instance handle.
+  // The parent of |evas_object_|.
   Evas_Object *parent_ = nullptr;
 
   // The initial width of the view.

--- a/embedding/cpp/include/elm_flutter_view.h
+++ b/embedding/cpp/include/elm_flutter_view.h
@@ -36,11 +36,15 @@ class ElmFlutterView {
   FlutterEngine *engine() { return engine_.get(); }
 
   // Sets an engine associated with this view.
+  //
+  // The engine must not be already running.
   void SetEngine(std::unique_ptr<FlutterEngine> engine) {
     engine_ = std::move(engine);
   }
 
   // Starts running the view with the associated engine, creating if not set.
+  //
+  // |SetEngine| must not be called after this call.
   bool RunEngine();
 
   // Resizes the view.


### PR DESCRIPTION
Adds `ElmFlutterView::engine()` which returns a pointer to the view's engine instance.

This is a preparation for https://github.com/flutter-tizen/flutter-tizen/pull/416#discussion_r943087246.

Important notice: The plugin registration API will also be changed as follows.

```patch
@@ -64,7 +64,7 @@ class App {

     flutter_view = new ElmFlutterView(box, 720, 400);
     if (flutter_view->RunEngine()) {
-      RegisterPlugins(flutter_view);
+      RegisterPlugins(flutter_view->engine());
       elm_box_pack_end(box, flutter_view->evas_object());
     }
```

@bbrto21 How do you think of this change? I decided not to make additional changes to `FlutterEngine::Create` or `ElmFlutterView::SetEngine`.