### PR TITLE
Fix OverflowException in StandardMessageHelper

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
@@ -68,7 +68,7 @@ namespace Tizen.Flutter.Embedding
             else
             {
                 stream.WriteByte(255);
-                WriteBytes(stream, BitConverter.GetBytes(Convert.ToInt32(size)));
+                WriteBytes(stream, BitConverter.GetBytes(Convert.ToUInt32(size)));
             }
         }
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
@@ -60,7 +60,7 @@ namespace Tizen.Flutter.Embedding
             {
                 stream.WriteByte(Convert.ToByte(size));
             }
-            else if (size <= 0xffff)
+            else if (size <= Int16.MaxValue)
             {
                 stream.WriteByte(254);
                 WriteBytes(stream, BitConverter.GetBytes(Convert.ToInt16(size)));

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
@@ -60,10 +60,10 @@ namespace Tizen.Flutter.Embedding
             {
                 stream.WriteByte(Convert.ToByte(size));
             }
-            else if (size <= Int16.MaxValue)
+            else if (size <= 0xffff)
             {
                 stream.WriteByte(254);
-                WriteBytes(stream, BitConverter.GetBytes(Convert.ToInt16(size)));
+                WriteBytes(stream, BitConverter.GetBytes(Convert.ToUInt16(size)));
             }
             else
             {

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
@@ -56,7 +56,7 @@ namespace Tizen.Flutter.Embedding
             {
                 throw new ArgumentException("value can not be negative.", nameof(size));
             }
-            if (size < 254)
+            if (size < byte.MaxValue)
             {
                 stream.WriteByte(Convert.ToByte(size));
             }

--- a/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Channels/StandardMessageHelper.cs
@@ -56,7 +56,7 @@ namespace Tizen.Flutter.Embedding
             {
                 throw new ArgumentException("value can not be negative.", nameof(size));
             }
-            if (size < byte.MaxValue)
+            if (size < 254)
             {
                 stream.WriteByte(Convert.ToByte(size));
             }


### PR DESCRIPTION
0xffff = 65535
Int16.MaxValue = 32767

So all platform messages, that has size between 32767 and 65532 will raise exception `System.OverflowException: Value was either too large or too small for an Int16`

This PR fix this problem