### PR TITLE
Fix flutter_tools.stamp version check

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -47,7 +47,7 @@ GOTO :EOF
       IF !version! NEQ !revision! (
         git reset --hard
         git clean -xdf
-        git fetch "%flutter_repo%" "!version!"
+        git fetch --tags "%flutter_repo%" "!version!"
         git checkout FETCH_HEAD
 
         REM Invalidate the cache.
@@ -83,7 +83,7 @@ GOTO :EOF
   SET stamp_path=%ROOT_DIR%\bin\cache\flutter-tizen.stamp
 
   SETLOCAL
-    IF NOT EXIST "%snapshot_path%" GOTO do_update_snapshot   
+    IF NOT EXIST "%snapshot_path%" GOTO do_update_snapshot
     IF NOT EXIST "%stamp_path%" GOTO do_update_snapshot
     SET /P stamp_value=<"%stamp_path%"
     IF !revision! NEQ !stamp_value! GOTO do_update_snapshot

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -63,10 +63,11 @@ GOTO :EOF
     POPD
 
     REM Invalidate the flutter cache.  
+    SET compilekey="%version%:"
     SET stamp_path=%flutter_dir%\bin\cache\flutter_tools.stamp
     IF NOT EXIST "%stamp_path%" GOTO do_flutter_version
     SET /P stamp=<"%stamp_path%"
-    IF !version! NEQ !stamp! GOTO do_flutter_version
+    IF !compilekey! NEQ !stamp! GOTO do_flutter_version
 
     EXIT /B
     :do_flutter_version

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -49,7 +49,7 @@ function update_flutter() {
   if [[ "$version" != "$(git rev-parse HEAD)" ]]; then
     git reset --hard
     git clean -xdf
-    git fetch "$FLUTTER_REPO" "$version"
+    git fetch --tags "$FLUTTER_REPO" "$version"
     git checkout FETCH_HEAD
 
     # Invalidate the cache.
@@ -67,7 +67,7 @@ function update_flutter() {
 
   # Invalidate the flutter cache.
   local stamp_path="$FLUTTER_DIR/bin/cache/flutter_tools.stamp"
-  if [[ ! -f "$stamp_path" || "$version" != "$(cat "$stamp_path")" ]]; then
+  if [[ ! -f "$stamp_path" || "$(cat "$stamp_path")" != "$version"* ]]; then
     "$FLUTTER_EXE" > /dev/null
   fi
 }
@@ -78,7 +78,7 @@ function update_flutter_tizen() {
   local revision="$(git --git-dir="$ROOT_DIR/.git" rev-parse HEAD)"
   local stamp_path="$ROOT_DIR/bin/cache/flutter-tizen.stamp"
 
-  if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$stamp_path" || "$revision" != "$(cat "$stamp_path")" 
+  if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$stamp_path" || "$revision" != "$(cat "$stamp_path")"
         || "$ROOT_DIR/pubspec.yaml" -nt "$ROOT_DIR/pubspec.lock" ]]; then
     echo "Running pub upgrade..."
     (cd "$ROOT_DIR" && "$FLUTTER_EXE" pub upgrade) || {

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -66,8 +66,9 @@ function update_flutter() {
   unset GIT_WORK_TREE
 
   # Invalidate the flutter cache.
+  local compilekey="$version:"
   local stamp_path="$FLUTTER_DIR/bin/cache/flutter_tools.stamp"
-  if [[ ! -f "$stamp_path" || "$(cat "$stamp_path")" != "$version"* ]]; then
+  if [[ ! -f "$stamp_path" || "$compilekey" != "$(cat "$stamp_path")" ]]; then
     "$FLUTTER_EXE" > /dev/null
   fi
 }


### PR DESCRIPTION
The `flutter` command is being called redundantly due to https://github.com/flutter/flutter/commit/2835c3f1161afcd93894324475c72eb66f67a05e.