### PR TITLE
[ci] Change ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   dart:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Fetch Flutter SDK
@@ -20,7 +20,7 @@ jobs:
         run: flutter/bin/dart analyze --fatal-infos lib test
 
   csharp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   pub:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository_owner == 'flutter-tizen' }}
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
           done
 
   nuget:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository_owner == 'flutter-tizen' }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Fetch Flutter SDK
@@ -18,7 +18,7 @@ jobs:
       - name: Run tests
         run: flutter/bin/flutter test --coverage
       - name: Report coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt update
           sudo apt install -y lcov
@@ -26,7 +26,7 @@ jobs:
           lcov --list coverage/lcov.info
 
   embedding:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2
@@ -36,7 +36,7 @@ jobs:
         run: dotnet test embedding/csharp
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
           path: flutter-tizen
       - name: Install Tizen Studio
         run: |
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt update
           sudo apt install -y libncurses5 python2.7 libpython2.7 gettext \
             libkf5itemmodels5 libkf5kiowidgets5 libkchart2
           curl https://download.tizen.org/sdk/Installer/tizen-studio_5.6/web-cli_Tizen_Studio_5.6_ubuntu-64.bin -o install.bin


### PR DESCRIPTION
Tizen studio requires python 2.7 and libncurses5.
However, Ubuntu 24.04's apt no longer supports these packages.
I considered options like deadsnake(24.04), but python 2.7 is no longer supported.
Rather than installing this manually, I decided that tizen studio is not ready for 24.04 yet,
so I fixed the version of ubuntu runnner to 22.04.