### PR TITLE
Make dart_api_dl.h symbols available to app and plugin code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
         with:
           channel: stable
       - name: Install credentials
-        run: echo '${{ secrets.PUB_CREDENTIALS }}' > $PUB_CACHE/credentials.json
+        run: |
+          mkdir -p $PUB_CACHE
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $PUB_CACHE/credentials.json
       - name: Dry run on pull request
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/embedding/cpp/project_def.prop
+++ b/embedding/cpp/project_def.prop
@@ -8,6 +8,8 @@ profile = common-4.0
 
 USER_INC_DIRS = include \
     ../../flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include \
-    ../../flutter/bin/cache/artifacts/engine/tizen-common/public
+    ../../flutter/bin/cache/artifacts/engine/tizen-common/public \
+    ../../flutter/bin/cache/dart-sdk/include
 USER_SRCS = *.cc \
-    ../../flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/*.cc
+    ../../flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/*.cc \
+    ../../flutter/bin/cache/dart-sdk/include/dart_api_dl.c

--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -86,6 +86,13 @@ class NativeEmbedding extends Target {
         .forEach(inputs.add);
     publicDir.listSync(recursive: true).whereType<File>().forEach(inputs.add);
 
+    final Directory dartSdkIncludeDir =
+        getDartSdkDirectory().childDirectory('include');
+    dartSdkIncludeDir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .forEach(inputs.add);
+
     assert(tizenSdk != null);
     String? apiVersion;
     if (tizenProject.manifestFile.existsSync()) {

--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -86,9 +86,8 @@ class NativeEmbedding extends Target {
         .forEach(inputs.add);
     publicDir.listSync(recursive: true).whereType<File>().forEach(inputs.add);
 
-    final Directory dartSdkIncludeDir =
-        getDartSdkDirectory().childDirectory('include');
-    dartSdkIncludeDir
+    getDartSdkDirectory()
+        .childDirectory('include')
         .listSync(recursive: true)
         .whereType<File>()
         .forEach(inputs.add);

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -290,6 +290,8 @@ class NativeTpk extends TizenPackage {
         commonDir.childDirectory('cpp_client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
 
+    final Directory dartSdkDir = getDartSdkDirectory();
+
     assert(tizenSdk != null);
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
       profile: profile,
@@ -353,6 +355,7 @@ class NativeTpk extends TizenPackage {
       '"-Wl,--unresolved-symbols=ignore-in-shared-libs"',
       '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
       '-I${publicDir.path.toPosixPath()}',
+      '-I${dartSdkDir.childDirectory('include').path.toPosixPath()}',
       '-I${embeddingDir.childDirectory('include').path.toPosixPath()}',
       embeddingLib.path.toPosixPath(),
       '-L${libDir.path.toPosixPath()}',

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -99,6 +99,13 @@ class NativePlugins extends Target {
         commonDir.childDirectory('cpp_client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
 
+    final Directory dartSdkDir = getDartSdkDirectory();
+    dartSdkDir
+        .childDirectory('include')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .forEach(inputs.add);
+
     assert(tizenSdk != null);
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
       profile: profile,
@@ -132,6 +139,7 @@ class NativePlugins extends Target {
           if (!plugin.isSharedLib) '-fPIC',
           '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
           '-I${publicDir.path.toPosixPath()}',
+          '-I${dartSdkDir.parent.path.toPosixPath()}',
           if (plugin.isSharedLib) ...<String>[
             '-l${getLibNameForFileName(embedder.basename)}',
             '-L${embedderDir.path.toPosixPath()}',

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -99,8 +99,7 @@ class NativePlugins extends Target {
         commonDir.childDirectory('cpp_client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
 
-    final Directory dartSdkIncludeDir =
-        getDartSdkDirectory().childDirectory('include');
+    final Directory dartSdkDir = getDartSdkDirectory();
 
     assert(tizenSdk != null);
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
@@ -135,7 +134,7 @@ class NativePlugins extends Target {
           if (!plugin.isSharedLib) '-fPIC',
           '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
           '-I${publicDir.path.toPosixPath()}',
-          '-I${dartSdkIncludeDir.path.toPosixPath()}',
+          '-I${dartSdkDir.childDirectory('include').path.toPosixPath()}',
           if (plugin.isSharedLib) ...<String>[
             '-l${getLibNameForFileName(embedder.basename)}',
             '-L${embedderDir.path.toPosixPath()}',

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -99,12 +99,8 @@ class NativePlugins extends Target {
         commonDir.childDirectory('cpp_client_wrapper');
     final Directory publicDir = commonDir.childDirectory('public');
 
-    final Directory dartSdkDir = getDartSdkDirectory();
-    dartSdkDir
-        .childDirectory('include')
-        .listSync(recursive: true)
-        .whereType<File>()
-        .forEach(inputs.add);
+    final Directory dartSdkIncludeDir =
+        getDartSdkDirectory().childDirectory('include');
 
     assert(tizenSdk != null);
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
@@ -139,7 +135,7 @@ class NativePlugins extends Target {
           if (!plugin.isSharedLib) '-fPIC',
           '-I${clientWrapperDir.childDirectory('include').path.toPosixPath()}',
           '-I${publicDir.path.toPosixPath()}',
-          '-I${dartSdkDir.parent.path.toPosixPath()}',
+          '-I${dartSdkIncludeDir.path.toPosixPath()}',
           if (plugin.isSharedLib) ...<String>[
             '-l${getLibNameForFileName(embedder.basename)}',
             '-L${embedderDir.path.toPosixPath()}',

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -56,6 +56,10 @@ Directory getCommonArtifactsDirectory() {
       .childDirectory('tizen-common');
 }
 
+Directory getDartSdkDirectory() {
+  return globals.cache.getCacheDir('dart-sdk');
+}
+
 /// Removes the "lib" prefix and file extension from [name] and returns.
 String getLibNameForFileName(String name) {
   if (name.startsWith('lib')) {

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -184,6 +184,7 @@ class TizenSdk {
       ],
       environment: <String, String>{
         'PATH': getPathVariable(),
+        'USER_CPP_OPTS': '-std=c++17',
       },
     );
   }
@@ -215,6 +216,7 @@ class TizenSdk {
       ],
       environment: <String, String>{
         'PATH': getPathVariable(),
+        'USER_CPP_OPTS': '-std=c++17',
       },
     );
   }
@@ -328,19 +330,11 @@ class TizenSdk {
   <rootstrap id="$flutterRootstrapId" name="Flutter" version="Tizen $apiVersion" architecture="$buildArch" path="${rootstrap.rootDirectory.path}" supportToolchainType="tizen.core">
     <property key="DEV_PACKAGE_CONFIG_PATH" value="${configFile.path}"/>
     <property key="LINKER_MISCELLANEOUS_OPTION" value="${linkerFlags.join(' ')}"/>
-    <property key="COMPILER_MISCELLANEOUS_OPTION" value="-std=c++17"/>
+    <property key="COMPILER_MISCELLANEOUS_OPTION" value=""/>
     <toolchain name="gcc" version="$defaultGccVersion"/>
   </rootstrap>
 </extension>
 ''');
-
-    // Remove files created by previous versions of the flutter-tizen tool.
-    final Iterable<File> manifests = pluginsDir.listSync().whereType<File>();
-    for (final File file in manifests) {
-      if (file.basename.endsWith('.flutter.xml')) {
-        file.deleteSync();
-      }
-    }
 
     return Rootstrap(flutterRootstrapId, rootstrap.rootDirectory);
   }

--- a/test/general/build_targets/embedding_test.dart
+++ b/test/general/build_targets/embedding_test.dart
@@ -44,7 +44,7 @@ type = staticLib
 ''');
     embeddingDir.childFile('include/flutter.h').createSync(recursive: true);
 
-    _installFakeEngineArtifacts(cache.getArtifactDirectory('engine'));
+    _createFakeIncludeDirs(cache);
   });
 
   testUsingContext('Build succeeds', () async {
@@ -74,7 +74,11 @@ type = staticLib
   });
 }
 
-void _installFakeEngineArtifacts(Directory engineArtifactDir) {
+void _createFakeIncludeDirs(Cache cache) {
+  final Directory dartSdkDir = cache.getCacheDir('dart-sdk');
+  dartSdkDir.childDirectory('include').createSync(recursive: true);
+
+  final Directory engineArtifactDir = cache.getArtifactDirectory('engine');
   for (final String directory in <String>[
     'tizen-common/cpp_client_wrapper/include',
     'tizen-common/public',

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -94,7 +94,7 @@ dependencies:
 </manifest>
 ''');
 
-    _installFakeEngineArtifacts(cache.getArtifactDirectory('engine'));
+    _createFakeIncludeDirs(cache);
   });
 
   testUsingContext('Can build staticLib project', () async {
@@ -217,7 +217,11 @@ dependencies:
   });
 }
 
-void _installFakeEngineArtifacts(Directory engineArtifactDir) {
+void _createFakeIncludeDirs(Cache cache) {
+  final Directory dartSdkDir = cache.getCacheDir('dart-sdk');
+  dartSdkDir.childDirectory('include').createSync(recursive: true);
+
+  final Directory engineArtifactDir = cache.getArtifactDirectory('engine');
   for (final String directory in <String>[
     'tizen-common/cpp_client_wrapper/include',
     'tizen-common/public',


### PR DESCRIPTION
Currently it's not very easy to access the Dart VM API from plugin native code because the relevant header and source files must be included in each plugin's source tree. This patch automatically adds `dart_api_dl.c` to the `NativeEmbedding` build target (so it's statically linked with the plugin code) and adds the `dart_api_dl.h` location to the include path during build, making the APIs available to all app and plugin native code:

```cpp
#include <dart_api_dl.h>

intptr_t ImagePickerTizenPluginInitializeDartApi(void *data) {
  return Dart_InitializeApiDL(data);
}
```