### PR TITLE
Make Dart plugin registrants work on background isolates

### DIFF
--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -19,12 +19,9 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/assemble.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
-import 'package:flutter_tools/src/compile.dart';
-import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/linux/build_linux.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:package_config/package_config.dart';
 
 import 'build_targets/package.dart';
 import 'tizen_build_info.dart';
@@ -41,7 +38,6 @@ TizenBuilder? get tizenBuilder => context.get<TizenBuilder>();
 /// - [BuildIOSFrameworkCommand._produceAppFramework] in `build_ios_framework.dart` (build target)
 /// - [AssembleCommand.runCommand] in `assemble.dart` (performance measurement)
 /// - [buildLinux] in `build_linux.dart` (code size)
-/// - [KernelCompiler.compile] in `compile.dart` (Dart plugin registrant)
 class TizenBuilder {
   TizenBuilder();
 
@@ -69,23 +65,6 @@ class TizenBuilder {
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final String targetPlatform = getNameForTargetPlatform(
         getTargetPlatformForArch(tizenBuildInfo.targetArch));
-
-    // The generated main contains the Dart plugin registrant.
-    final File dartPluginRegistrant = globals.fs.file(targetFile);
-    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-      project.packageConfigFile,
-      logger: globals.logger,
-    );
-    String? dartPluginRegistrantUri;
-    if (dartPluginRegistrant.existsSync()) {
-      final Uri dartPluginRegistrantFileUri = dartPluginRegistrant.uri;
-      dartPluginRegistrantUri =
-          packageConfig.toPackageUri(dartPluginRegistrantFileUri)?.toString() ??
-              dartPluginRegistrantFileUri.toString();
-    }
-    // See the engine's FindAndInvokeDartPluginRegistrant() in `dart_plugin_registrant.cc`.
-    buildInfo.dartDefines
-        .add('flutter.dart_plugin_registrant=$dartPluginRegistrantUri');
 
     final Environment environment = Environment(
       projectDir: project.directory,
@@ -221,21 +200,6 @@ class TizenBuilder {
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
     final String targetPlatform = getNameForTargetPlatform(
         getTargetPlatformForArch(tizenBuildInfo.targetArch));
-
-    final File dartPluginRegistrant = globals.fs.file(targetFile);
-    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-      project.packageConfigFile,
-      logger: globals.logger,
-    );
-    String? dartPluginRegistrantUri;
-    if (dartPluginRegistrant.existsSync()) {
-      final Uri dartPluginRegistrantFileUri = dartPluginRegistrant.uri;
-      dartPluginRegistrantUri =
-          packageConfig.toPackageUri(dartPluginRegistrantFileUri)?.toString() ??
-              dartPluginRegistrantFileUri.toString();
-    }
-    buildInfo.dartDefines
-        .add('flutter.dart_plugin_registrant=$dartPluginRegistrantUri');
 
     final Environment environment = Environment(
       projectDir: project.directory,

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -194,11 +194,13 @@ const String _generatedMainTemplate = '''
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unnecessary_cast
+// ignore_for_file: unused_import
 
 import '{{mainImport}}' as entrypoint;
 {{#plugins}}
 import 'package:{{name}}/{{name}}.dart';
 {{/plugins}}
+import 'package:flutter/src/dart_plugin_registrant.dart';
 
 @pragma('vm:entry-point')
 class _PluginRegistrant {

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -10,8 +10,10 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/language_version.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
@@ -144,6 +146,37 @@ mixin DartPluginRegistry on FlutterCommand {
 
   @override
   String get targetFile => _targetFile ?? super.targetFile;
+
+  /// See: [KernelCompiler.compile] in `compile.dart`
+  @override
+  Future<BuildInfo> getBuildInfo({
+    BuildMode? forcedBuildMode,
+    File? forcedTargetFile,
+  }) async {
+    final BuildInfo buildInfo = await super.getBuildInfo(
+      forcedBuildMode: forcedBuildMode,
+      forcedTargetFile: forcedTargetFile,
+    );
+
+    // The generated main contains the Dart plugin registrant.
+    final File dartPluginRegistrant = globals.fs.file(targetFile);
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+      FlutterProject.current().packageConfigFile,
+      logger: globals.logger,
+    );
+    String? dartPluginRegistrantUri;
+    if (dartPluginRegistrant.existsSync()) {
+      final Uri dartPluginRegistrantFileUri = dartPluginRegistrant.uri;
+      dartPluginRegistrantUri =
+          packageConfig.toPackageUri(dartPluginRegistrantFileUri)?.toString() ??
+              dartPluginRegistrantFileUri.toString();
+    }
+    // See the engine's FindAndInvokeDartPluginRegistrant().
+    buildInfo.dartDefines
+        .add('flutter.dart_plugin_registrant=$dartPluginRegistrantUri');
+
+    return buildInfo;
+  }
 }
 
 /// Finds entry point functions annotated with `@pragma('vm:entry-point')`

--- a/test/commands/build_test.dart
+++ b/test/commands/build_test.dart
@@ -33,6 +33,9 @@ void main() {
     fileSystem = MemoryFileSystem.test();
     fileSystem.file('lib/main.dart').createSync(recursive: true);
     fileSystem.file('pubspec.yaml').createSync(recursive: true);
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"configVersion": 2, "packages": []}');
 
     tizenBuilder = _FakeTizenBuilder();
   });

--- a/test/general/tizen_builder_test.dart
+++ b/test/general/tizen_builder_test.dart
@@ -34,7 +34,6 @@ void main() {
   late BufferLogger logger;
   late Platform platform;
   late FlutterProject project;
-  late List<String> dartDefines;
   late TizenBuildInfo tizenBuildInfo;
 
   setUpAll(() {
@@ -52,13 +51,11 @@ void main() {
     platform = FakePlatform(environment: <String, String>{'HOME': '/'});
     project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
 
-    dartDefines = <String>[];
-    tizenBuildInfo = TizenBuildInfo(
+    tizenBuildInfo = const TizenBuildInfo(
       BuildInfo(
         BuildMode.release,
         null,
         trackWidgetCreation: true,
-        dartDefines: dartDefines,
         treeShakeIcons: false,
         codeSizeDirectory: 'code_size_analysis',
       ),
@@ -136,7 +133,6 @@ void main() {
         logger.statusText,
         contains('Built build/tizen/tpk/package_id-1.0.0.tpk (0.0MB).'),
       );
-      expect(dartDefines, contains('flutter.dart_plugin_registrant=main.dart'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -206,7 +202,6 @@ void main() {
       );
 
       expect(logger.statusText, contains('Built build/tizen/module.'));
-      expect(dartDefines, contains('flutter.dart_plugin_registrant=main.dart'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -75,6 +75,7 @@ dependencies:
     expect(generatedMain, exists);
     expect(generatedMain.readAsStringSync(), contains('''
 import 'package:some_dart_plugin/some_dart_plugin.dart';
+import 'package:flutter/src/dart_plugin_registrant.dart';
 
 @pragma('vm:entry-point')
 class _PluginRegistrant {


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/plugins/issues/123.

Implements https://github.com/flutter/flutter/issues/98591 for Tizen.

Previously, an app that depends on any _Dart plugin_ (a platform package of a federated plugin that has any Dart implementation) had to explicitly call the `register` method of each plugin to use the plugin in a _background isolate_ as follows.

```dart
compute((_) async {
  PathProviderPlugin.register();

  print(await getApplicationDocumentsDirectory());
}, null);
```

Now this platform-specific call is no longer necessary, and instead the app can simply call Flutter's `DartPluginRegistrant.ensureInitialized` to initialize all Dart plugins that it depends on.

```dart
compute((_) async {
  DartPluginRegistrant.ensureInitialized();

  print(await getApplicationDocumentsDirectory());
}, null);
```

For details, see also:
- `FindAndInvokeDartPluginRegistrant` in [runtime/dart_plugin_registrant.cc](https://github.com/flutter/engine/blob/main/runtime/dart_plugin_registrant.cc)
- `dartPluginRegistrantLibrary` in [dart_plugin_registrant.dart](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/dart_plugin_registrant.dart)
- `DartPluginRegistrant` in [dart:ui/natives.dart](https://github.com/flutter/engine/blob/main/lib/ui/natives.dart)

Known issue: This still does not work after a Hot restart.

Note that if the app wants to use _platform channels_ in a background isolate, it should additionally call `BackgroundIsolateBinaryMessenger.ensureInitialized` to initialize the engine's binary messenger as follows.

```dart
compute((RootIsolateToken rootToken) async {
  BackgroundIsolateBinaryMessenger.ensureInitialized(rootToken);
  // DartPluginRegistrant.ensureInitialized(); // called implicitly by the above

  ...
}, RootIsolateToken.instance!);
```