### PR TITLE
Do additional cleanup before multi app build

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -315,6 +315,15 @@ class NativeTpk extends TizenPackage {
     }
     buildDir.createSync(recursive: true);
 
+    if (tizenProject.isMultiApp) {
+      final Directory serviceBuildDir =
+          tizenProject.serviceAppDirectory.childDirectory(buildConfig);
+      if (serviceBuildDir.existsSync()) {
+        serviceBuildDir.deleteSync(recursive: true);
+      }
+      serviceBuildDir.createSync(recursive: true);
+    }
+
     // The output TPK is signed with an active profile unless otherwise
     // specified.
     String? securityProfile = buildInfo.securityProfile;

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -60,7 +60,6 @@ class TizenProject extends FlutterProjectPlatform {
   @visibleForTesting
   Directory get uiAppDirectory => editableDirectory.childDirectory('ui');
 
-  @visibleForTesting
   Directory get serviceAppDirectory =>
       editableDirectory.childDirectory('service');
 


### PR DESCRIPTION
If the service app build dir of a multi app (`tizen/service/Debug` or `tizen/service/Release`) is not cleaned up before running a build, the following linker error can be generated after switching a profile (e.g. `-pwearable` to `-pmobile`).

```sh
/home/swift/tizen-studio/tools/smart-build-interface/../i586-linux-gnueabi-gcc-9.2/lib/gcc/i586-tizen-linux-gnueabi/9.2.0/../../../../i586-tizen-linux-gnueabi/bin/ld: cannot find
-lappcore-watch
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [/home/swift/tizen-studio/tools/ide/resources/native/Build/makefile.mk:135: Debug/runner_service] Error 1
make[1]: Leaving directory '/home/swift/Git/plugins/packages/tizen_app_control/example/tizen/service'
make: *** [/home/swift/tizen-studio/tools/ide/resources/native/Build/makefile:27: app_build] Error 2
```

