### PR TITLE
Pass API_VERSION environment variable to the builder

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -398,6 +398,7 @@ class NativeTpk extends TizenPackage {
       sign: securityProfile,
       environment: <String, String>{
         'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(''),
+        'API_VERSION': apiVersion ?? '',
       },
     );
     if (result.exitCode != 0) {

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -144,6 +144,7 @@ class NativePlugins extends Target {
         rootstrap: rootstrap.id,
         environment: <String, String>{
           'FLUTTER_BUILD_DIR': environment.buildDir.path.toPosixPath(''),
+          'API_VERSION': apiVersion ?? '',
         },
       );
       if (result.exitCode != 0) {
@@ -198,10 +199,13 @@ class NativePlugins extends Target {
       // Copy user libraries.
       // TODO(swift-kim): Remove user libs support for staticLib projects.
       final Directory pluginLibDir = plugin.directory.childDirectory('lib');
+      final String buildArch = getTizenBuildArch(buildInfo.targetArch);
       final List<Directory> pluginLibDirs = <Directory>[
-        pluginLibDir.childDirectory(buildInfo.targetArch),
-        pluginLibDir.childDirectory(getTizenBuildArch(buildInfo.targetArch)),
         pluginLibDir,
+        pluginLibDir.childDirectory(buildInfo.targetArch),
+        pluginLibDir.childDirectory(buildArch),
+        if (apiVersion != null)
+          pluginLibDir.childDirectory(buildArch).childDirectory(apiVersion),
       ];
       for (final Directory directory
           in pluginLibDirs.where((Directory dir) => dir.existsSync())) {

--- a/test/general/build_targets/plugins_test.dart
+++ b/test/general/build_targets/plugins_test.dart
@@ -181,7 +181,7 @@ dependencies:
     TizenSdk: () => FakeTizenSdk(fileSystem),
   });
 
-  testUsingContext('Can link to user libraries', () async {
+  testUsingContext('Can link and copy user libraries', () async {
     final Environment environment = Environment.test(
       projectDir,
       fileSystem: fileSystem,
@@ -191,6 +191,18 @@ dependencies:
     );
     pluginDir.childFile('tizen/lib/libstatic.a').createSync(recursive: true);
     pluginDir.childFile('tizen/lib/libshared.so').createSync(recursive: true);
+    pluginDir
+        .childFile('tizen/lib/armel/libshared_arm.so')
+        .createSync(recursive: true);
+    pluginDir
+        .childFile('tizen/lib/i586/libshared_x86.so')
+        .createSync(recursive: true);
+    pluginDir
+        .childFile('tizen/lib/armel/4.0/libshared_40.so')
+        .createSync(recursive: true);
+    pluginDir
+        .childFile('tizen/lib/armel/5.0/libshared_50.so')
+        .createSync(recursive: true);
 
     await NativePlugins(const TizenBuildInfo(
       BuildInfo.release,
@@ -202,12 +214,16 @@ dependencies:
         environment.buildDir.childDirectory('tizen_plugins');
     expect(outputDir.childFile('lib/libstatic.a'), isNot(exists));
     expect(outputDir.childFile('lib/libshared.so'), exists);
+    expect(outputDir.childFile('lib/libshared_arm.so'), exists);
+    expect(outputDir.childFile('lib/libshared_x86.so'), isNot(exists));
+    expect(outputDir.childFile('lib/libshared_40.so'), exists);
+    expect(outputDir.childFile('lib/libshared_50.so'), isNot(exists));
 
     final Map<String, String> projectDef =
         parseIniFile(outputDir.childFile('project_def.prop'));
     expect(
       projectDef['USER_LIBS'],
-      contains('some_native_plugin static shared'),
+      contains('some_native_plugin static shared shared_arm shared_40'),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,


### PR DESCRIPTION
A feature requested by our SRC-N members. @xiaowei-guan

- Sets the `API_VERSION` environment variable (which is in the `x.y` format) when building native plugins and apps.
- Searches the `lib/{BUILD_ARCH}/{API_VERSION}` directory for platform-version specific user libraries.
