### PR TITLE
Fix FormatException during log processing

### DIFF
--- a/lib/forwarding_log_reader.dart
+++ b/lib/forwarding_log_reader.dart
@@ -98,7 +98,7 @@ class ForwardingLogReader extends DeviceLogReader {
     globals.printTrace('Connecting to localhost:$hostPort...');
     Socket? socket = await _socketFactory('localhost', hostPort);
 
-    const Utf8Decoder decoder = Utf8Decoder();
+    const Utf8Decoder decoder = Utf8Decoder(allowMalformed: true);
     final Completer<void> completer = Completer<void>();
 
     socket.listen(


### PR DESCRIPTION
The following program results in a decoding error because the `Utf8Decoder` cannot handle the `¦` character.

```dart
import 'dart:convert';
import 'dart:typed_data';

const log = '''
errno = 2 (No such file or directory), LastError = 2
InternalCanonicalizeRealPath fail: /proc/12431/fd/13/lib/.native_image/PluginCsharpPlugin.ni.exe ¦k 2
''';

void main() {
  const decoder = Utf8Decoder(allowMalformed: false);
  final data = Uint8List.fromList(log.codeUnits);
  print(decoder.convert(data));
}
```