### PR TITLE
Remove PackageReference to Tizen.NET from C# plugin template

### DIFF
--- a/templates/plugin/csharp/pluginClass.csproj
+++ b/templates/plugin/csharp/pluginClass.csproj
@@ -8,8 +8,4 @@
     <ProjectReference Include="$(FlutterEmbeddingPath)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.1.14164" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Remove unnecessary `PackageReference` for `Tizen.NET` from the C# plugin template. Since the C# plugin project already refers to the `Tizen.NET` package in the `Tizen.NET.Embedding` project being referenced, version conflicts can occur such as follows:

```
/home/zzervb/Tests/FlutterTizenTests/test_plugin/tizen/TestPlugin.csproj : error NU1605: Detected package downgrade: Tizen.NET from 9.0.0.16760 to 4.0.1.14164. Reference the package directly from the project to select a different version. 
/home/zzervb/Tests/FlutterTizenTests/test_plugin/tizen/TestPlugin.csproj : error NU1605:  TestPlugin -> Tizen.Flutter.Embedding -> Tizen.NET (>= 9.0.0.16760) 
/home/zzervb/Tests/FlutterTizenTests/test_plugin/tizen/TestPlugin.csproj : error NU1605:  TestPlugin -> Tizen.NET (>= 4.0.1.14164)
    0 Warning(s)
    1 Error(s)

```