### PR TITLE
Update tizen-manifest.xml of C# app templates

### DIFF
--- a/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/templates/service-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/csharp/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <service-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="true" taskmanage="false" api-version="4" auto-restart="false">
+    <service-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <background-category value="media"/>

--- a/templates/ui-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/csharp/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>


### PR DESCRIPTION
The `api-version` attribute of the `ui-application` element in `tizen-manifest.xml` is never used and we can safely remove it according to https://github.com/flutter-tizen/flutter-tizen/pull/420#discussion_r944099917.