### PR TITLE
Add type to support external output

### DIFF
--- a/bin/internal/embedder.version
+++ b/bin/internal/embedder.version
@@ -1,1 +1,1 @@
-b54ad05b4b89fe31b6f75c3c6df242a6b9a0dbad
+2f6ee56eac907b719befdb2e15b58bf5b06db95a

--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -25,6 +25,14 @@ bool FlutterApp::OnCreate() {
   }
 #endif
 
+  if (renderer_type_ == FlutterRendererType::kEGL &&
+      external_output_type_ != FlutterExternalOutputType::kNone) {
+    TizenLog::Error(
+        "External output is not supported by FlutterRendererType::kEGL type "
+        "renderer.");
+    return false;
+  }
+
   FlutterDesktopWindowProperties window_prop = {};
   window_prop.x = window_offset_x_;
   window_prop.y = window_offset_y_;
@@ -35,6 +43,8 @@ bool FlutterApp::OnCreate() {
   window_prop.top_level = is_top_level_;
   window_prop.renderer_type =
       static_cast<FlutterDesktopRendererType>(renderer_type_);
+  window_prop.external_output_type =
+      static_cast<FlutterDesktopExternalOutputType>(external_output_type_);
 
   view_ = FlutterDesktopViewCreateFromNewWindow(window_prop,
                                                 engine_->RelinquishEngine());

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -22,6 +22,13 @@ enum class FlutterRendererType {
   kEGL,
 };
 
+enum class FlutterExternalOutputType {
+  // No use external output.
+  kNone,
+  // Display to the HDMI external output.
+  kHDMI,
+};
+
 // The app base class for headed Flutter execution.
 class FlutterApp : public flutter::PluginRegistry {
  public:
@@ -112,6 +119,12 @@ class FlutterApp : public flutter::PluginRegistry {
   //
   // Defaults to kEGL. If the profile is wearable, defaults to kEvasGL.
   FlutterRendererType renderer_type_ = FlutterRendererType::kEGL;
+
+  // The external output type of the engine.
+  //
+  // Defaults to kNone.
+  FlutterExternalOutputType external_output_type_ =
+      FlutterExternalOutputType::kNone;
 
  private:
   // The optional entrypoint in the Dart project.

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -23,7 +23,7 @@ enum class FlutterRendererType {
 };
 
 enum class FlutterExternalOutputType {
-  // No use external output.
+  // No external output.
   kNone,
   // Display to the HDMI external output.
   kHDMI,

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -120,7 +120,7 @@ class FlutterApp : public flutter::PluginRegistry {
   // Defaults to kEGL. If the profile is wearable, defaults to kEvasGL.
   FlutterRendererType renderer_type_ = FlutterRendererType::kEGL;
 
-  // The external output type of the engine.
+  // The external output type of the window.
   //
   // Defaults to kNone.
   FlutterExternalOutputType external_output_type_ =

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -27,7 +27,7 @@ namespace Tizen.Flutter.Embedding
     public enum FlutterExternalOutputType
     {
         /// <summary>
-        /// No use external output.
+        /// No external output.
         /// </summary>
         None = 0,
         /// <summary>
@@ -117,6 +117,7 @@ namespace Tizen.Flutter.Embedding
         /// The external output type of the engine. Defaults to None.
         /// </summary>
         protected FlutterExternalOutputType ExternalOutputType { get; set; } = FlutterExternalOutputType.None;
+
         public override void Run(string[] args)
         {
             // Log any unhandled exception.

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -114,7 +114,7 @@ namespace Tizen.Flutter.Embedding
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
 
         /// <summary>
-        /// The external output type of the engine. Defaults to None.
+        /// The external output type of the window. Defaults to None.
         /// </summary>
         protected FlutterExternalOutputType ExternalOutputType { get; set; } = FlutterExternalOutputType.None;
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -24,6 +24,18 @@ namespace Tizen.Flutter.Embedding
         EGL,
     }
 
+    public enum FlutterExternalOutputType
+    {
+        /// <summary>
+        /// No use external output.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Display to the HDMI external output.
+        /// </summary>
+        HDMI,
+    }
+
     /// <summary>
     /// The app base class for headed Flutter execution.
     /// </summary>
@@ -101,6 +113,10 @@ namespace Tizen.Flutter.Embedding
         /// </summary>
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
 
+        /// <summary>
+        /// The external output type of the engine. Defaults to None.
+        /// </summary>
+        protected FlutterExternalOutputType ExternalOutputType { get; set; } = FlutterExternalOutputType.None;
         public override void Run(string[] args)
         {
             // Log any unhandled exception.
@@ -138,6 +154,11 @@ namespace Tizen.Flutter.Embedding
                 throw new Exception("FlutterRendererType.kEGL is not supported by this profile.");
             }
 #endif
+            if (RendererType == FlutterRendererType.EGL && ExternalOutputType != FlutterExternalOutputType.None)
+            {
+                throw new Exception("External output is not supported by FlutterRendererType::kEGL type renderer.");
+            }
+
             var windowProperties = new FlutterDesktopWindowProperties
             {
                 x = WindowOffsetX,
@@ -148,6 +169,7 @@ namespace Tizen.Flutter.Embedding
                 focusable = IsWindowFocusable,
                 top_level = IsTopLevel,
                 renderer_type = (FlutterDesktopRendererType)RendererType,
+                external_output_type = (FlutterDesktopExternalOutputType)ExternalOutputType,
             };
 
             View = FlutterDesktopViewCreateFromNewWindow(ref windowProperties, Engine.Engine);

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -24,6 +24,12 @@ namespace Tizen.Flutter.Embedding
             kPointerMove,
         };
 
+        public enum FlutterDesktopExternalOutputType
+        {
+            kNone,
+            kHDMI,
+        };
+
         [StructLayout(LayoutKind.Sequential)]
         public struct FlutterDesktopWindowProperties
         {
@@ -38,6 +44,7 @@ namespace Tizen.Flutter.Embedding
             [MarshalAs(UnmanagedType.U1)]
             public bool top_level;
             public FlutterDesktopRendererType renderer_type;
+            public FlutterDesktopExternalOutputType external_output_type;
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Add type to supports External Output feature, if renderer is EvasGL.
If HDMI is connected to the HW device and the type is set to HDMI,
the application is output to the device.

related pr : https://github.com/flutter-tizen/embedder/pull/3