### PR TITLE
Add missing inputs to NativeEmbedding

### DIFF
--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -64,6 +64,7 @@ class NativeEmbedding extends Target {
         .parent
         .childDirectory('embedding')
         .childDirectory('cpp');
+    embeddingDir.listSync().whereType<File>().forEach(inputs.add);
     copyDirectory(
       embeddingDir.childDirectory('include'),
       outputDir.childDirectory('include'),


### PR DESCRIPTION
Fixes a problem of C++ embedding not rebuilding after modifying its source code.