### PR TITLE
Support C# multi app with C# plugin dependency

### DIFF
--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -543,6 +543,16 @@ void _writeTizenPluginRegistrant(
       context,
       project.managedDirectory.childFile('GeneratedPluginRegistrant.cs'),
     );
+    if (project.isMultiApp) {
+      // TODO(swift-kim): Use a single plugin registrant for both projects.
+      renderTemplateToFile(
+        _csharpPluginRegistryTemplate,
+        context,
+        project.serviceAppDirectory
+            .childDirectory('flutter')
+            .childFile('GeneratedPluginRegistrant.cs'),
+      );
+    }
   } else {
     renderTemplateToFile(
       _cppPluginRegistryTemplate,
@@ -574,20 +584,41 @@ void _writeIntermediateDotnetFiles(
   TizenProject project,
   List<TizenPlugin> dotnetPlugins,
 ) {
-  final String projectFileName = project.projectFile!.basename;
   final Map<String, Object> context = <String, Object>{
     'dotnetPlugins': dotnetPlugins.map((TizenPlugin plugin) => plugin.toMap()),
   };
+
+  final String projectFileName = project.projectFile!.basename;
+  final Directory intermediateDirectory =
+      project.hostAppRoot.childDirectory('obj');
   renderTemplateToFile(
     _intermediateDotnetPropsTemplate,
     context,
-    project.intermediateDirectory.childFile('$projectFileName.flutter.props'),
+    intermediateDirectory.childFile('$projectFileName.flutter.props'),
   );
   renderTemplateToFile(
     _intermediateDotnetTargetsTemplate,
     context,
-    project.intermediateDirectory.childFile('$projectFileName.flutter.targets'),
+    intermediateDirectory.childFile('$projectFileName.flutter.targets'),
   );
+
+  if (project.isMultiApp) {
+    final File? serviceProjectFile =
+        findDotnetProjectFile(project.serviceAppDirectory);
+    final String projectFileName = serviceProjectFile!.basename;
+    final Directory intermediateDirectory =
+        project.serviceAppDirectory.childDirectory('obj');
+    renderTemplateToFile(
+      _intermediateDotnetPropsTemplate,
+      context,
+      intermediateDirectory.childFile('$projectFileName.flutter.props'),
+    );
+    renderTemplateToFile(
+      _intermediateDotnetTargetsTemplate,
+      context,
+      intermediateDirectory.childFile('$projectFileName.flutter.targets'),
+    );
+  }
 }
 
 /// Source: [_renderTemplateToFile] in `flutter_plugins.dart`

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -51,9 +51,6 @@ class TizenProject extends FlutterProjectPlatform {
   Directory get ephemeralDirectory =>
       managedDirectory.childDirectory('ephemeral');
 
-  /// The intermediate output directory in the project that is managed by dotnet.
-  Directory get intermediateDirectory => hostAppRoot.childDirectory('obj');
-
   bool get isMultiApp =>
       uiAppDirectory.existsSync() && serviceAppDirectory.existsSync();
 

--- a/templates/multi-app/csharp/service/RunnerService.csproj
+++ b/templates/multi-app/csharp/service/RunnerService.csproj
@@ -9,8 +9,4 @@
     <ProjectReference Include="$(FlutterEmbeddingPath)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ui\flutter\*.cs" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Create `GeneratedPluginRegistrant.cs` and `.flutter.targets` files in both the UI and service directories.

> **Note**
> For already created C# multi app projects, please remove the following lines in your `tizen/service/RunnerService.csproj` file.

```xml
<ItemGroup>
  <Compile Include="..\ui\flutter\*.cs" />
</ItemGroup>
```