### PR TITLE
Use 8.0 embedder in Tizen 8.0 application

### DIFF
--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -39,10 +39,12 @@ Directory getEngineArtifactsDirectory(String arch, BuildMode mode) {
 
 Directory getEmbedderArtifactsDirectory(String? apiVersion, String arch) {
   final Version? version = Version.parse(apiVersion);
-  if (version != null && version >= Version(6, 5, 0)) {
+  if (version == null || version <= Version(6, 0, 0)) {
+    apiVersion = '5.5';
+  } else if (version >= Version(6, 5, 0) && version < Version(8, 0, 0)) {
     apiVersion = '6.5';
   } else {
-    apiVersion = '5.5';
+    apiVersion = '8.0';
   }
   return globals.cache
       .getArtifactDirectory('engine')

--- a/lib/tizen_cache.dart
+++ b/lib/tizen_cache.dart
@@ -360,10 +360,13 @@ class TizenEmbedderArtifacts extends TizenCachedArtifacts {
       <String>['tizen-common', 'tizen-common.zip'],
       <String>['tizen-arm/5.5', 'tizen-5.5-arm.zip'],
       <String>['tizen-arm/6.5', 'tizen-6.5-arm.zip'],
+      <String>['tizen-arm/8.0', 'tizen-8-arm.zip'],
       <String>['tizen-arm64/5.5', 'tizen-5.5-arm64.zip'],
       <String>['tizen-arm64/6.5', 'tizen-6.5-arm64.zip'],
+      <String>['tizen-arm64/8.0', 'tizen-8-arm64.zip'],
       <String>['tizen-x86/5.5', 'tizen-5.5-x86.zip'],
       <String>['tizen-x86/6.5', 'tizen-6.5-x86.zip'],
+      <String>['tizen-x86/8.0', 'tizen-8-x86.zip'],
     ];
   }
 }


### PR DESCRIPTION
In Tizen 8.0, cbhm library has been deprecated.
So we need to use an embedder that does not depend on the cbhm library.

related issue: https://github.com/flutter-tizen/flutter-tizen/issues/538