### PR TITLE
Optimize flutter tizen app build time

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -173,14 +173,8 @@ class DotnetTpk extends TizenPackage {
         'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',
       );
     }
-    final RunResult result = await _processUtils.run(<String>[
-      dotnetCli!.path,
-      'build',
-      '-c',
-      buildConfig,
-      '/p:DefineConstants=${profile.toUpperCase()}_PROFILE',
-      tizenProject.hostAppRoot.path,
-    ]);
+    final RunResult result = await tizenSdk!
+        .buildDotnet(tizenProject.hostAppRoot.path, configuration: buildConfig);
     if (result.exitCode != 0) {
       throwToolExit('Failed to build .NET application:\n$result');
     }
@@ -209,14 +203,6 @@ class DotnetTpk extends TizenPackage {
       );
       if (result.exitCode != 0) {
         throwToolExit('Failed to create a TPK:\n$result');
-      }
-    } else {
-      // build-task-tizen signs the output TPK with a dummy profile by default.
-      // We need to regenerate the TPK by signing it with a valid profile.
-      final RunResult result =
-          await tizenSdk!.package(outputTpk.path, sign: securityProfile);
-      if (result.exitCode != 0) {
-        throwToolExit('Failed to sign the TPK:\n$result');
       }
     }
 

--- a/lib/tizen_cache.dart
+++ b/lib/tizen_cache.dart
@@ -14,6 +14,8 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/flutter_cache.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:process/process.dart';
@@ -45,20 +47,29 @@ class TizenDevelopmentArtifact implements DevelopmentArtifact {
   static const DevelopmentArtifact tizen = TizenDevelopmentArtifact('tizen');
 }
 
