### PR TITLE
Fix TizenDevice.uninstallApp unexpectedly returning false

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -305,7 +305,7 @@ class TizenDevice extends Device {
   }) async {
     final RunResult result =
         await runSdbAsync(<String>['uninstall', app.id], checked: false);
-    if (result.exitCode != 0 || !result.stdout.contains('val[ok]')) {
+    if (result.exitCode != 0) {
       _logger.printError('sdb uninstall failed:\n$result');
       return false;
     }


### PR DESCRIPTION
The TV 8.0 emulator no longer prints `val[ok]` during uninstall.

```sh
00:36 +0: loading /tmp/flutter_tools.YPMDVO/BQGDKV/shared_preferences_test.dart
00:45 +16: (tearDownAll)                                                                                                                                                          
sdb uninstall failed:

uninstall org.tizen.shared_preferences_tizen_example
app_id[org.tizen.shared_preferences_tizen_example] uninstall start
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[11]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[23]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[34]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[46]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[57]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[69]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[80]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[92]
app_id[org.tizen.shared_preferences_tizen_example] uninstalling[100]
app_id[org.tizen.shared_preferences_tizen_example] uninstall completed
spend time for wascmd is [1193]ms
00:45 +16: All tests passed!
```