### PR TITLE
Format C# code

### DIFF
--- a/embedding/csharp/.editorconfig
+++ b/embedding/csharp/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####
@@ -177,7 +177,6 @@ csharp_preserve_single_line_statements = true
 #### Naming styles ####
 
 # Naming rules
-
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
@@ -191,7 +190,6 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_m
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 # Symbol specifications
-
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.interface.required_modifiers = 
@@ -205,7 +203,6 @@ dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, int
 dotnet_naming_symbols.non_field_members.required_modifiers = 
 
 # Naming styles
-
 dotnet_naming_style.pascal_case.required_prefix = 
 dotnet_naming_style.pascal_case.required_suffix = 
 dotnet_naming_style.pascal_case.word_separator = 
@@ -215,6 +212,3 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-[*.{cs,vb}]
-end_of_line=lf

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/BinaryCodecTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/BinaryCodecTests.cs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-using System;
 using Xunit;
 
 namespace Tizen.Flutter.Embedding.Tests.Channels

--- a/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/EventChannelTests.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding.Tests/Channels/EventChannelTests.cs
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/BinaryCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/BinaryCodec.cs
@@ -5,7 +5,7 @@
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// <see cref="IMessageCodec{T}" /> with unencoded binary messages.
+    /// <see cref="IMessageCodec{T}"/> with unencoded binary messages.
     /// </summary>
     public class BinaryCodec : IMessageCodec<byte[]>
     {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/DefaultBinaryMessenger.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/DefaultBinaryMessenger.cs
@@ -16,10 +16,10 @@ namespace Tizen.Flutter.Embedding
         private static DefaultBinaryMessenger _instance;
         private static readonly object _lock = new object();
         private readonly FlutterDesktopMessenger _messenger;
-        private readonly Dictionary<string, BinaryMessageHandler> _handlers
-            = new Dictionary<string, BinaryMessageHandler>();
-        private readonly Dictionary<int, TaskCompletionSource<byte[]>> _replyCallbackSources
-            = new Dictionary<int, TaskCompletionSource<byte[]>>();
+        private readonly Dictionary<string, BinaryMessageHandler> _handlers =
+            new Dictionary<string, BinaryMessageHandler>();
+        private readonly Dictionary<int, TaskCompletionSource<byte[]>> _replyCallbackSources =
+            new Dictionary<int, TaskCompletionSource<byte[]>>();
         private readonly FlutterDesktopBinaryReply _replyCallback;
         private readonly FlutterDesktopMessageCallback _messageCallback;
 
@@ -78,12 +78,14 @@ namespace Tizen.Flutter.Embedding
             }
             if (message == null)
             {
-                FlutterDesktopMessengerSendWithReply(_messenger, channel, IntPtr.Zero, 0, _replyCallback, (IntPtr)replyId);
+                FlutterDesktopMessengerSendWithReply(
+                    _messenger, channel, IntPtr.Zero, 0, _replyCallback, (IntPtr)replyId);
                 return tcs.Task;
             }
             using (var pinned = PinnedObject.Get(message))
             {
-                FlutterDesktopMessengerSendWithReply(_messenger, channel, pinned.Pointer, (uint)message.Length, _replyCallback, (IntPtr)replyId);
+                FlutterDesktopMessengerSendWithReply(
+                    _messenger, channel, pinned.Pointer, (uint)message.Length, _replyCallback, (IntPtr)replyId);
             }
             return tcs.Task;
         }
@@ -124,7 +126,8 @@ namespace Tizen.Flutter.Embedding
                 {
                     using (var pinned = PinnedObject.Get(replyBytes))
                     {
-                        FlutterDesktopMessengerSendResponse(messenger, receivedMessage.response_handle, pinned.Pointer, (uint)replyBytes.Length);
+                        FlutterDesktopMessengerSendResponse(
+                            messenger, receivedMessage.response_handle, pinned.Pointer, (uint)replyBytes.Length);
                     }
                 }
                 else

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/EventChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/EventChannel.cs
@@ -17,8 +17,7 @@ namespace Tizen.Flutter.Embedding
         /// and the default <see cref="IBinaryMessenger"/>.
         /// </summary>
         /// <param name="name">A channel name string.</param>
