### PR TITLE
Change the PATH search order on Windows

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -129,15 +129,16 @@ class TizenSdk {
 
   /// On non-Windows, returns the PATH environment variable.
   ///
-  /// On Windows, appends the msys2 executables directory to PATH and returns.
-  String _getPathVariable() {
+  /// On Windows, prepends the msys2 /usr/bin directory to PATH and returns.
+  @visibleForTesting
+  String getPathVariable() {
     String path = _platform.environment['PATH'] ?? '';
     if (_platform.isWindows) {
       final Directory msysUsrBin = toolsDirectory
           .childDirectory('msys2')
           .childDirectory('usr')
           .childDirectory('bin');
-      path += ';${msysUsrBin.path}';
+      path = '${msysUsrBin.path};$path';
     }
     return path;
   }
@@ -182,7 +183,7 @@ class TizenSdk {
         workingDirectory,
       ],
       environment: <String, String>{
-        'PATH': _getPathVariable(),
+        'PATH': getPathVariable(),
       },
     );
   }
@@ -213,7 +214,7 @@ class TizenSdk {
         workingDirectory,
       ],
       environment: <String, String>{
-        'PATH': _getPathVariable(),
+        'PATH': getPathVariable(),
       },
     );
   }

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -82,6 +82,21 @@ void main() {
     expect(tizenSdk.securityProfiles, isNull);
   });
 
+  testUsingContext(
+      'TizenSdk.getPathVariable prepends msys2 directory to PATH on Windows',
+      () async {
+    final TizenSdk tizenSdk = TizenSdk.locateSdk();
+    expect(tizenSdk, isNotNull);
+    expect(tizenSdk.getPathVariable(), equals('/tools/msys2/usr/bin;/my/path'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    Platform: () => FakePlatform(
+          operatingSystem: 'windows',
+          environment: <String, String>{'TIZEN_SDK': '/', 'PATH': '/my/path'},
+        ),
+  });
+
   testWithoutContext('TizenSdk.buildApp invokes the build-app command',
       () async {
     processManager.addCommand(FakeCommand(


### PR DESCRIPTION
Potentially fixes https://github.com/flutter-tizen/flutter-tizen/issues/441.

Ensures the `make.exe` executable in the msys2 directory is detected first during Tizen CLI build on Windows.