### PR TITLE
Clean up embedding code

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -11,7 +11,7 @@
 bool FlutterApp::OnCreate() {
   TizenLog::Debug("Launching a Flutter application...");
 
-  engine_ = FlutterEngine::Create(dart_entrypoint_, dart_entrypoint_args_);
+  engine_ = FlutterEngine::Create(dart_entrypoint_);
   if (!engine_) {
     TizenLog::Error("Could not create a Flutter engine.");
     return false;

--- a/embedding/cpp/flutter_service_app.cc
+++ b/embedding/cpp/flutter_service_app.cc
@@ -11,7 +11,7 @@
 bool FlutterServiceApp::OnCreate() {
   TizenLog::Debug("Launching a Flutter service application...");
 
-  engine_ = FlutterEngine::Create(dart_entrypoint_, dart_entrypoint_args_);
+  engine_ = FlutterEngine::Create(dart_entrypoint_);
   if (!engine_) {
     TizenLog::Error("Could not create a Flutter engine.");
     return false;

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -119,9 +119,6 @@ class FlutterApp : public flutter::PluginRegistry {
   // Defaults to main() if the value is empty.
   std::string dart_entrypoint_;
 
-  // The list of Dart entrypoint arguments.
-  std::vector<std::string> dart_entrypoint_args_;
-
   // The Flutter engine instance.
   std::unique_ptr<FlutterEngine> engine_;
 

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -65,9 +65,6 @@ class FlutterServiceApp : public flutter::PluginRegistry {
   // Defaults to main() if the value is empty.
   std::string dart_entrypoint_;
 
-  // The list of Dart entrypoint arguments.
-  std::vector<std::string> dart_entrypoint_args_;
-
   // The Flutter engine instance.
   std::unique_ptr<FlutterEngine> engine_;
 };

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -30,9 +30,24 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class ElmFlutterView
     {
+        /// <summary>
+        /// The initial width of the view. Defaults to the parent width if the value is zero.
+        /// </summary>
         private int _initialWidth;
+
+        /// <summary>
+        /// The initial height of the view. Defaults to the parent height if the value is zero.
+        /// </summary>
         private int _initialHeight;
+
+        /// <summary>
+        /// The parent of <see cref="EvasObject"/>.
+        /// </summary>        
         private EvasObject _parent;
+
+        /// <summary>
+        /// The Flutter view instance handle.
+        /// </summary>
         private FlutterDesktopView _flutterView;
 
         public ElmFlutterView(EvasObject parent) : this(parent, 0, 0)

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -42,7 +42,7 @@ namespace Tizen.Flutter.Embedding
 
         /// <summary>
         /// The parent of <see cref="EvasObject"/>.
-        /// </summary>        
+        /// </summary>
         private EvasObject _parent;
 
         /// <summary>
@@ -124,11 +124,7 @@ namespace Tizen.Flutter.Embedding
                 return false;
             }
 
-            if (Engine == null)
-            {
-                Engine = new FlutterEngine();
-            }
-
+            Engine = Engine ?? new FlutterEngine();
             if (!Engine.IsValid)
             {
                 TizenLog.Error("Could not create a Flutter engine.");

--- a/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/ElmFlutterView.cs
@@ -33,7 +33,7 @@ namespace Tizen.Flutter.Embedding
         private int _initialWidth;
         private int _initialHeight;
         private EvasObject _parent;
-        private FlutterDesktopView _desktopView;
+        private FlutterDesktopView _flutterView;
 
         public ElmFlutterView(EvasObject parent) : this(parent, 0, 0)
         {
@@ -44,7 +44,7 @@ namespace Tizen.Flutter.Embedding
             _parent = parent;
             _initialWidth = initialWidth;
             _initialHeight = initialHeight;
-            _desktopView = new FlutterDesktopView();
+            _flutterView = new FlutterDesktopView();
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// Whether the view is running.
         /// </summary>
-        public bool IsRunning => !_desktopView.IsInvalid;
+        public bool IsRunning => !_flutterView.IsInvalid;
 
         /// <summary>
         /// The current width of the view.
@@ -126,14 +126,14 @@ namespace Tizen.Flutter.Embedding
                 height = _initialHeight,
             };
 
-            _desktopView = FlutterDesktopViewCreateFromElmParent(ref viewProperties, Engine.Engine, _parent);
-            if (_desktopView.IsInvalid)
+            _flutterView = FlutterDesktopViewCreateFromElmParent(ref viewProperties, Engine.Engine, _parent);
+            if (_flutterView.IsInvalid)
             {
                 TizenLog.Error("Could not launch a Flutter view.");
                 return false;
             }
 
-            EvasObject = new EvasObjectImpl(_parent, FlutterDesktopViewGetNativeHandle(_desktopView));
+            EvasObject = new EvasObjectImpl(_parent, FlutterDesktopViewGetNativeHandle(_flutterView));
             if (!EvasObject.IsRealized)
             {
                 TizenLog.Error("Could not get an Evas object.");
@@ -150,9 +150,9 @@ namespace Tizen.Flutter.Embedding
         {
             if (IsRunning)
             {
-                FlutterDesktopViewDestroy(_desktopView);
+                FlutterDesktopViewDestroy(_flutterView);
                 Engine = null;
-                _desktopView = new FlutterDesktopView();
+                _flutterView = new FlutterDesktopView();
             }
         }
 
@@ -165,7 +165,7 @@ namespace Tizen.Flutter.Embedding
 
             if (EvasObject.Geometry.Width != width || EvasObject.Geometry.Height != height)
             {
-                FlutterDesktopViewResize(_desktopView, width, height);
+                FlutterDesktopViewResize(_flutterView, width, height);
             }
         }
     }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Tizen.Applications;
 using static Tizen.Flutter.Embedding.Interop;
@@ -51,6 +50,16 @@ namespace Tizen.Flutter.Embedding
         public bool IsRunning => View != null;
 
         /// <summary>
+        /// The Flutter engine instance.
+        /// </summary>
+        internal FlutterEngine Engine { get; private set; } = null;
+
+        /// <summary>
+        /// The Flutter view instance handle.
+        /// </summary>
+        protected internal FlutterDesktopView View { get; private set; } = new FlutterDesktopView();
+
+        /// <summary>
         /// The x-coordinate of the top left corner of the window.
         /// </summary>
         protected int WindowOffsetX { get; set; } = 0;
@@ -91,16 +100,6 @@ namespace Tizen.Flutter.Embedding
         /// The renderer type of the engine. Defaults to EGL. If the profile is wearable, defaults to EvasGL.
         /// </summary>
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
-
-        /// <summary>
-        /// The Flutter view instance handle.
-        /// </summary>
-        protected internal FlutterDesktopView View { get; private set; } = new FlutterDesktopView();
-
-        /// <summary>
-        /// The Flutter engine instance.
-        /// </summary>
-        internal FlutterEngine Engine { get; private set; } = null;
 
         public override void Run(string[] args)
         {

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -41,6 +41,16 @@ namespace Tizen.Flutter.Embedding
         }
 
         /// <summary>
+        /// The optional entrypoint in the Dart project. Defaults to main() if the value is empty.
+        /// </summary>
+        public string DartEntrypoint { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether the app has started.
+        /// </summary>
+        public bool IsRunning => View != null;
+
+        /// <summary>
         /// The x-coordinate of the top left corner of the window.
         /// </summary>
         protected int WindowOffsetX { get; set; } = 0;
@@ -83,29 +93,14 @@ namespace Tizen.Flutter.Embedding
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
 
         /// <summary>
-        /// The optional entrypoint in the Dart project. Defaults to main() if the value is empty.
-        /// </summary>
-        public string DartEntrypoint { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The list of Dart entrypoint arguments.
-        /// </summary>
-        private List<string> DartEntrypointArgs { get; } = new List<string>();
-
-        /// <summary>
-        /// The Flutter engine instance.
-        /// </summary>
-        internal FlutterEngine Engine { get; private set; } = null;
-
-        /// <summary>
         /// The Flutter view instance handle.
         /// </summary>
         protected internal FlutterDesktopView View { get; private set; } = new FlutterDesktopView();
 
         /// <summary>
-        /// Whether the app has started.
+        /// The Flutter engine instance.
         /// </summary>
-        public bool IsRunning => View != null;
+        internal FlutterEngine Engine { get; private set; } = null;
 
         public override void Run(string[] args)
         {
@@ -119,11 +114,20 @@ namespace Tizen.Flutter.Embedding
             base.Run(args);
         }
 
+        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
+        {
+            if (IsRunning)
+            {
+                return Engine.GetRegistrarForPlugin(pluginName);
+            }
+            return new FlutterDesktopPluginRegistrar();
+        }
+
         protected override void OnCreate()
         {
             base.OnCreate();
 
-            Engine = new FlutterEngine(DartEntrypoint, DartEntrypointArgs);
+            Engine = new FlutterEngine(DartEntrypoint);
             if (!Engine.IsValid)
             {
                 throw new Exception("Could not create a Flutter engine.");
@@ -216,15 +220,6 @@ namespace Tizen.Flutter.Embedding
             Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
-        }
-
-        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
-        {
-            if (IsRunning)
-            {
-                return Engine.GetRegistrarForPlugin(pluginName);
-            }
-            return new FlutterDesktopPluginRegistrar();
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -15,16 +15,6 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class FlutterEngine : IPluginRegistry
     {
-        /// <summary>
-        /// Handle for interacting with the C API's engine reference.
-        /// </summary>
-        protected internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
-
-        /// <summary>
-        /// Whether the engine is valid or not.
-        /// </summary>
-        public bool IsValid => !Engine.IsInvalid;
-
         public FlutterEngine(string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
             : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so", dartEntrypoint, dartEntrypointArgs)
         {
@@ -54,6 +44,16 @@ namespace Tizen.Flutter.Embedding
                 Engine = FlutterDesktopEngineCreate(ref engineProperties);
             }
         }
+
+        /// <summary>
+        /// Whether the engine is valid or not.
+        /// </summary>
+        public bool IsValid => !Engine.IsInvalid;
+
+        /// <summary>
+        /// Handle for interacting with the C API's engine reference.
+        /// </summary>
+        protected internal FlutterDesktopEngine Engine { get; private set; } = new FlutterDesktopEngine();
 
         /// <summary>
         /// Starts running the engine.

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -20,19 +20,14 @@ namespace Tizen.Flutter.Embedding
         public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
-        /// The list of Dart entrypoint arguments.
+        /// Whether the app has started.
         /// </summary>
-        private List<string> DartEntrypointArgs { get; } = new List<string>();
+        public bool IsRunning => Engine != null;
 
         /// <summary>
         /// The Flutter engine instance.
         /// </summary>
         internal FlutterEngine Engine { get; private set; } = null;
-
-        /// <summary>
-        /// Whether the app has started.
-        /// </summary>
-        public bool IsRunning => Engine != null;
 
         public override void Run(string[] args)
         {
@@ -46,11 +41,20 @@ namespace Tizen.Flutter.Embedding
             base.Run(args);
         }
 
+        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
+        {
+            if (IsRunning)
+            {
+                return Engine.GetRegistrarForPlugin(pluginName);
+            }
+            return new FlutterDesktopPluginRegistrar();
+        }
+
         protected override void OnCreate()
         {
             base.OnCreate();
 
-            Engine = new FlutterEngine(DartEntrypoint, DartEntrypointArgs);
+            Engine = new FlutterEngine(DartEntrypoint);
             if (!Engine.IsValid)
             {
                 throw new Exception("Could not create a Flutter engine.");
@@ -106,15 +110,6 @@ namespace Tizen.Flutter.Embedding
             Debug.Assert(IsRunning);
 
             Engine.NotifyLocaleChange();
-        }
-
-        public FlutterDesktopPluginRegistrar GetRegistrarForPlugin(string pluginName)
-        {
-            if (IsRunning)
-            {
-                return Engine.GetRegistrarForPlugin(pluginName);
-            }
-            return new FlutterDesktopPluginRegistrar();
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Tizen.Applications;
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -8,7 +8,7 @@ using Tizen.Applications;
 
 namespace Tizen.Flutter.Embedding
 {
-    public static class Interop
+    internal static class Interop
     {
         #region flutter_tizen.h
         public enum FlutterDesktopRendererType

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -103,11 +103,8 @@ namespace Tizen.Flutter.Embedding
 
         [DllImport("flutter_tizen.so")]
         public static extern FlutterDesktopView FlutterDesktopViewCreateFromImageView(
-            ref FlutterDesktopViewProperties view_properties,
-            FlutterDesktopEngine engine,
-            IntPtr image_view,
-            IntPtr native_image_queue,
-            int default_window_id);
+            ref FlutterDesktopViewProperties view_properties, FlutterDesktopEngine engine, IntPtr image_view,
+            IntPtr native_image_queue, int default_window_id);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopViewDestroy(
@@ -117,29 +114,17 @@ namespace Tizen.Flutter.Embedding
         public static extern IntPtr FlutterDesktopViewGetNativeHandle(FlutterDesktopView view);
 
         [DllImport("flutter_tizen.so")]
-        public static extern void FlutterDesktopViewResize(
-            FlutterDesktopView view,
-            int width,
-            int height);
+        public static extern void FlutterDesktopViewResize(FlutterDesktopView view, int width, int height);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopViewOnPointerEvent(
-            FlutterDesktopView view,
-            FlutterDesktopPointerEventType type,
-            double x,
-            double y,
-            uint timestamp,
+            FlutterDesktopView view, FlutterDesktopPointerEventType type, double x, double y, uint timestamp,
             int device_id);
 
         [DllImport("flutter_tizen.so")]
         public static extern void FlutterDesktopViewOnKeyEvent(
-            FlutterDesktopView view,
-            string key,
-            string key_string,
-            uint modifiers,
-            uint scan_code,
-            [MarshalAs(UnmanagedType.U1)]
-            bool is_down);
+            FlutterDesktopView view, string key, string key_string, uint modifiers, uint scan_code,
+            [MarshalAs(UnmanagedType.U1)] bool is_down);
         #endregion
 
         #region flutter_messenger.h
@@ -159,8 +144,7 @@ namespace Tizen.Flutter.Embedding
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void FlutterDesktopMessageCallback(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FlutterDesktopMessenger.Marshaler))]
-            FlutterDesktopMessenger messenger,
-            IntPtr message, IntPtr user_data);
+            FlutterDesktopMessenger messenger, IntPtr message, IntPtr user_data);
 
         [DllImport("flutter_tizen.so")]
         public static extern bool FlutterDesktopMessengerSend(

--- a/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Tizen.NUI;

--- a/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
@@ -16,7 +16,14 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class NUIFlutterView : ImageView
     {
+        /// <summary>
+        /// When the view last received a touch event in milliseconds.
+        /// </summary>
         private uint _lastTouchEventTime = 0;
+
+        /// <summary>
+        /// The size of the Flutter view.
+        /// </summary>
         private Size2D _size = new Size2D();
 
         /// <summary>
@@ -99,6 +106,9 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
+        /// <summary>
+        /// Returns the size that can be the default.
+        /// </summary>
         private Size2D GetDefaultSize()
         {
             if (Size2D.Width == 0 || Size2D.Height == 0)
@@ -121,6 +131,9 @@ namespace Tizen.Flutter.Embedding
             return Size2D;
         }
 
+        /// <summary>
+        /// Registers view event handlers.
+        /// </summary>
         private void RegisterEventHandlers()
         {
             Focusable = true;

--- a/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
@@ -18,6 +18,9 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class NUIFlutterView : ImageView
     {
+        private uint _lastTouchEventTime = 0;
+        private Size2D _size = new Size2D();
+
         /// <summary>
         /// The Flutter engine instance.
         /// </summary>
@@ -34,16 +37,6 @@ namespace Tizen.Flutter.Embedding
         public bool IsRunning => !View.IsInvalid;
 
         /// <summary>
-        /// When the view last received a touch event in milliseconds.
-        /// </summary>
-        private uint _lastTouchEventTime = 0;
-
-        /// <summary>
-        /// The size of the Flutter view.
-        /// </summary>
-        private Size2D _size = new Size2D();
-
-        /// <summary>
         /// Starts running the view with the associated engine, creating if not set.
         /// </summary>
         /// <remarks>
@@ -58,11 +51,7 @@ namespace Tizen.Flutter.Embedding
                 return false;
             }
 
-            if (Engine == null)
-            {
-                Engine = new FlutterEngine();
-            }
-
+            Engine = Engine ?? new FlutterEngine();
             if (!Engine.IsValid)
             {
                 TizenLog.Error("Could not create a Flutter engine.");
@@ -70,17 +59,13 @@ namespace Tizen.Flutter.Embedding
             }
 
             Size2D size = GetDefaultSize();
-            Type baseType = typeof(NativeImageQueue).BaseType.BaseType.BaseType;
-            FieldInfo field = baseType.GetField("swigCPtr", BindingFlags.NonPublic | BindingFlags.Instance);
-            NativeImageQueue nativeImageQueue =
+
+            var nativeImageQueue =
                 new NativeImageQueue((uint)size.Width, (uint)size.Height, NativeImageQueue.ColorFormat.RGBA8888);
-            HandleRef nativeImageQueueRef = (HandleRef)field.GetValue(nativeImageQueue);
+            var nativeImageQueueRef = GetFieldValue<HandleRef>(nativeImageQueue, typeof(Tizen.NUI.Disposable), "swigCPtr");
             SetImage(nativeImageQueue.GenerateUrl().ToString());
 
-            Type imageViewBaseType = typeof(ImageView).BaseType.BaseType.BaseType.BaseType;
-            FieldInfo imageViewField =
-                imageViewBaseType.GetField("swigCPtr", BindingFlags.NonPublic | BindingFlags.Instance);
-            HandleRef imageViewRef = (HandleRef)imageViewField.GetValue(this);
+            var imageViewRef = GetFieldValue<HandleRef>(this, typeof(Tizen.NUI.BaseHandle), "swigCPtr");
 
             var viewProperties = new FlutterDesktopViewProperties
             {
@@ -116,9 +101,6 @@ namespace Tizen.Flutter.Embedding
             }
         }
 
-        /// <summary>
-        /// Returns the size that can be the default.
-        /// </summary>
         private Size2D GetDefaultSize()
         {
             if (Size2D.Width == 0 || Size2D.Height == 0)
@@ -141,9 +123,6 @@ namespace Tizen.Flutter.Embedding
             return Size2D;
         }
 
-        /// <summary>
-        /// Registers view event handlers.
-        /// </summary>
         private void RegisterEventHandlers()
         {
             Focusable = true;
@@ -203,6 +182,12 @@ namespace Tizen.Flutter.Embedding
                     _size = Size2D;
                 }
             };
+        }
+
+        private T GetFieldValue<T>(object obj, Type type, string fieldName)
+        {
+            FieldInfo field = type.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            return (T)field.GetValue(obj);
         }
     }
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <TargetFrameworks>netstandard2.0;tizen40;tizen90</TargetFrameworks>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### C#
- Change private properties to private fields.
- Fix class layout orders. [SA1201](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md) , [SA1202](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md)

- Remove `DartEntrypoint` property of `FlutterApplication` and `FlutterServiceApplication`.
- Simplify `NUIFlutterView.RunEngine()` .

### C++
- Remove unused private member `dart_entrypoint_args_` from `FlutterApp` and `FlutterServiceApp`.