-class TizenCache extends FlutterCache {
+class TizenCache extends Cache {
   TizenCache({
     required Logger logger,
     required FileSystem fileSystem,
     required Platform platform,
     required OperatingSystemUtils osUtils,
     required ProcessManager processManager,
-    required super.projectFactory,
+    required FlutterProjectFactory projectFactory,
   }) : super(
-          logger: logger,
-          fileSystem: fileSystem,
-          platform: platform,
-          osUtils: osUtils,
-        ) {
+            logger: logger,
+            platform: platform,
+            fileSystem: fileSystem,
+            osUtils: osUtils,
+            artifacts: <ArtifactSet>[]) {
+    registerArtifact(FontSubsetArtifacts(this, platform: platform));
+    registerArtifact(PubDependencies(
+      logger: logger,
+      // flutter root and pub must be lazily initialized to avoid accessing
+      // before the version is determined.
+      flutterRoot: () => Cache.flutterRoot!,
+      pub: () => pub,
+      projectFactory: projectFactory,
+    ));
     registerArtifact(TizenEngineArtifacts(
       cache: this,
       logger: logger,

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -107,6 +107,10 @@ class TizenSdk {
       .childDirectory('bin')
       .childFile(_platform.isWindows ? 'tizen.bat' : 'tizen');
 
+  File get tzCore => toolsDirectory
+      .childDirectory('tizen-core')
+      .childFile(_platform.isWindows ? 'tz.exe' : 'tz');
+
   File get emCli => toolsDirectory
       .childDirectory('emulator')
       .childDirectory('bin')
@@ -222,6 +226,31 @@ class TizenSdk {
         'USER_CPP_OPTS': '-std=c++17',
         ...environment,
       },
+    );
+  }
+
+  Future<RunResult> buildDotnet(
+    String workingDirectory, {
+    String? configuration,
+    String? sign,
+  }) {
+    _processUtils.run(
+      <String>[
+        tzCore.path,
+        'set',
+        if (configuration != null) ...<String>['-b', configuration],
+        '-w',
+        workingDirectory,
+      ],
+    );
+
+    return _processUtils.run(
+      <String>[
+        tzCore.path,
+        'build',
+        '-w',
+        workingDirectory,
+      ],
     );
   }
 


### PR DESCRIPTION
This PR includes the following changes to reduce the build time for flutter tizen apps.

### Removed unnecessary artifact registration for Tizen app builds
Changed `TizenCache` to inherit from `Cache` instead of `FlutterCache`.

The test results on Ubuntu  are as follows.
<details>
<summary> Before </summary>

```sh
rookiejava@paris:~/workspace/temp/hello_f2/tizen$ flutter-tizen build tpk --verbose
[  +81 ms] executing: uname -m
[  +27 ms] Exit code 0 from: uname -m
[        ] x86_64
[ +464 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
[   +1 ms] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +14 ms] Artifact Instance of 'TizenEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'TizenEmbedderArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MaterialFonts' is not required, skipping update.
[        ] Artifact Instance of 'GradleWrapper' is not required, skipping update.
[        ] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
[        ] Artifact Instance of 'FlutterSdk' is not required, skipping update.
[        ] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FontSubsetArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'PubDependencies' is not required, skipping update.
[  +13 ms] Skipping pub get: version match.
[ +216 ms] Generating /home/rookiejava/workspace/temp/hello_f2/tizen/.android/Flutter/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
[  +36 ms] Building a Tizen application in release mode...
```
</details>

<details>
<summary> After </summary>
rookiejava@paris:~/workspace/temp/hello_f2/tizen$ flutter-tizen build tpk --verbose
[  +85 ms] executing: uname -m
[  +26 ms] Exit code 0 from: uname -m
[        ] x86_64
[ +503 ms] Artifact Instance of 'TizenEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'TizenEmbedderArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FontSubsetArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'PubDependencies' is not required, skipping update.
[  +11 ms] Skipping pub get: version match.
[ +227 ms] Generating /home/rookiejava/workspace/temp/hello_f2/tizen/.android/Flutter/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
[  +36 ms] !!! Building a Tizen application in release mode...
</details>

### Optimized the app packaging and signing process
This process is the most time-consuming part of app builds. The existing packaging and signing process involved using the `dotnet build` command to package the app with a default certificate, followed by a second packaging step using the `tizen package` command for signing. This PR introduces a new approach that leverages the [tizen-core CLI](https://docs.tizen.org/application/tizen-studio/tizen-core/tizen-core-cli/)(`tz`) command, which was added in [Tizen Studio 4.6](https://docs.tizen.org/application/tizen-studio/release-notes/4-6-release-notes/), to perform both packaging and signing in a single step.

> ℹ️  Note that this patch requires Tizen Studio 4.6 or later to be installed in the user's environment.

The test results on Ubuntu  are as follows.

<details>
<summary> Before </summary>

```sh
[  +23 ms] The test profile is used for signing.
[  +15 ms] executing: /usr/bin/dotnet build -c Release /p:DefineConstants=TV_PROFILE /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen
[+2979 ms]   복원할 프로젝트를 확인하는 중...
                      복원할 모든 프로젝트가 최신 상태입니다.
                      Tizen.Flutter.Embedding -> /home/rookiejava/workspace/github/flutter-tizen/embedding/csharp/Tizen.Flutter.Embedding/bin/Release/tizen90/Tizen.Flutter.Embedding.dll
                      Runner -> /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/Runner.dll
                      Configuration :
                      Platform :
                      TargetFramework :
                      TizenTpkFiles : shared/res/ic_launcher.png
                      TizenTpkFiles : tizen-manifest.xml
                      TizenTpkFiles : flutter/ephemeral/lib/libapp.so
                      TizenTpkFiles : flutter/ephemeral/lib/libflutter_engine.so
                      TizenTpkFiles : flutter/ephemeral/lib/libflutter_tizen.so
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/AssetManifest.bin
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/AssetManifest.json
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/FontManifest.json
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/fonts/MaterialIcons-Regular.otf
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/NOTICES.Z
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/shaders/ink_sparkle.frag
                      TizenTpkFiles : flutter/ephemeral/res/icudtl.dat
                      Runner is signed with Default Certificates!
                      Runner -> /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/com.example.tizen-1.0.0.tpk

                    빌드했습니다.
                        경고 0개
                        오류 0개

                    경과 시간: 00:00:02.34
[   +2 ms] executing: /home/rookiejava/tizen-studio/tools/ide/bin/tizen package -t tpk -s test --
/home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/com.example.tizen-1.0.0.tpk
[+2541 ms] Author certficate: /home/rookiejava/tizen-studio-data/keystore/author/test.p12
                    Distributor1 certificate : /home/rookiejava/tizen-studio/tools/certificate-generator/certificates/distributor/tizen-distributor-signer-new.p12
                    Package( /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/com.example.tizen-1.0.0.tpk ) is created successfully.
[  +23 ms] tizen_dotnet_tpk: Complete
```
</details>

<details>
<summary> After </summary>

```sh
[  +26 ms] The test profile is used for signing.
[   +9 ms] executing: /home/rookiejava/tizen-studio/tools/tizen-core/tz set -b Release -w /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen
[   +1 ms] executing: /home/rookiejava/tizen-studio/tools/tizen-core/tz build -w /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen
[+3085 ms] Signing using certificates:
                        Author cert : /home/rookiejava/tizen-studio-data/keystore/author/test.p12
                        Distributor cert : /home/rookiejava/tizen-studio/tools/certificate-generator/certificates/distributor/tizen-distributor-signer-new.p12
                        Distributor2 cert :
                      복원할 프로젝트를 확인하는 중...
                      복원할 모든 프로젝트가 최신 상태입니다.
                      Tizen.Flutter.Embedding -> /home/rookiejava/workspace/github/flutter-tizen/embedding/csharp/Tizen.Flutter.Embedding/bin/Release/tizen90/Tizen.Flutter.Embedding.dll
                      Runner -> /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/Runner.dll
                      Configuration :
                      Platform :
                      TargetFramework :
                      TizenTpkFiles : shared/res/ic_launcher.png
                      TizenTpkFiles : tizen-manifest.xml
                      TizenTpkFiles : flutter/ephemeral/lib/libapp.so
                      TizenTpkFiles : flutter/ephemeral/lib/libflutter_engine.so
                      TizenTpkFiles : flutter/ephemeral/lib/libflutter_tizen.so
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/AssetManifest.bin
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/AssetManifest.json
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/FontManifest.json
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/fonts/MaterialIcons-Regular.otf
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/NOTICES.Z
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf
                      TizenTpkFiles : flutter/ephemeral/res/flutter_assets/shaders/ink_sparkle.frag
                      TizenTpkFiles : flutter/ephemeral/res/icudtl.dat
                      Runner -> /home/rookiejava/workspace/temp/hello_f2/tizen/.tizen/bin/Release/tizen90/com.example.tizen-1.0.0.tpk

                    빌드했습니다.
                        경고 0개
                        오류 0개

                    경과 시간: 00:00:02.62
[  +23 ms] tizen_dotnet_tpk: Complete
```
</details>

### Summary
Flutter tizen **app build time was improved by approximately 38%** when this change was applied.

| Enviroment | Before | After | Gap |
| ---         | ---      |  --- | ---|
| Windows 10  |   13.16s   | 8.06s    | **-5.1s (39%↓)** |
| Ubuntu 22.04  | 5.9s  | 3.72s      | **-3.72s (37%↓)** |