### PR TITLE
Add enable_impeller metadata key

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -25,6 +25,14 @@ bool FlutterApp::OnCreate() {
     return false;
   }
 
+  if (renderer_type_ == FlutterRendererType::kEvasGL &&
+      engine_->IsImpellerEnabled()) {
+    TizenLog::Error(
+        "Impeller is not supported by FlutterRendererType::kEvasGL type "
+        "renderer.");
+    return false;
+  }
+
   FlutterDesktopWindowProperties window_prop = {};
   window_prop.x = window_offset_x_;
   window_prop.y = window_offset_y_;

--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -73,15 +73,20 @@ std::vector<std::string> ParseEngineArgs(bool* is_impeller_enabled) {
     }
   }
 
+  auto engine_args_it =
+      std::find(engine_args.begin(), engine_args.end(), "--enable-impeller");
+  if (engine_args_it != engine_args.end()) {
+    *is_impeller_enabled = true;
+  }
+
   std::map<std::string, std::string> metadata = GetMetadata(app_id);
   auto it = metadata.find(kMetadataKeyEnableImepeller);
   if (it != metadata.end()) {
-    auto engine_args_it =
-        std::find(engine_args.begin(), engine_args.end(), "--enable-impeller");
     if (engine_args_it == engine_args.end() && it->second == "true") {
       *is_impeller_enabled = true;
       engine_args.insert(engine_args.begin(), "--enable-impeller");
     } else if (engine_args_it != engine_args.end() && it->second == "false") {
+      *is_impeller_enabled = false;
       engine_args.erase(engine_args_it);
     }
   }

--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -42,7 +42,7 @@ std::map<std::string, std::string> GetMetadata(std::string app_id) {
 }
 
 // Reads engine arguments passed from the flutter-tizen tool.
-std::vector<std::string> ParseEngineArgs() {
+std::vector<std::string> ParseEngineArgs(bool* is_impeller_enabled) {
   std::vector<std::string> engine_args;
   char* id;
   if (app_get_id(&id) != 0) {
@@ -79,6 +79,7 @@ std::vector<std::string> ParseEngineArgs() {
     auto engine_args_it =
         std::find(engine_args.begin(), engine_args.end(), "--enable-impeller");
     if (engine_args_it == engine_args.end() && it->second == "true") {
+      *is_impeller_enabled = true;
       engine_args.insert(engine_args.begin(), "--enable-impeller");
     } else if (engine_args_it != engine_args.end() && it->second == "false") {
       engine_args.erase(engine_args_it);
@@ -126,7 +127,7 @@ FlutterEngine::FlutterEngine(
   engine_prop.icu_data_path = icu_data_path.c_str();
   engine_prop.aot_library_path = aot_library_path.c_str();
 
-  std::vector<std::string> engine_args = ParseEngineArgs();
+  std::vector<std::string> engine_args = ParseEngineArgs(&is_impeller_enabled_);
   std::vector<const char*> switches;
   for (const std::string& arg : engine_args) {
     switches.push_back(arg.c_str());

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -9,6 +9,8 @@
 #include <flutter/plugin_registry.h>
 #include <flutter_tizen.h>
 
+#include <algorithm>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -79,6 +79,9 @@ class FlutterEngine : public flutter::PluginRegistry {
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string& plugin_name) override;
 
+  // Whether the impeller is enabled or not.
+  bool IsImpellerEnabled() { return is_impeller_enabled_; }
+
  private:
   FlutterEngine(const std::string& assets_path,
                 const std::string& icu_data_path,
@@ -91,6 +94,9 @@ class FlutterEngine : public flutter::PluginRegistry {
 
   // Whether or not this wrapper owns |engine_|.
   bool owns_engine_ = true;
+
+  // Whether the impeller is enabled or not.
+  bool is_impeller_enabled_ = false;
 };
 
 #endif /* FLUTTER_TIZEN_EMBEDDING_CPP_INCLUDE_FLUTTER_ENGINE_H_ */

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -152,7 +152,7 @@ namespace Tizen.Flutter.Embedding
 
             if (RendererType == FlutterRendererType.EvasGL && Engine.IsImpellerEnabled)
             {
-                throw new Exception("Impeller is is not supported by FlutterRendererType::kEvasGL type renderer.");
+                throw new Exception("Impeller is not supported by FlutterRendererType::kEvasGL type renderer.");
             }
 
             var windowProperties = new FlutterDesktopWindowProperties

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -150,6 +150,11 @@ namespace Tizen.Flutter.Embedding
                 throw new Exception("External output is not supported by FlutterRendererType::kEGL type renderer.");
             }
 
+            if (RendererType == FlutterRendererType.EvasGL && Engine.IsImpellerEnabled)
+            {
+                throw new Exception("Impeller is is not supported by FlutterRendererType::kEvasGL type renderer.");
+            }
+
             var windowProperties = new FlutterDesktopWindowProperties
             {
                 x = WindowOffsetX,

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -203,6 +203,11 @@ namespace Tizen.Flutter.Embedding
                 }
             }
 
+            if (result.Contains("--enable-impeller"))
+            {
+                IsImpellerEnabled = true;
+            }
+
             if (enableImpellerKeyExist)
             {
                 if (!result.Contains("--enable-impeller") && appInfo.Metadata[MetadataKeyEnableImepeller] == "true")
@@ -212,6 +217,7 @@ namespace Tizen.Flutter.Embedding
                 }
                 else if (result.Contains("--enable-impeller") && appInfo.Metadata[MetadataKeyEnableImepeller] == "false")
                 {
+                    IsImpellerEnabled = false;
                     result.Remove("--enable-impeller");
                 }
             }

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -335,6 +335,7 @@ class NativeTpk extends TizenPackage {
       'appcore-agent',
       'capi-appfw-app-common',
       'capi-appfw-application',
+      'capi-appfw-app-manager',
       'dlog',
       'elementary',
       'evas',


### PR DESCRIPTION
(Currently, impeller is experimental step in flutter-tizen.)
The flutter-tizen tool supports --enable-impeller flag.
However, when running an already installed application with app select,
impeller cannot be applied. So, add a metadata key to turn impeller on and off in tizen-manifest.xml.

```
<metadata key="http://tizen.org/metadata/flutter_tizen/enable_impeller" value="true" />
```