### PR TITLE
Prevent libembedding_cpp.a from being included in TPK

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -412,6 +412,9 @@ class NativeModule extends TizenPackage {
         FlutterProject.fromDirectory(environment.projectDir);
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
 
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final String buildConfig = getBuildConfig(buildMode);
+
     final Directory outputDir = environment.outputDir;
     if (outputDir.existsSync()) {
       outputDir.deleteSync(recursive: true);
@@ -423,6 +426,8 @@ class NativeModule extends TizenPackage {
       ..createSync(recursive: true);
     final Directory libDir = outputDir.childDirectory('lib')
       ..createSync(recursive: true);
+    final Directory buildDir = outputDir.childDirectory(buildConfig)
+      ..createSync(recursive: true);
 
     // Copy necessary files.
     copyDirectory(
@@ -430,7 +435,6 @@ class NativeModule extends TizenPackage {
       resDir.childDirectory('flutter_assets'),
     );
 
-    final BuildMode buildMode = buildInfo.buildInfo.mode;
     final Directory engineDir =
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
@@ -482,6 +486,6 @@ class NativeModule extends TizenPackage {
     copyDirectory(embeddingDir.childDirectory('include'), incDir);
 
     final File embeddingLib = embeddingDir.childFile('libembedding_cpp.a');
-    embeddingLib.copySync(libDir.childFile(embeddingLib.basename).path);
+    embeddingLib.copySync(buildDir.childFile(embeddingLib.basename).path);
   }
 }

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -334,7 +334,8 @@ type = app
           outputDir.childFile('inc/generated_plugin_registrant.h');
       final File pluginsLib = outputDir.childFile('lib/libflutter_plugins.so');
       final File embeddingHeader = outputDir.childFile('inc/flutter.h');
-      final File embeddingLib = outputDir.childFile('lib/libembedding_cpp.a');
+      final File embeddingLib =
+          outputDir.childFile('Release/libembedding_cpp.a');
 
       expect(flutterAssetsDir, exists);
       expect(engineBinary, exists);


### PR DESCRIPTION
The current native module builder implementation (https://github.com/flutter-tizen/flutter-tizen/pull/405) generates `libembedding_cpp.a` in the output directory's `lib` directory.

```sh
build/tizen/module/
└── lib
    └── libembedding_cpp.a
```
This results in the file being included in the container app's TPK if no extra care is taken. This change makes the file to be generated in either `Debug` or `Release` (which is determined by the builder from the build mode).

The app developer should add `${BUILD_CONFIG}` (which is transformed into `Debug` or `Release` by the Tizen CLI builder) to the container app's library searching path as follows.

```patch
 USER_INC_DIRS = inc
 USER_OBJS =
 USER_LIBS = embedding_cpp flutter_tizen_mobile flutter_plugins
-USER_LIB_DIRS = lib
+USER_LIB_DIRS = lib ${BUILD_CONFIG}
 USER_LFLAGS = -Wl,--unresolved-symbols=ignore-in-shared-libs
 USER_EDCS =
```