### PR TITLE
Fix the create command trailing whitespace error

### DIFF
--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -425,7 +425,7 @@ class TizenCreateCommand extends CreateCommand {
 
   void _runGitApply(Directory directory, File patchFile) {
     final ProcessResult result = globals.processManager.runSync(
-      <String>['git', 'apply', patchFile.path],
+      <String>['git', 'apply', '--whitespace=fix', patchFile.path],
       workingDirectory: directory.path,
     );
     if (result.exitCode != 0) {


### PR DESCRIPTION
The following error was reported from an engineer at SRI-Delhi.

```powershell
D:\2022>flutter-tizen create .
Failed to run git apply: D:/2022/flutter-tizen/templates/ui-app/.gitignore.patch:13: trailing whitespace.
# VS Code related
D:/2022/flutter-tizen/templates/ui-app/.gitignore.patch:14: trailing whitespace.
.vscode/
error: patch failed: packages/flutter_tools/templates/app_shared/.gitignore.tmpl:15
error: packages/flutter_tools/templates/app_shared/.gitignore.tmpl: patch does not apply
```

I couldn't reproduce the error but it seems it occurs under some condition during `git apply` on Windows. This patch prevents the error by supplying the `--whitespace=fix` option to `git apply`.