### PR TITLE
Fix build error when api-version=6.0 and arch=x86

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -269,8 +269,7 @@ class TizenSdk {
         // Note: Starting with Tizen 8.0, the unified "tizen" profile is used.
         profile = 'tizen';
       } else {
-        // Note: The headless profile is not supported.
-        profile = 'iot-headed';
+        profile = arch == 'x86' ? 'mobile' : 'iot-headed';
       }
     } else if (profile == 'tv') {
       // Note: The tv-samsung rootstrap is not publicly available.
@@ -288,8 +287,7 @@ class TizenSdk {
       type = 'device64';
     }
 
-    Rootstrap getTizenRootstrap(
-        String profile, String apiVersion, String type) {
+    Rootstrap findRootstrap(String profile, String apiVersion, String type) {
       final String id = '$profile-$apiVersion-$type.core';
       final Directory rootDir = platformsDirectory
           .childDirectory('tizen-$apiVersion')
@@ -299,19 +297,15 @@ class TizenSdk {
       return Rootstrap(id, rootDir);
     }
 
-    Rootstrap rootstrap = getTizenRootstrap(profile, apiVersion, type);
+    Rootstrap rootstrap = findRootstrap(profile, apiVersion, type);
     if (!rootstrap.isValid && profile == 'tv-samsung') {
       _logger.printTrace('TV SDK could not be found.');
       if (versionToDouble(apiVersion) >= 8.0) {
         profile = 'tizen';
       } else {
-        if (arch == 'x86') {
-          profile = 'mobile';
-        } else {
-          profile = 'iot-headed';
-        }
+        profile = arch == 'x86' ? 'mobile' : 'iot-headed';
       }
-      rootstrap = getTizenRootstrap(profile, apiVersion, type);
+      rootstrap = findRootstrap(profile, apiVersion, type);
     }
 
     if (!rootstrap.isValid) {


### PR DESCRIPTION
The IoT-Headed 6.0 SDK doesn't have a rootstrap for emulator. Use the mobile 6.0 rootstrap instead.

```sh
$ flutter-tizen build tpk --debug --target-arch x86 -p common

target: tizen_cpp_embedding
exception:Error: The rootstrap iot-headed-6.0-emulator.core could not be found.
To install missing package(s), run:
/home/swift/tizen-studio/package-manager/package-manager-cli.bin install IOT-Headed-6.0-NativeAppDevelopment-CLI
#0      throwToolExit (package:flutter_tools/src/base/common.dart:10:3)
#1      TizenSdk.getRootstrap (package:flutter_tizen/tizen_sdk.dart:320:7)
#2      NativeEmbedding.build (package:flutter_tizen/build_targets/embedding.dart:103:43)
#3      _BuildInstance._invokeInternal (package:flutter_tools/src/build_system/build_system.dart:861:27)
<asynchronous suspension>
#4      Future.wait.<anonymous closure> (dart:async/future.dart:518:21)

$ /home/swift/tizen-studio/package-manager/package-manager-cli.bin install IOT-Headed-6.0-NativeAppDevelopment-CLI
Package Manager (0.5.54)

****************************************
******* Start to update packages *******
****************************************
Nothing to update.

****************************************
****** Start to install packages *******
****************************************
Nothing to install.
```