### PR TITLE
Support building a .NET module

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -146,7 +146,7 @@ class DotnetTpk extends TizenPackage {
       '-o',
       '${outputDir.path}/', // The trailing '/' is needed.
       '/p:DefineConstants=${profile.toUpperCase()}_PROFILE',
-      tizenProject.editableDirectory.path,
+      tizenProject.hostAppRoot.path,
     ]);
     if (result.exitCode != 0) {
       throwToolExit('Failed to build .NET application:\n$result');

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -397,6 +397,77 @@ class NativeTpk extends TizenPackage {
   }
 }
 
+class DotnetModule extends TizenPackage {
+  DotnetModule(super.tizenBuildInfo);
+
+  @override
+  String get name => 'tizen_dotnet_module';
+
+  @override
+  Future<void> build(Environment environment) async {
+    final FlutterProject project =
+        FlutterProject.fromDirectory(environment.projectDir);
+    final TizenProject tizenProject = TizenProject.fromFlutter(project);
+
+    final Directory outputDir = environment.outputDir;
+    if (outputDir.existsSync()) {
+      outputDir.deleteSync(recursive: true);
+    }
+    outputDir.createSync(recursive: true);
+    final Directory resDir = outputDir.childDirectory('res')
+      ..createSync(recursive: true);
+    final Directory libDir = outputDir.childDirectory('lib')
+      ..createSync(recursive: true);
+    final Directory srcDir = outputDir.childDirectory('src')
+      ..createSync(recursive: true);
+
+    // Copy necessary files.
+    copyDirectory(
+      environment.buildDir.childDirectory('flutter_assets'),
+      resDir.childDirectory('flutter_assets'),
+    );
+
+    final BuildMode buildMode = buildInfo.buildInfo.mode;
+    final Directory engineDir =
+        getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
+    final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
+
+    final File engineBinary = engineDir.childFile('libflutter_engine.so');
+    final File embedder =
+        engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
+    final File icuData =
+        commonDir.childDirectory('icu').childFile('icudtl.dat');
+
+    engineBinary.copySync(libDir.childFile(engineBinary.basename).path);
+    // The embedder so name is statically defined in C# code and cannot be
+    // provided at runtime, so the file name must be a constant.
+    embedder.copySync(libDir.childFile('libflutter_tizen.so').path);
+    icuData.copySync(resDir.childFile(icuData.basename).path);
+
+    if (buildMode.isPrecompiled) {
+      final File aotSnapshot = environment.buildDir.childFile('app.so');
+      aotSnapshot.copySync(libDir.childFile('libapp.so').path);
+    }
+
+    final File generatedPluginRegistrant =
+        tizenProject.managedDirectory.childFile('GeneratedPluginRegistrant.cs');
+    assert(generatedPluginRegistrant.existsSync());
+    generatedPluginRegistrant
+        .copySync(srcDir.childFile(generatedPluginRegistrant.basename).path);
+
+    final Directory pluginsDir =
+        environment.buildDir.childDirectory('tizen_plugins');
+    final Directory pluginsResDir = pluginsDir.childDirectory('res');
+    if (pluginsResDir.existsSync()) {
+      copyDirectory(pluginsResDir, resDir);
+    }
+    final Directory pluginsLibDir = pluginsDir.childDirectory('lib');
+    if (pluginsLibDir.existsSync()) {
+      copyDirectory(pluginsLibDir, libDir);
+    }
+  }
+}
+
 class NativeModule extends TizenPackage {
   NativeModule(super.tizenBuildInfo);
 

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -223,13 +223,9 @@ class TizenBuilder {
       generateDartPluginRegistry: false,
     );
 
-    if (tizenProject.isDotnet) {
-      throwToolExit(
-        'Building a .NET module is currently not supported.\n'
-        'Delete the project and recreate with the "--tizen-language cpp" option.',
-      );
-    }
-    final Target target = NativeModule(tizenBuildInfo);
+    final Target target = tizenProject.isDotnet
+        ? DotnetModule(tizenBuildInfo)
+        : NativeModule(tizenBuildInfo);
 
     final String buildModeName = getNameForBuildMode(buildInfo.mode);
     final Status status = globals.logger.startProgress(

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -469,27 +469,24 @@ using System;
 using System.Runtime.InteropServices;
 using Tizen.Flutter.Embedding;
 
-namespace Runner
+internal class GeneratedPluginRegistrant
 {
-    internal class GeneratedPluginRegistrant
+  {{#cppPlugins}}
+    [DllImport("{{libName}}.so")]
+    public static extern void {{pluginClass}}RegisterWithRegistrar(
+        FlutterDesktopPluginRegistrar registrar);
+
+  {{/cppPlugins}}
+    public static void RegisterPlugins(IPluginRegistry registry)
     {
       {{#cppPlugins}}
-        [DllImport("{{libName}}.so")]
-        public static extern void {{pluginClass}}RegisterWithRegistrar(
-            FlutterDesktopPluginRegistrar registrar);
-
+        {{pluginClass}}RegisterWithRegistrar(
+            registry.GetRegistrarForPlugin("{{pluginClass}}"));
       {{/cppPlugins}}
-        public static void RegisterPlugins(IPluginRegistry registry)
-        {
-          {{#cppPlugins}}
-            {{pluginClass}}RegisterWithRegistrar(
-                registry.GetRegistrarForPlugin("{{pluginClass}}"));
-          {{/cppPlugins}}
-          {{#dotnetPlugins}}
-            DotnetPluginRegistry.Instance.AddPlugin(
-                new global::{{namespace}}.{{pluginClass}}());
-          {{/dotnetPlugins}}
-        }
+      {{#dotnetPlugins}}
+        DotnetPluginRegistry.Instance.AddPlugin(
+            new global::{{namespace}}.{{pluginClass}}());
+      {{/dotnetPlugins}}
     }
 }
 ''';

--- a/templates/module/csharp/.tizen.tmpl/Runner.csproj
+++ b/templates/module/csharp/.tizen.tmpl/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen90</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="{{tizenIdentifier}}" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>{{projectName}}</label>

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -184,19 +184,16 @@ dependencies:
         fileSystem.file('tizen/flutter/GeneratedPluginRegistrant.cs');
     expect(csharpPluginRegistrant, exists);
     expect(csharpPluginRegistrant.readAsStringSync(), contains('''
-namespace Runner
+internal class GeneratedPluginRegistrant
 {
-    internal class GeneratedPluginRegistrant
-    {
-        [DllImport("flutter_plugins.so")]
-        public static extern void SomeNativePluginRegisterWithRegistrar(
-            FlutterDesktopPluginRegistrar registrar);
+    [DllImport("flutter_plugins.so")]
+    public static extern void SomeNativePluginRegisterWithRegistrar(
+        FlutterDesktopPluginRegistrar registrar);
 
-        public static void RegisterPlugins(IPluginRegistry registry)
-        {
-            SomeNativePluginRegisterWithRegistrar(
-                registry.GetRegistrarForPlugin("SomeNativePlugin"));
-        }
+    public static void RegisterPlugins(IPluginRegistry registry)
+    {
+        SomeNativePluginRegisterWithRegistrar(
+            registry.GetRegistrarForPlugin("SomeNativePlugin"));
     }
 }
 '''));
@@ -243,15 +240,12 @@ dependencies:
         fileSystem.file('tizen/flutter/GeneratedPluginRegistrant.cs');
     expect(csharpPluginRegistrant, exists);
     expect(csharpPluginRegistrant.readAsStringSync(), contains('''
-namespace Runner
+internal class GeneratedPluginRegistrant
 {
-    internal class GeneratedPluginRegistrant
+    public static void RegisterPlugins(IPluginRegistry registry)
     {
-        public static void RegisterPlugins(IPluginRegistry registry)
-        {
-            DotnetPluginRegistry.Instance.AddPlugin(
-                new global::Some.Plugin.Namespace.SomeDotnetPlugin());
-        }
+        DotnetPluginRegistry.Instance.AddPlugin(
+            new global::Some.Plugin.Namespace.SomeDotnetPlugin());
     }
 }
 '''));


### PR DESCRIPTION
Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/397.

Building a module:

```sh
# Create a module project.
$ flutter-tizen create -t module dotnet_module
$ cd dotnet_module

# Run build (for mobile x86).
$ flutter-tizen build module -pmobile --debug --target-arch x86

# Test without a container app.
$ flutter-tizen run
```

Importing the module from a container app:

```xml
<PropertyGroup>
  <FlutterModuleDir>../dotnet_module/build/tizen/module</FlutterModuleDir>
</PropertyGroup>

<ItemGroup>
  <PackageReference Include="Tizen.Flutter.Embedding" Version="1.0.0" />
</ItemGroup>
```

Note: The `Tizen.Flutter.Embedding` nuget will be published after https://github.com/flutter-tizen/flutter-tizen/pull/429 is merged.