-        public EventChannel(string name)
-            : this(name, StandardMethodCodec.Instance)
+        public EventChannel(string name) : this(name, StandardMethodCodec.Instance)
         {
         }
 
@@ -28,8 +27,7 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         /// <param name="name">A channel name string.</param>
         /// <param name="codec">A <see cref="IMethodCodec"/>.</param>
-        public EventChannel(string name, IMethodCodec codec)
-            : this(name, codec, DefaultBinaryMessenger.Instance)
+        public EventChannel(string name, IMethodCodec codec) : this(name, codec, DefaultBinaryMessenger.Instance)
         {
         }
 
@@ -151,7 +149,8 @@ namespace Tizen.Flutter.Embedding
             }
             else
             {
-                return Task.FromResult(_channel.Codec.EncodeErrorEnvelope("error", "No active stream to cancel.", null));
+                return Task.FromResult(
+                    _channel.Codec.EncodeErrorEnvelope("error", "No active stream to cancel.", null));
             }
         }
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/IEventSink.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/IEventSink.cs
@@ -25,7 +25,8 @@ namespace Tizen.Flutter.Embedding
 
         /// <summary>
         /// Consumes end of stream. 
-        /// <para>Ensuing calls to <see cref="Success(object)"/> or <see cref="Error(string, string, object)"/>, if any, are ignored.</para>
+        /// <para>Ensuing calls to <see cref="Success(object)"/> or <see cref="Error(string, string, object)"/>,
+        /// if any, are ignored.</para>
         /// </summary>
         void EndOfStream();
     }

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMessageCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMessageCodec.cs
@@ -6,7 +6,7 @@ namespace Tizen.Flutter.Embedding
 {
     /// <summary>
     /// A message encoding/decoding mechanism.
-    /// <para>Both operations throw an exception, if conversion fails, Such situations should be treated
+    /// <para>Both operations throw an exception, if conversion fails. Such situations should be treated
     /// as programming errors.</para>
     /// </summary>
     public interface IMessageCodec<T>

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/IMethodCodec.cs
@@ -37,8 +37,8 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         /// <param name="errorCode">An error code string.</param>
         /// <param name="errorMessage">An error message String, possibly null.</param>
-        /// <param name="errorDetails">Error details, possibly null. Consider supporting
-        /// <see cref="Exception"/>in your codec.This is the most common value passed to this field.</param>
+        /// <param name="errorDetails">Error details, possibly null. Consider supporting <see cref="Exception"/>
+        /// in your codec. This is the most common value passed to this field.</param>
         /// <returns>A byte array containing the encoding.</returns>
         byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails);
 
@@ -47,8 +47,8 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         /// <param name="errorCode">An error code string.</param>
         /// <param name="errorMessage">An error message String, possibly null.</param>
-        /// <param name="errorDetails">Error details, possibly null. Consider supporting
-        /// <see cref="Exception"/>in your codec.This is the most common value passed to this field.</param>
+        /// <param name="errorDetails">Error details, possibly null. Consider supporting <see cref="Exception"/>
+        /// in your codec. This is the most common value passed to this field.</param>
         /// <param name="errorStacktrace">Platform stacktrace for the error. possibly null.</param>
         /// <returns>A byte array containing the encoding.</returns>
         byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails, string errorStacktrace);

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/MethodChannel.cs
@@ -17,8 +17,7 @@ namespace Tizen.Flutter.Embedding
         /// and the default <see cref="IBinaryMessenger"/>.
         /// </summary>
         /// <param name="name">A channel name string.</param>
-        public MethodChannel(string name)
-            : this(name, StandardMethodCodec.Instance)
+        public MethodChannel(string name) : this(name, StandardMethodCodec.Instance)
         {
         }
 
@@ -28,8 +27,7 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         /// <param name="name">A channel name string.</param>
         /// <param name="codec">A <see cref="IMethodCodec"/>.</param>
-        public MethodChannel(string name, IMethodCodec codec)
-            : this(name, codec, DefaultBinaryMessenger.Instance)
+        public MethodChannel(string name, IMethodCodec codec) : this(name, codec, DefaultBinaryMessenger.Instance)
         {
         }
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageCodec.cs
@@ -14,10 +14,10 @@ using static Tizen.Flutter.Embedding.StandardMessageHelper;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// <see cref="IMessageCodec{T}" /> using the Flutter standard binary encoding.
+    /// <see cref="IMessageCodec{T}"/> using the Flutter standard binary encoding.
     /// <para>
     /// This codec is guaranteed to be compatible with the corresponding
