### PR TITLE
Add prefer_nuget_cache metadata to tizen-manifest.xml

### DIFF
--- a/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -5,7 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -5,6 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
@@ -5,7 +5,7 @@
         <label>{{projectName}}</label>
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
@@ -5,6 +5,7 @@
         <label>{{projectName}}</label>
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
@@ -5,6 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
     </ui-application>
     <privileges>
         <privilege>http://tizen.org/privilege/appmanager.launch</privilege>

--- a/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
@@ -5,7 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
     </ui-application>
     <privileges>
         <privilege>http://tizen.org/privilege/appmanager.launch</privilege>

--- a/templates/service-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/csharp/tizen-manifest.xml.tmpl
@@ -6,6 +6,7 @@
         <icon>ic_launcher.png</icon>
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/service-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/csharp/tizen-manifest.xml.tmpl
@@ -6,7 +6,7 @@
         <icon>ic_launcher.png</icon>
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/ui-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/csharp/tizen-manifest.xml.tmpl
@@ -5,7 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/ui-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/csharp/tizen-manifest.xml.tmpl
@@ -5,6 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true" />
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>


### PR DESCRIPTION
Add metadata to enable caching for Tizen assembly/library cache(TLC, TAC).
It is known that the TAC on TV devices caches Tizen.Flutter.Embedding by default.
In the tizen profile (RPI), so files (TLC) are applied starting with Tizen 10.