### PR TITLE
Copy a correct embedder binary during .NET module build

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -104,7 +104,6 @@ class DotnetTpk extends TizenPackage {
     final File engineBinary = engineDir.childFile('libflutter_engine.so');
     final File embedder =
         engineDir.childFile('libflutter_tizen_$profile$nuiSuffix.so');
-
     final File icuData =
         commonDir.childDirectory('icu').childFile('icudtl.dat');
 
@@ -431,9 +430,15 @@ class DotnetModule extends TizenPackage {
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
 
+    final TizenManifest tizenManifest =
+        TizenManifest.parseFromXml(tizenProject.manifestFile);
+    final String profile = buildInfo.deviceProfile;
+    final String? apiVersion = tizenManifest.apiVersion;
+    final String nuiSuffix = supportsNui(profile, apiVersion) ? '_nui' : '';
+
     final File engineBinary = engineDir.childFile('libflutter_engine.so');
     final File embedder =
-        engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
+        engineDir.childFile('libflutter_tizen_$profile$nuiSuffix.so');
     final File icuData =
         commonDir.childDirectory('icu').childFile('icudtl.dat');
 


### PR DESCRIPTION
Fixes a bug reported by @bbrto21 where the tool incorrectly copies `libflutter_tizen_mobile.so` instead of `libflutter_tizen_mobile_nui.so` during .NET module build (targeting Tizen 6.5).

The relevant code has accidentally been removed during rebase (due to a conflict between https://github.com/flutter-tizen/flutter-tizen/pull/431 and https://github.com/flutter-tizen/flutter-tizen/pull/418).