### PR TITLE
Re-enable the attach command

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -30,6 +30,16 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   flutter-tizen analyze
   ```
 
+- ### `attach`
+
+  Attach to a running app.
+
+  ```sh
+  flutter-tizen attach --debug-url http://127.0.0.1:43000/Swm0bjIe0ks=/
+  ```
+
+  For attaching to Tizen devices, the `--debug-url` value must be provided. The observatory URL can be obtained from the device log output (`flutter-tizen run` or `sdb dlog ConsoleMessage`) after you launch an app in either debug or profile mode.
+
 - ### `build`
 
   Flutter build command. See `flutter-tizen build -h` for all available subcommands.
@@ -200,10 +210,10 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   Take a screenshot from a connected device.
 
   ```sh
-  flutter-tizen screenshot --type rasterizer --observatory-uri http://127.0.0.1:43000/Swm0bjIe0ks=
+  flutter-tizen screenshot --type rasterizer --observatory-uri http://127.0.0.1:43000/Swm0bjIe0ks=/
   ```
 
-  You have to specify both `--type` and `--observatory-uri` values because the default (`device`) screenshot type is not supported by Tizen devices. The observatory URI value can be found in the device log output (`flutter-tizen run` or `flutter-tizen logs`) after you start an app in debug or profile mode.
+  Both `--type` and `--observatory-uri` must be provided because the default (`device`) screenshot type is not supported by Tizen devices. The observatory URI can be obtained from the device log output (`flutter-tizen run` or `sdb dlog ConsoleMessage`) after you launch an app in either debug or profile mode.
 
   If you're using a watch device, you can also take a screenshot by swiping the screen from left to right while pressing the Home button.
 

--- a/lib/commands/attach.dart
+++ b/lib/commands/attach.dart
@@ -1,0 +1,17 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter_tools/src/commands/attach.dart';
+
+class TizenAttachCommand extends AttachCommand {
+  TizenAttachCommand({bool verboseHelp = false})
+      : super(verboseHelp: verboseHelp);
+
+  @override
+  String get description => '${super.description}\n\n'
+      'For attaching to Tizen devices, the observatory URL must be provided, e.g.\n'
+      r'`$ flutter attach --debug-url=http://127.0.0.1:43000/Swm0bjIe0ks=/`';
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -40,6 +40,7 @@ import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:path/path.dart';
 
+import 'commands/attach.dart';
 import 'commands/build.dart';
 import 'commands/clean.dart';
 import 'commands/create.dart';
@@ -119,6 +120,7 @@ Future<void> main(List<String> args) async {
       ScreenshotCommand(),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       // Commands extended for Tizen.
+      TizenAttachCommand(verboseHelp: verboseHelp),
       TizenBuildCommand(verboseHelp: verboseHelp),
       TizenCleanCommand(verbose: verbose),
       TizenCreateCommand(verboseHelp: verboseHelp),

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -470,6 +470,9 @@ class TizenDevice extends Device {
 
   @override
   Future<bool> stopApp(TizenTpk app, {String? userIdentifier}) async {
+    if (app == null) {
+      return false;
+    }
     try {
       final List<String> command = usesSecureProtocol
           ? <String>['shell', '0', 'kill', app.applicationId]

--- a/lib/vscode_helper.dart
+++ b/lib/vscode_helper.dart
@@ -68,7 +68,7 @@ void updateLaunchJsonFile(FlutterProject project, Uri observatoryUri) {
     config['cwd'] = project.hasExampleApp
         ? r'${workspaceFolder}/example'
         : r'${workspaceFolder}';
-    config['observatoryUri'] = observatoryUri.toString();
+    config['vmServiceUri'] = observatoryUri.toString();
   }
 
   const JsonEncoder encoder = JsonEncoder.withIndent('    ');

--- a/test/general/vscode_helper_test.dart
+++ b/test/general/vscode_helper_test.dart
@@ -22,7 +22,7 @@ const String _kLaunchJson = r'''
             "type": "dart",
             "deviceId": "flutter-tester",
             "cwd": "${workspaceFolder}",
-            "observatoryUri": "http://127.0.0.1:12345"
+            "vmServiceUri": "http://127.0.0.1:12345"
         }
     ]
 }''';


### PR DESCRIPTION
Add the `attach` command again but with a limitation.

This change is for debugging support of module apps (contributes to https://github.com/flutter-tizen/flutter-tizen/issues/351). The `debug-url` should be manually obtained from the device log (dlog) by the user. I tried to automate the procedure but failed for several reasons:

- `TizenDevice.getLogReader` has not enough information to choose between `TizenDlogReader` and `ForwardingLogReader`.
- `dlogutil -c` and `dlogutil -m` are not supported by non-root devices.
- The device log has incorrect timestamps on TV. Also the `getdate` command doesn't provide any timezone information.