-    /// <see href = "https://api.flutter.dev/flutter/services/StandardMessageCodec-class.html">StandardMessageCodec</see>
+    /// <see href="https://api.flutter.dev/flutter/services/StandardMessageCodec-class.html">StandardMessageCodec</see>
     /// on the Dart side. These parts of the Flutter SDK are evolved synchronously.
     /// </para>
     /// </summary>
@@ -40,7 +40,7 @@ namespace Tizen.Flutter.Embedding
         private const byte FLOAT_ARRAY = 14;
 
         /// <summary>
-        /// Singleton instance of <see cref="StandardMessageCodec" />.
+        /// Singleton instance of <see cref="StandardMessageCodec"/>.
         /// </summary>
         public static StandardMessageCodec Instance => new StandardMessageCodec();
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMethodCodec.cs
@@ -9,7 +9,7 @@ using Tizen.Flutter.Embedding.Common;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// <see cref="IMethodCodec" /> using the Flutter standard binary encoding.
+    /// <see cref="IMethodCodec"/> using the Flutter standard binary encoding.
     /// <para>
     /// This codec is guaranteed to be compatible with the corresponding
     /// <see href = "https://api.flutter.dev/flutter/services/StandardMethodCodec-class.html">StandardMethodCodec</see>
@@ -84,7 +84,8 @@ namespace Tizen.Flutter.Embedding
         }
 
         /// <InheritDoc/>
