### PR TITLE
Set FLUTTER_BUILD_DIR environment variable when building plugins

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -397,7 +397,7 @@ class NativeTpk extends TizenPackage {
       },
       sign: securityProfile,
       environment: <String, String>{
-        'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(),
+        'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(''),
       },
     );
     if (result.exitCode != 0) {

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -396,6 +396,9 @@ class NativeTpk extends TizenPackage {
         'targets': <String>['b1'],
       },
       sign: securityProfile,
+      environment: <String, String>{
+        'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(),
+      },
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to build native application:\n$result');

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -142,6 +142,9 @@ class NativePlugins extends Target {
           ],
         ],
         rootstrap: rootstrap.id,
+        environment: <String, String>{
+          'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(),
+        },
       );
       if (result.exitCode != 0) {
         throwToolExit('Failed to build ${plugin.name} plugin:\n$result');

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -143,7 +143,7 @@ class NativePlugins extends Target {
         ],
         rootstrap: rootstrap.id,
         environment: <String, String>{
-          'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(),
+          'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(''),
         },
       );
       if (result.exitCode != 0) {

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -150,6 +150,7 @@ class TizenSdk {
     String? output,
     Map<String, Object> package = const <String, Object>{},
     String? sign,
+    Map<String, String> environment = const <String, String>{},
   }) {
     String stringify(Object argument) {
       if (argument is String) {
@@ -185,6 +186,7 @@ class TizenSdk {
       environment: <String, String>{
         'PATH': getPathVariable(),
         'USER_CPP_OPTS': '-std=c++17',
+        ...environment,
       },
     );
   }
@@ -197,6 +199,7 @@ class TizenSdk {
     List<String> predefines = const <String>[],
     List<String> extraOptions = const <String>[],
     String? rootstrap,
+    Map<String, String> environment = const <String, String>{},
   }) {
     return _processUtils.run(
       <String>[
@@ -217,6 +220,7 @@ class TizenSdk {
       environment: <String, String>{
         'PATH': getPathVariable(),
         'USER_CPP_OPTS': '-std=c++17',
+        ...environment,
       },
     );
   }

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -112,6 +112,11 @@ void main() {
         '--',
         projectDir.path,
       ],
+      environment: const <String, String>{
+        'PATH': '',
+        'USER_CPP_OPTS': '-std=c++17',
+        'test_key': 'test_value',
+      },
     ));
 
     await tizenSdk.buildApp(
@@ -137,6 +142,7 @@ void main() {
         'targets': <String>['test_build'],
       },
       sign: 'test_profile',
+      environment: <String, String>{'test_key': 'test_value'},
     );
 
     expect(processManager, hasNoRemainingExpectations);
@@ -163,6 +169,11 @@ void main() {
         '--',
         projectDir.path,
       ],
+      environment: const <String, String>{
+        'PATH': '',
+        'USER_CPP_OPTS': '-std=c++17',
+        'test_key': 'test_value',
+      },
     ));
 
     await tizenSdk.buildNative(
@@ -173,6 +184,7 @@ void main() {
       predefines: <String>['ABC'],
       extraOptions: <String>['def', 'ghi'],
       rootstrap: 'test_rootstrap',
+      environment: <String, String>{'test_key': 'test_value'},
     );
 
     expect(processManager, hasNoRemainingExpectations);

--- a/test/src/fake_tizen_sdk.dart
+++ b/test/src/fake_tizen_sdk.dart
@@ -48,6 +48,7 @@ class FakeTizenSdk extends TizenSdk {
     String? output,
     Map<String, Object> package = const <String, Object>{},
     String? sign,
+    Map<String, String> environment = const <String, String>{},
   }) async {
     final List<String>? buildConfigs = method['configs'] as List<String>?;
     expect(buildConfigs, isNotNull);
@@ -70,6 +71,7 @@ class FakeTizenSdk extends TizenSdk {
     List<String> predefines = const <String>[],
     List<String> extraOptions = const <String>[],
     String? rootstrap,
+    Map<String, String> environment = const <String, String>{},
   }) async {
     final Directory projectDir = _fileSystem.directory(workingDirectory);
     final Map<String, String> projectDef =


### PR DESCRIPTION
Set the `FLUTTER_BUILD_DIR` environment variable during plugin and app build to allow some files to be downloaded to the location when building FlutterFire plugins.

cc @daeyeon @hs0225