### PR TITLE
Allow embedding user lib and res in native TPK

### DIFF
--- a/doc/linux-install.md
+++ b/doc/linux-install.md
@@ -4,8 +4,8 @@
 
 - Operating system: Linux (x64)
 - Tools:
-  - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
-  - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux) (3.0 or later)
+  - [Tizen Studio](install-tizen-sdk.md) (5.0 or later)
+  - [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/install/linux) (6.0 or later)
   - `bash` `curl` `file` `git` `make` `mkdir` `rm` `unzip` `which` `xz-utils` `zip`
 
 ## Installing flutter-tizen

--- a/doc/macos-install.md
+++ b/doc/macos-install.md
@@ -8,9 +8,9 @@
      sudo softwareupdate --install-rosetta --agree-to-license
      ```
 - Tools:
-  - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
+  - [Tizen Studio](install-tizen-sdk.md) (5.0 or later)
     - Tizen Emulator is not available on an Apple Silicon Mac as of Tizen Studio 5.0.
-  - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/macos) (3.0 or later)
+  - [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/install/macos) (6.0 or later)
   - `git` (either [standalone](https://git-scm.com/download/mac) or integrated with [Xcode](https://developer.apple.com/xcode))
 
 ## Installing flutter-tizen

--- a/doc/windows-install.md
+++ b/doc/windows-install.md
@@ -4,8 +4,8 @@
 
 - Operating system: Windows 10 or later (x64)
 - Tools:
-  - [Tizen Studio](install-tizen-sdk.md) (4.0 or later)
-  - [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/windows) (3.0 or later)
+  - [Tizen Studio](install-tizen-sdk.md) (5.0 or later)
+  - [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/install/windows) (6.0 or later)
   - [Git for Windows](https://git-scm.com/download/win) 2.x (enable the **Use Git from the Windows Command Prompt** option)
 
 ## Installing flutter-tizen

--- a/lib/tizen_doctor.dart
+++ b/lib/tizen_doctor.dart
@@ -137,7 +137,7 @@ class TizenValidator extends DoctorValidator {
     }
 
     final Version? sdkVersion = Version.parse(_tizenSdk!.sdkVersion);
-    if (sdkVersion != null && sdkVersion < Version(4, 0, 0)) {
+    if (sdkVersion != null && sdkVersion < Version(5, 0, 0)) {
       messages.add(ValidationMessage.error(
         'A newer version of Tizen Studio is required. To update, run:\n'
         '${_tizenSdk!.packageManagerCli.path} update',
@@ -161,7 +161,7 @@ class TizenValidator extends DoctorValidator {
             .stdout
             .trim(),
       );
-      if (dotnetVersion == null || dotnetVersion < Version(3, 0, 0)) {
+      if (dotnetVersion == null || dotnetVersion < Version(6, 0, 0)) {
         messages.add(const ValidationMessage.error(
           'A newer version of the .NET SDK is required.\n'
           'Install the latest release from: https://dotnet.microsoft.com/download',

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -229,6 +229,7 @@ class TizenSdk {
     String workingDirectory, {
     String type = 'tpk',
     String? reference,
+    String? extraDir,
     String? sign,
   }) {
     return _processUtils.run(<String>[
@@ -238,6 +239,7 @@ class TizenSdk {
       type,
       if (sign != null) ...<String>['-s', sign],
       if (reference != null) ...<String>['-r', reference],
+      if (extraDir != null) ...<String>['-e', extraDir],
       '--',
       workingDirectory,
     ]);

--- a/templates/multi-app/cpp/service/.gitignore
+++ b/templates/multi-app/cpp/service/.gitignore
@@ -1,6 +1,4 @@
-lib/*.so
-res/flutter_assets/
-res/icudtl.dat
+flutter/
 .cproject
 .sign
 crash-info/

--- a/templates/multi-app/cpp/ui/.gitignore
+++ b/templates/multi-app/cpp/ui/.gitignore
@@ -1,7 +1,4 @@
 flutter/
-lib/*.so
-res/flutter_assets/
-res/icudtl.dat
 .cproject
 .sign
 crash-info/

--- a/templates/service-app/cpp/.gitignore
+++ b/templates/service-app/cpp/.gitignore
@@ -1,7 +1,4 @@
 flutter/
-lib/*.so
-res/flutter_assets/
-res/icudtl.dat
 .cproject
 .sign
 crash-info/

--- a/templates/ui-app/cpp/.gitignore
+++ b/templates/ui-app/cpp/.gitignore
@@ -1,7 +1,4 @@
 flutter/
-lib/*.so
-res/flutter_assets/
-res/icudtl.dat
 .cproject
 .sign
 crash-info/

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -241,16 +241,19 @@ type = app
       final File outputTpk = outputDir.childFile('package_id-1.0.0.tpk');
       expect(outputTpk, exists);
 
-      final Directory tizenDir = projectDir.childDirectory('tizen');
+      final Directory ephemeralDir =
+          projectDir.childDirectory('tizen/flutter/ephemeral');
       final Directory flutterAssetsDir =
-          tizenDir.childDirectory('res/flutter_assets');
-      final File engineBinary = tizenDir.childFile('lib/libflutter_engine.so');
+          ephemeralDir.childDirectory('res/flutter_assets');
+      final File engineBinary =
+          ephemeralDir.childFile('lib/libflutter_engine.so');
       final File embedder =
-          tizenDir.childFile('lib/libflutter_tizen_common.so');
-      final File icuData = tizenDir.childFile('res/icudtl.dat');
-      final File aotSnapshot = tizenDir.childFile('lib/libapp.so');
-      final File pluginsLib = tizenDir.childFile('lib/libflutter_plugins.so');
-      final File pluginsUserLib = tizenDir.childFile('lib/libshared.so');
+          ephemeralDir.childFile('lib/libflutter_tizen_common.so');
+      final File icuData = ephemeralDir.childFile('res/icudtl.dat');
+      final File aotSnapshot = ephemeralDir.childFile('lib/libapp.so');
+      final File pluginsLib =
+          ephemeralDir.childFile('lib/libflutter_plugins.so');
+      final File pluginsUserLib = ephemeralDir.childFile('lib/libshared.so');
 
       expect(flutterAssetsDir, exists);
       expect(engineBinary, exists);

--- a/test/general/tizen_doctor_test.dart
+++ b/test/general/tizen_doctor_test.dart
@@ -51,7 +51,7 @@ void main() {
 
   testUsingContext('Detects minimum required SDK version', () async {
     final _FakeTizenSdk tizenSdk = _FakeTizenSdk(fileSystem);
-    tizenSdk.sdkVersion = '3.7';
+    tizenSdk.sdkVersion = '4.5';
 
     final TizenValidator tizenValidator = TizenValidator(
       tizenSdk: tizenSdk,
@@ -126,5 +126,5 @@ class _FakeTizenSdk extends TizenSdk {
         );
 
   @override
-  String? sdkVersion = '4.0';
+  String? sdkVersion = '5.0';
 }

--- a/test/general/tizen_sdk_test.dart
+++ b/test/general/tizen_sdk_test.dart
@@ -201,6 +201,8 @@ void main() {
         'test_profile',
         '-r',
         '/path/to/reference/project',
+        '-e',
+        '/path/to/extradir',
         '--',
         projectDir.path,
       ],
@@ -209,6 +211,7 @@ void main() {
     await tizenSdk.package(
       projectDir.path,
       reference: '/path/to/reference/project',
+      extraDir: '/path/to/extradir',
       sign: 'test_profile',
     );
 


### PR DESCRIPTION
Previously, arbitrary lib and res files provided by an app developer (for a C++ project) could not be included in the output TPK because the `tizen/lib` and `tizen/res` directories were exclusively used by the flutter-tizen tool. However, as of Tizen Studio 5.0 (released last year), it is possible to repackage an existing TPK by [appending any lib and res files](https://github.sec.samsung.net/RS-TizenStudio/home/issues/256) to it using the `-e` parameter.

Directory structure after build:

<table>
<tr><th>Before</th><th>Now</th></tr>
<tr>
<td>

```
tizen/
├── Debug
│   └── ...
├── flutter
│   ├── generated_main.dart
│   └── generated_plugin_registrant.h
├── inc
│   └── runner.h
├── lib
│   ├── libflutter_engine.so
│   └── libflutter_tizen_mobile.so
├── project_def.prop
├── res
│   ├── flutter_assets
│   │   └── ...
│   └── icudtl.dat
├── shared
│   └── res
│       └── ic_launcher.png
├── src
│   └── runner.cc
└── tizen-manifest.xml
```

</td>
<td>

```
tizen/
├── Debug
│   └── ...
├── flutter
│   ├── ephemeral
│   │   ├── lib
│   │   │   ├── libflutter_engine.so
│   │   │   └── libflutter_tizen_mobile.so
│   │   └── res
│   │       ├── flutter_assets
│   │       │   └── ...
│   │       └── icudtl.dat
│   ├── generated_main.dart
│   └── generated_plugin_registrant.h
├── inc
│   └── runner.h
├── lib
├── project_def.prop
├── res
├── shared
│   └── res
│       └── ic_launcher.png
├── src
│   └── runner.cc
└── tizen-manifest.xml
```

</td>
</tr>
</table>

Note: For existing C++ app projects, please remove any stale files (such as `libflutter_engine.so` and `flutter_assets`) in `tizen/lib` and `tizen/res`.