-        public byte[] EncodeErrorEnvelope(string errorCode, string errorMessage, object errorDetails, String errorStacktrace)
+        public byte[] EncodeErrorEnvelope(
+            string errorCode, string errorMessage, object errorDetails, string errorStacktrace)
         {
             using (var stream = new MemoryStream())
             using (var writer = new BinaryWriter(stream))

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StringCodec.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StringCodec.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
-    /// <see cref="IMessageCodec{T}" /> for UTF-8 encoded String messages.
+    /// <see cref="IMessageCodec{T}"/> for UTF-8 encoded String messages.
     /// </summary>
     public class StringCodec : IMessageCodec<string>
     {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Common/StreamExtensions.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Common/StreamExtensions.cs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-using System;
 using System.IO;
 
 namespace Tizen.Flutter.Embedding.Common

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -72,7 +72,8 @@ namespace Tizen.Flutter.Embedding
 
         /// <summary>
         /// Whether the app should be displayed over other apps.
-        /// If true, the "http://tizen.org/privilege/window.priority.set" privilege must be added to tizen-manifest.xml file.
+        /// If true, the "http://tizen.org/privilege/window.priority.set" privilege must be added to tizen-manifest.xml
+        /// file.
         /// </summary>
         protected bool IsTopLevel { get; set; } = false;
 
@@ -129,7 +130,7 @@ namespace Tizen.Flutter.Embedding
             }
 
 #if WEARABLE_PROFILE
-            if (RendererType ==  FlutterRendererType.EGL)
+            if (RendererType == FlutterRendererType.EGL)
             {
                 throw new Exception("FlutterRendererType.kEGL is not supported by this profile.");
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -26,13 +26,13 @@ namespace Tizen.Flutter.Embedding
         public bool IsValid => !Engine.IsInvalid;
 
         public FlutterEngine(string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
-            : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so",
-                   dartEntrypoint, dartEntrypointArgs)
+            : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so", dartEntrypoint, dartEntrypointArgs)
         {
         }
 
-        public FlutterEngine(string assetsPath, string icuDataPath, string aotLibraryPath,
-                             string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
+        public FlutterEngine(
+            string assetsPath, string icuDataPath, string aotLibraryPath, string dartEntrypoint = "",
+            List<string> dartEntrypointArgs = null)
         {
             dartEntrypointArgs = dartEntrypointArgs ?? new List<string>();
 
@@ -117,7 +117,7 @@ namespace Tizen.Flutter.Embedding
 
         /// <summary>
         /// Notifies that a low memory warning has been received.
-        /// This method sends a "memory pressure warning" message to Flutter over the "system channel".
+        /// This method sends a "memory pressure warning" message to Flutter over the "system" channel.
         /// </summary>
         public void NotifyLowMemoryWarning()
         {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -58,75 +58,55 @@ namespace Tizen.Flutter.Embedding
             ref FlutterDesktopEngineProperties engine_properties);
 
         [DllImport("flutter_tizen.so")]
-        public static extern bool FlutterDesktopEngineRun(
-            FlutterDesktopEngine engine);
+        public static extern bool FlutterDesktopEngineRun(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopEngineShutdown(
-            FlutterDesktopEngine engine);
+        public static extern void FlutterDesktopEngineShutdown(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
         public static extern FlutterDesktopPluginRegistrar FlutterDesktopEngineGetPluginRegistrar(
-            FlutterDesktopEngine engine,
-            string plugin_name);
+            FlutterDesktopEngine engine, string plugin_name);
 
         [DllImport("flutter_tizen.so")]
-        public static extern FlutterDesktopMessenger FlutterDesktopEngineGetMessenger(
-            FlutterDesktopEngine engine);
+        public static extern FlutterDesktopMessenger FlutterDesktopEngineGetMessenger(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopEngineNotifyAppControl(
-            FlutterDesktopEngine engine,
-            SafeAppControlHandle handle);
+            FlutterDesktopEngine engine, SafeAppControlHandle handle);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopEngineNotifyLocaleChange(
-            FlutterDesktopEngine engine);
+        public static extern void FlutterDesktopEngineNotifyLocaleChange(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopEngineNotifyLowMemoryWarning(
-            FlutterDesktopEngine engine);
+        public static extern void FlutterDesktopEngineNotifyLowMemoryWarning(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopEngineNotifyAppIsResumed(
-            FlutterDesktopEngine engine);
+        public static extern void FlutterDesktopEngineNotifyAppIsResumed(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopEngineNotifyAppIsPaused(
-            FlutterDesktopEngine engine);
+        public static extern void FlutterDesktopEngineNotifyAppIsPaused(FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
         public static extern FlutterDesktopView FlutterDesktopViewCreateFromNewWindow(
-            ref FlutterDesktopWindowProperties window_properties,
-            FlutterDesktopEngine engine);
+            ref FlutterDesktopWindowProperties window_properties, FlutterDesktopEngine engine);
 
         [DllImport("flutter_tizen.so")]
         public static extern FlutterDesktopView FlutterDesktopViewCreateFromElmParent(
-            ref FlutterDesktopViewProperties view_properties,
-            FlutterDesktopEngine engine,
-            IntPtr parent);
+            ref FlutterDesktopViewProperties view_properties, FlutterDesktopEngine engine, IntPtr parent);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopViewDestroy(
-            FlutterDesktopView view);
+        public static extern void FlutterDesktopViewDestroy(FlutterDesktopView view);
 
         [DllImport("flutter_tizen.so")]
-        public static extern IntPtr FlutterDesktopViewGetNativeHandle(
-            FlutterDesktopView view);
+        public static extern IntPtr FlutterDesktopViewGetNativeHandle(FlutterDesktopView view);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopViewResize(
-            FlutterDesktopView view,
-            int width,
-            int height);
+        public static extern void FlutterDesktopViewResize(FlutterDesktopView view, int width, int height);
         #endregion
 
         #region flutter_messenger.h
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void FlutterDesktopBinaryReply(
-            IntPtr data,
-            uint data_size,
-            IntPtr user_data);
+        public delegate void FlutterDesktopBinaryReply(IntPtr data, uint data_size, IntPtr user_data);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct FlutterDesktopMessage
@@ -140,41 +120,26 @@ namespace Tizen.Flutter.Embedding
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void FlutterDesktopMessageCallback(
-            [MarshalAs(
-                UnmanagedType.CustomMarshaler,
-                MarshalTypeRef = typeof(FlutterDesktopMessenger.Marshaler))]
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FlutterDesktopMessenger.Marshaler))]
             FlutterDesktopMessenger messenger,
-            IntPtr message,
-            IntPtr user_data);
+            IntPtr message, IntPtr user_data);
 
         [DllImport("flutter_tizen.so")]
         public static extern bool FlutterDesktopMessengerSend(
-            FlutterDesktopMessenger messenger,
-            string channel,
-            IntPtr message,
-            uint message_size);
+            FlutterDesktopMessenger messenger, string channel, IntPtr message, uint message_size);
 
         [DllImport("flutter_tizen.so")]
         public static extern bool FlutterDesktopMessengerSendWithReply(
-            FlutterDesktopMessenger messenger,
-            string channel,
-            IntPtr message,
-            uint message_size,
-            FlutterDesktopBinaryReply reply,
-            IntPtr user_data);
+            FlutterDesktopMessenger messenger, string channel, IntPtr message, uint message_size,
+            FlutterDesktopBinaryReply reply, IntPtr user_data);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopMessengerSendResponse(
-            FlutterDesktopMessenger messenger,
-            IntPtr handle,
-            IntPtr data,
-            uint data_length);
+            FlutterDesktopMessenger messenger, IntPtr handle, IntPtr data, uint data_length);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopMessengerSetCallback(
-            FlutterDesktopMessenger messenger,
-            string channel,
-            FlutterDesktopMessageCallback callback,
+            FlutterDesktopMessenger messenger, string channel, FlutterDesktopMessageCallback callback,
             IntPtr user_data);
         #endregion
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Plugins/DotnetPluginRegistry.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Plugins/DotnetPluginRegistry.cs
@@ -11,16 +11,17 @@ namespace Tizen.Flutter.Embedding
     /// A registry for dotnet plugins implementing the <see cref="IFlutterPlugin"/> interface.
     /// </summary>
     /// <remarks>
-    /// When the plugin is registered, the <see cref="IFlutterPlugin.OnAttachedToEngine"/> method is called.
+    /// When a plugin is registered, the <see cref="IFlutterPlugin.OnAttachedToEngine"/> method is called.
     /// The registered plugin is automatically unregistered with the <see cref="IFlutterPlugin.OnDetachedFromEngine"/>
     /// method call when the Flutter engine is detached.
     /// </remarks>
     public class DotnetPluginRegistry
     {
-        private static readonly Lazy<DotnetPluginRegistry> _instance
-            = new Lazy<DotnetPluginRegistry>(() => new DotnetPluginRegistry());
+        private static readonly Lazy<DotnetPluginRegistry> _instance =
+            new Lazy<DotnetPluginRegistry>(() => new DotnetPluginRegistry());
 
-        private readonly ConcurrentDictionary<int, IFlutterPlugin> _plugins = new ConcurrentDictionary<int, IFlutterPlugin>();
+        private readonly ConcurrentDictionary<int, IFlutterPlugin> _plugins =
+            new ConcurrentDictionary<int, IFlutterPlugin>();
 
         private DotnetPluginRegistry()
         {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Plugins/FlutterPluginBinding.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Plugins/FlutterPluginBinding.cs
@@ -9,7 +9,7 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     /// <remarks>
     /// This interface is used by Flutter plugins to access the Flutter engine.
-    /// Currently, only <see cref="IBinaryMessenger" /> is supported, but more interfaces may be added in the future.
+    /// Currently, only <see cref="IBinaryMessenger"/> is supported, but more interfaces may be added in the future.
     /// </remarks>
     public interface IFlutterPluginBinding
     {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Plugins/IPluginRegistry.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Plugins/IPluginRegistry.cs
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-using System;
-
 namespace Tizen.Flutter.Embedding
 {
     public interface IPluginRegistry


### PR DESCRIPTION
Format the C# embedding code in a consistent manner.

The code has been hand-formatted without assistance by a tool. The `dotnet format` command and the [`.editorconfig`](https://github.com/flutter-tizen/flutter-tizen/blob/master/embedding/csharp/.editorconfig) file are almost useless.

Unlike Dart or C++, there's no universal style rule that can be applied to our C# code. [Google's C# style guide](https://google.github.io/styleguide/csharp-style.html) defines its own unique set of rules that do not comply with the general C# standard. So I tried to make only minimal changes to the existing code:

- Column width: 120
- Indentation: 4 spaces
- Always make a line break with a 4 space indent if arguments do not fit on one line.
