### PR TITLE
Optimize the `flutter-tizen run` execution time

### DIFF
--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -75,9 +75,6 @@ void main() {
       FakeCommand(
         command: _sdbCommand(<String>['shell', 'app_launcher', '-l']),
       ),
-      FakeCommand(
-        command: _sdbCommand(<String>['shell', 'app_launcher', '-l']),
-      ),
       FakeCommand(command: _sdbCommand(<String>['install', 'app.tpk'])),
       FakeCommand(
         command: _sdbCommand(<String>[
@@ -182,7 +179,7 @@ User's Application
       FakeCommand(
         command: _sdbCommand(<String>[
           'pull',
-          '/opt/usr/apps/TestPackage/author-signature.xml',
+          '/opt/usr/home/owner/apps_rw/TestPackage/author-signature.xml',
           '/.tmp_rand0/rand0/author-signature.xml',
         ]),
         onRun: (_) {


### PR DESCRIPTION
This PR includes the following changes to reduce the `flutter-tizen run` execution time.
The main idea of the PR is to minimize unnecessary calls to `sdb` commands, which are relatively time-consuming, in order to reduce the overall execution time. 
> When measured on Windows, each execution of `sdb` command takes approximately 800~900ms.

### Use `getCapability('architecture')` instead of `sdb ls`
Currently, the target architecture is determined by checking the existence of a specific path (`/usr/lib64`) as below. 
```sh
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell ls /usr/lib64
[ +909 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell ls /usr/lib64
[        ] ls: cannot access /usr/lib64: No such file or directory
```
This has been modified to utilize the already obtained capability information (`architecture`). The `architecture` is available from Tizen 6.5 and can have a value of either 32 or 64.

### Use `$[HOME}/apps_rw` to obtain the app installation path
In the existing implementatio, the app's installation path is determined by iterating through `/opt/usr/apps` and`/opt/usr/globalapps` to check for the presence of the `author-signature.xml`, which may lead to unnecessary iterations.
```sh
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/apps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\51a86d45\author-signature.xml
[ +976 ms] error: failed to get status of '/opt/usr/apps/com.example.crossapp/author-signature.xml': unknown reason
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/globalapps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\698ced0a\author-signature.xml
pulled           author-signature.xml   100%       8235 B           0KB/s
                    1 file(s) pulled. 0 file(s) skipped.
                    /opt/usr/globalapps/com.example.crossapp/author-signature.xml   154KB/s (8235 bytes in 0.052s)
[   +2 ms] Latest build already installed.
```
By using `/opt/usr/home/owner/apps_rw`, the installation path can be accessed more efficiently. Below is a mapping of the `author-signature.xml` files on TV and RPI4.
- TV
  ```sh
  root@localhost:~# ls -al /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml
  lrwxrwxrwx 1 app_fw app_fw 55 Mar 24 10:17 /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml -> /opt/usr/apps/com.example.crossapp/author-signature.xml
  ```
- RPI4
  ```sh
  root:~> ls -al /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml
  lrwxrwxrwx 1 app_fw app_fw 61 Jan 10 10:18 /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml -> /opt/usr/globalapps/com.example.crossapp/author-signature.xml
  ```

### Optimize the App installaction process
Previously, the app installation process was performed in the following steps:
1. Check if the app is installed (`isAppInstalled()` - `sdb shell app_launcher -l`)
2. If the app is installed, stop the running app (`stopApp()` - `sdb shell app_launcher -k`)
3. Check again if the app is installed (`isAppInstalled()` - `sdb shell app_launcher -l`)
4. If the app is already installed, verify whether it matches the latest build (`isLatestBuildInstalled()` - `sdb pull author-signature.xml`)
5. Installed app

```sh
[   +3 ms] ✓ Built build\tizen\tpk\com.example.crossapp-1.0.0.tpk (6.8MB)
[ +112 ms] Stopping app 'com.example.crossapp-1.0.0.tpk' on Tizen rpi4.
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +953 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                         ...
                        =================================================
[   +5 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[+1074 ms] result: App isn't running
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +992 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                         ...
                        =================================================
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/apps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\51a86d45\author-signature.xml
[ +976 ms] error: failed to get status of '/opt/usr/apps/com.example.crossapp/author-signature.xml': unknown reason
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/globalapps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\698ced0a\author-signature.xml
pulled           author-signature.xml   100%       8235 B           0KB/s
                    1 file(s) pulled. 0 file(s) skipped.
                    /opt/usr/globalapps/com.example.crossapp/author-signature.xml   154KB/s (8235 bytes in 0.052s)
[   +2 ms] Latest build already installed.
```

By default, in the Tizen app installation process, if ther same app is already installed and running, it will be stopped before installation. Therefore, there is no need to check whether the app is installed and stop it before every installation. Stopping the app is only necessary when the latest build of the app is already installed (i.e., no need to re-install).
```sh
[   +3 ms] ✓ Built build\tizen\tpk\com.example.crossapp-1.0.0.tpk (6.8MB)
[ +103 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +898 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                        ...
                        =================================================
[  +14 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.4dce0edf\35ba6cdc\author-signature.xml
pulled           author-signature.xml   100%       8235 B           0KB/s
                    1 file(s) pulled. 0 file(s) skipped.
                    /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml   167KB/s (8235 bytes in 0.048s)
[   +2 ms] Latest build already installed.
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
```

### Summary
**`flutter-tizen run` execution time was improved by approximately 9%** when this change was applied.

| Enviroment | Before | After | Gap |
| ---         | ---      |  --- | ---|
| Windows 10  |   27.3s   | 25s    | **2.4s (9%↓)** |

The full logs before and after the change are as follows.
<details>
<summary> Before </summary>

```sh
C:\workspace\temp\crossapp> flutter-tizen run --release --verbose
[+1575 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[   +4 ms] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
[   +2 ms] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +26 ms] Artifact Instance of 'TizenEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'TizenEmbedderArtifacts' is not required, skipping update.
[   +3 ms] executing: C:\Users\kangho.hur\AppData\Local\Android\sdk\platform-tools\adb.exe devices -l
[  +10 ms] executing: C:\tizen-studio\tools\sdb.exe devices
[ +794 ms] List of devices attached
[ +635 ms] List of devices attached
                    10000000f2770a98            device          rpi4
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 capability
[ +897 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 capability
[        ] secure_protocol:disabled
           intershell_support:enabled
           filesync_support:pushpull
           usbproto_support:enabled
           sockproto_support:enabled
           syncwinsz_support:enabled
           sdbd_rootperm:disabled
           rootonoff_support:enabled
           encryption_support:disabled
           zone_support:disabled
           multiuser_support:enabled
           cpu_arch:armv7l
           core_abi:arm_32
           sdk_toolpath:/home/owner/share/tmp/sdk_tools
           profile_name:common
           vendor_name:Tizen
           can_launch:unknown
           device_name:Tizen
           platform_version:9.0
           product_version:unknown
           sdbd_version:2.2.31
           sdbd_plugin_version:unknown
           sdbd_cap_version:1.0
           log_enable:disabled
           log_path:/home/owner/share/sdbdlog
           appcmd_support:enabled
           appid2pid_support:enabled
           pkgcmd_debugmode:enabled
           netcoredbg_support:enabled
           architecture:32
[   +4 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[   +8 ms] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +65 ms] Skipping pub get: version match.
[ +246 ms] Generating C:\workspace\temp\crossapp\android\app\src\main\java\io\flutter\plugins\GeneratedPluginRegistrant.java
[ +191 ms] Launching tizen\flutter\generated_main.dart on Tizen rpi4 in release mode...
[  +10 ms] Building TPK
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell ls /usr/lib64
[ +909 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell ls /usr/lib64
[        ] ls: cannot access /usr/lib64: No such file or directory
[   +5 ms] Building a Tizen application in release mode...
[   +1 ms] Initializing file store
[   +9 ms] Done initializing file store
[  +69 ms] Skipping target: gen_localizations
[  +10 ms] Skipping target: gen_dart_plugin_registrant
[  +37 ms] Skipping target: tizen_cpp_embedding
[ +502 ms] Skipping target: kernel_snapshot_program
[   +2 ms] tizen_native_plugins: Starting due to {}
[   +7 ms] Skipping target: native_assets
[   +3 ms] Skipping target: kernel_snapshot_native_assets
[        ] Skipping target: kernel_snapshot
[  +97 ms] Skipping target: tizen_aot_elf
[  +29 ms] tizen_native_plugins: Complete
[  +36 ms] Skipping target: release_tizen_application
[        ] tizen_dotnet_tpk: Starting due to {}
[  +77 ms] The test profile is used for signing.
[+1945 ms] executing: C:\Program Files\dotnet\dotnet.exe build -c Release /p:DefineConstants=COMMON_PROFILE C:\workspace\temp\crossapp\tizen
[+3848 ms]   蹂듭썝???꾨줈?앺듃瑜??뺤씤?섎뒗 以?..
                      蹂듭썝??紐⑤뱺 ?꾨줈?앺듃媛 理쒖떊 ?곹깭?낅땲??
                      Tizen.Flutter.Embedding -> C:\workspace\github\flutter-tizen\embedding\csharp\Tizen.Flutter.Embedding\bin\Release\tizen80\Tizen.Flutter.Embedding.dll
                      Runner -> C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\Runner.dll
                      Configuration :
                      Platform :
                      TargetFramework :
                      TizenTpkFiles : shared\res\ic_launcher.png
                      TizenTpkFiles : tizen-manifest.xml
                      TizenTpkFiles : flutter\ephemeral\lib\libapp.so
                      TizenTpkFiles : flutter\ephemeral\lib\libflutter_engine.so
                      TizenTpkFiles : flutter\ephemeral\lib\libflutter_tizen.so
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\AssetManifest.bin
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\AssetManifest.json
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\FontManifest.json
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\fonts\MaterialIcons-Regular.otf
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\NOTICES.Z
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\shaders\ink_sparkle.frag
                      TizenTpkFiles : flutter\ephemeral\res\icudtl.dat
                      Runner is signed with Default Certificates!
                      Runner -> C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk

                    鍮뚮뱶?덉뒿?덈떎.
                        寃쎄퀬 0媛?
                        ?ㅻ쪟 0媛?

                    寃쎄낵 ?쒓컙: 00:00:02.22

                    ?뚰겕濡쒕뱶 ?낅뜲?댄듃瑜??ъ슜?????덉뒿?덈떎. ?먯꽭???댁슜??蹂대젮硫?`dotnet workload list`???ㅽ뻾?섏꽭??
[   +2 ms] executing: C:\tizen-studio\tools\ide\bin\tizen.bat package -t tpk -s test -- C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk
[+7942 ms] Author certficate: C:/tizen-studio-data/keystore/author/test.p12
                    Distributor1 certificate : C:\tizen-studio\tools\certificate-generator\certificates\distributor\sdk-platform\tizen-distributor-signer-new.p12
                    Package( C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk ) is created successfully.
[  +53 ms] tizen_dotnet_tpk: Complete
[   +1 ms] Persisting file store
[   +8 ms] Done persisting file store
[  +11 ms] Building a Tizen application in release mode... (completed in 14.7s)
[   +3 ms] ✓ Built build\tizen\tpk\com.example.crossapp-1.0.0.tpk (6.8MB)
[ +112 ms] Stopping app 'com.example.crossapp-1.0.0.tpk' on Tizen rpi4.
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +953 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                        'Vietnamese keyboard'    'org.tizen.ise-engine-unikey'
                        'MusicPlayer'    'org.tizen.MusicPlayer'
                        'CLM english keyboard'   'org.tizen.ise-engine-glm.english'
                        'Wi-Fi'  'wifi-efl-ug'
                        'Thai Keyboard Engine'   'org.tizen.ise-engine-thai'
                        'CLM korean keyboard'    'org.tizen.ise-engine-glm.korean'
                        'CanJie 3 keyboard'      'org.tizen.ise-engine-tables.cangjie3'
                        'Notifications'  'org.tizen.notifications'
                        'TaskBar'        'org.tizen.taskbar'
                        'Bluetooth'      'ug-bluetooth-efl'
                        'screen-reader'  'org.tizen.screen-reader'
                        'Tizen Web Service Launcher'     'org.tizen.chromium-efl.wrt-service-launcher'
                        'Gallery'        'attach-panel-gallery'
                        'SettingCertificates'    'org.tizen.cssetting-certificates'
                        'IME Selector'   'org.tizen.inputmethod-setting-selector'
                        'ScreenMirroringSink'    'org.tizen.ScreenMirroringSink'
                        'Settings'       'org.tizen.cssettings'
                        'Network popup'  'org.tizen.net-popup'
                        'org.tizen.stt-engine-embedded'  'org.tizen.stt-engine-embedded'
                        'service'        'org.tizen.nlp.service'
                        'Bluetooth'      'ug-bluetooth-efl-single'
                        'Application Selection Popup'    'org.tizen.app-selector'
                        'Accounts'       'setting-myaccount-efl'
                        'Wi-Fi Direct System Popup'      'org.tizen.wifi-direct-popup'
                        'Chinese stoke keyboard'         'org.tizen.ise-engine-glm.chinese-stoke'
                        'Hangul keyboard'        'org.tizen.ise-engine-hangul'
                        'hello_f2'       'com.example.hello_f2'
                        'Japanese keyboard'      'org.tizen.ise-engine-anthy'
                        'DefaultDarkTheme'       'org.tizen.default-dark-theme'
                        'crossapp'       'com.example.crossapp'
                        'Wi-Fi Direct Setting'   'ug-setting-wifidirect-efl'
                        'Voice control panel'    'org.tizen.voice-control-panel'
                        'autofill daemon'        'org.tizen.autofilld'
                        'Document'       'attach-panel-document'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp_2'
                        'Oobe'   'org.tizen.oobe'
                        'Tizen keyboard'         'ise-default'
                        'SettingKeyboard'        'org.tizen.cssetting-keyboard'
                        'System popup'   'org.tizen.system-syspopup'
                        'Tizen keyboard setting'         'org.tizen.ise-default-setting'
                        'VolumeApp'      'org.tizen.volume-nui'
                        'Tizen Web Engine based on Chromium'     'org.tizen.chromium-efl'
                        'screen-reader-ui'       'org.tizen.screen-reader-ui'
                        'service'        'wakeup-engine-default'
                        'NUIGadgetViewer'        'org.tizen.NUIGadgetViewer'
                        'org.tizen.stt-engine-default'   'org.tizen.stt-engine-default'
                        'aurum bootstrap daemon'         'org.tizen.aurum-bootstrap'
                        'TizenDotNet1'   'org.tizen.example.TizenDotNet1'
                        'VoiceRecorderUG'        'attach-panel-voicerecorder'
                        'Power key system popup'         'org.tizen.powerkey-syspopup'
                        'Voice setting'  'org.tizen.voice-setting'
                        'CameraUG'       'attach-panel-camera'
                        'share-panel'    'org.tizen.share-panel'
                        'Bluetooth System Popup'         'org.tizen.bt-syspopup'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp'
                        'hello_flutter'  'com.example.hello_flutter'
                        'Autofill Setting'       'org.tizen.autofill-setting-mobile'
                        'Multi Assistant Service'        'org.tizen.multi-assistant-service'
                        'mmi-manager'    'mmi-manager'
                        'isf-kbd-mode-changer'   'org.tizen.isf-kbd-mode-changer'
                        'Chinese pinyin keyboard'        'org.tizen.ise-engine-glm.chinese-pinyin'
                        'IME List'       'org.tizen.inputmethod-setting-list'
                        'tts-engine-default'     'org.tizen.tts-engine-default'
                        ''       'org.tizen.secure-erase'
                        'DefaultLightTheme'      'org.tizen.default-light-theme'
                        'nui_layout_test'        'org.tizen.example.nui_layout_test'
                        'Voice Control Elm unittests'    'org.tizen.vc-elm-unittests'
                        'Apps'   'org.tizen.Apps'
                        'HomeScreen'     'org.tizen.homescreen-nui'
                        'fido-syspopup'  'org.tizen.fido-syspopup'
                        'org.tizen.vc-engine-default'    'org.tizen.vc-engine-default'
                        'System signal sender'   'org.tizen.system-signal-sender'
                        'HereMaps UC'    'org.tizen.heremaps-uc'
                        'askuser popup'  'org.tizen.askuser-popup'
                        'Tizen NUI keyboard'     'org.tizen.ISEDefaultNUI'
                        'ZhuYin Big keyboard'    'org.tizen.ise-engine-tables.zhuyin-big'
                        'Default keyboard'       'org.tizen.ise-engine-default'
                        =================================================
[   +5 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[+1074 ms] result: App isn't running
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +992 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                        'Vietnamese keyboard'    'org.tizen.ise-engine-unikey'
                        'MusicPlayer'    'org.tizen.MusicPlayer'
                        'CLM english keyboard'   'org.tizen.ise-engine-glm.english'
                        'Wi-Fi'  'wifi-efl-ug'
                        'Thai Keyboard Engine'   'org.tizen.ise-engine-thai'
                        'CLM korean keyboard'    'org.tizen.ise-engine-glm.korean'
                        'CanJie 3 keyboard'      'org.tizen.ise-engine-tables.cangjie3'
                        'Notifications'  'org.tizen.notifications'
                        'TaskBar'        'org.tizen.taskbar'
                        'Bluetooth'      'ug-bluetooth-efl'
                        'screen-reader'  'org.tizen.screen-reader'
                        'Tizen Web Service Launcher'     'org.tizen.chromium-efl.wrt-service-launcher'
                        'Gallery'        'attach-panel-gallery'
                        'SettingCertificates'    'org.tizen.cssetting-certificates'
                        'IME Selector'   'org.tizen.inputmethod-setting-selector'
                        'ScreenMirroringSink'    'org.tizen.ScreenMirroringSink'
                        'Settings'       'org.tizen.cssettings'
                        'Network popup'  'org.tizen.net-popup'
                        'org.tizen.stt-engine-embedded'  'org.tizen.stt-engine-embedded'
                        'service'        'org.tizen.nlp.service'
                        'Bluetooth'      'ug-bluetooth-efl-single'
                        'Application Selection Popup'    'org.tizen.app-selector'
                        'Accounts'       'setting-myaccount-efl'
                        'Wi-Fi Direct System Popup'      'org.tizen.wifi-direct-popup'
                        'Chinese stoke keyboard'         'org.tizen.ise-engine-glm.chinese-stoke'
                        'Hangul keyboard'        'org.tizen.ise-engine-hangul'
                        'hello_f2'       'com.example.hello_f2'
                        'Japanese keyboard'      'org.tizen.ise-engine-anthy'
                        'DefaultDarkTheme'       'org.tizen.default-dark-theme'
                        'crossapp'       'com.example.crossapp'
                        'Wi-Fi Direct Setting'   'ug-setting-wifidirect-efl'
                        'Voice control panel'    'org.tizen.voice-control-panel'
                        'autofill daemon'        'org.tizen.autofilld'
                        'Document'       'attach-panel-document'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp_2'
                        'Oobe'   'org.tizen.oobe'
                        'Tizen keyboard'         'ise-default'
                        'SettingKeyboard'        'org.tizen.cssetting-keyboard'
                        'System popup'   'org.tizen.system-syspopup'
                        'Tizen keyboard setting'         'org.tizen.ise-default-setting'
                        'VolumeApp'      'org.tizen.volume-nui'
                        'Tizen Web Engine based on Chromium'     'org.tizen.chromium-efl'
                        'screen-reader-ui'       'org.tizen.screen-reader-ui'
                        'service'        'wakeup-engine-default'
                        'NUIGadgetViewer'        'org.tizen.NUIGadgetViewer'
                        'org.tizen.stt-engine-default'   'org.tizen.stt-engine-default'
                        'aurum bootstrap daemon'         'org.tizen.aurum-bootstrap'
                        'TizenDotNet1'   'org.tizen.example.TizenDotNet1'
                        'VoiceRecorderUG'        'attach-panel-voicerecorder'
                        'Power key system popup'         'org.tizen.powerkey-syspopup'
                        'Voice setting'  'org.tizen.voice-setting'
                        'CameraUG'       'attach-panel-camera'
                        'share-panel'    'org.tizen.share-panel'
                        'Bluetooth System Popup'         'org.tizen.bt-syspopup'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp'
                        'hello_flutter'  'com.example.hello_flutter'
                        'Autofill Setting'       'org.tizen.autofill-setting-mobile'
                        'Multi Assistant Service'        'org.tizen.multi-assistant-service'
                        'mmi-manager'    'mmi-manager'
                        'isf-kbd-mode-changer'   'org.tizen.isf-kbd-mode-changer'
                        'Chinese pinyin keyboard'        'org.tizen.ise-engine-glm.chinese-pinyin'
                        'IME List'       'org.tizen.inputmethod-setting-list'
                        'tts-engine-default'     'org.tizen.tts-engine-default'
                        ''       'org.tizen.secure-erase'
                        'DefaultLightTheme'      'org.tizen.default-light-theme'
                        'nui_layout_test'        'org.tizen.example.nui_layout_test'
                        'Voice Control Elm unittests'    'org.tizen.vc-elm-unittests'
                        'Apps'   'org.tizen.Apps'
                        'HomeScreen'     'org.tizen.homescreen-nui'
                        'fido-syspopup'  'org.tizen.fido-syspopup'
                        'org.tizen.vc-engine-default'    'org.tizen.vc-engine-default'
                        'System signal sender'   'org.tizen.system-signal-sender'
                        'HereMaps UC'    'org.tizen.heremaps-uc'
                        'askuser popup'  'org.tizen.askuser-popup'
                        'Tizen NUI keyboard'     'org.tizen.ISEDefaultNUI'
                        'ZhuYin Big keyboard'    'org.tizen.ise-engine-tables.zhuyin-big'
                        'Default keyboard'       'org.tizen.ise-engine-default'
                        =================================================
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/apps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\51a86d45\author-signature.xml
[ +976 ms] error: failed to get status of '/opt/usr/apps/com.example.crossapp/author-signature.xml': unknown reason
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/globalapps/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\698ced0a\author-signature.xml
pulled           author-signature.xml   100%       8235 B           0KB/s
                    1 file(s) pulled. 0 file(s) skipped.
                    /opt/usr/globalapps/com.example.crossapp/author-signature.xml   154KB/s (8235 bytes in 0.052s)
[   +2 ms] Latest build already installed.
[        ] Tizen rpi4 startApp
[   +2 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 push C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\ed706cdc\com.example.crossapp.rpm /home/owner/share/tmp/sdk_tools/com.example.crossapp.rpm
[+1035 ms] WARNING: Your data are to be sent over an unencrypted connection and could be read by others.
pushed       com.example.crossapp.rpm   100%         50 B           0KB/s
                    1 file(s) pushed. 0 file(s) skipped.
                    C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.73ed148e\ed706cdc\com.example.crossapp.rpm   0KB/s (50 bytes in 0.086s)
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -e com.example.crossapp
[+1404 ms] ... successfully launched pid = 18915 with debug 0
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward tcp:62982 tcp:62982
[ +809 ms] Connecting to localhost:62982...
[  +17 ms] The logging service started at 127.0.0.1:62982.
[        ] Application running.
[   +1 ms] Flutter run key commands.
[        ] h List all available interactive commands.
[        ] c Clear the screen
[        ] q Quit (terminate the application on the device).
[ +897 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[ +849 ms]       Kill appId: com.example.crossapp (18915)
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[+1022 ms] result: App isn't running
[        ] Application finished.
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --list
[ +912 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --list
[        ] List of port forwarding
           SERIAL               LOCAL           REMOTE
           10000000f2770a98     tcp:62982       tcp:62982
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --remove tcp:62982
[ +802 ms] "flutter run" took 32,994ms.
[   +3 ms] ensureAnalyticsSent: 0ms
[        ] Running 2 shutdown hooks
[  +24 ms] Shutdown hooks complete
[   +1 ms] exiting with code 0

```
</details>

<details>
<summary> After </summary>

```sh
C:\workspace\temp\crossapp> flutter-tizen run --release --verbose
[+1415 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[   +4 ms] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
[   +4 ms] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +28 ms] Artifact Instance of 'TizenEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'TizenEmbedderArtifacts' is not required, skipping update.
[   +3 ms] executing: C:\Users\kangho.hur\AppData\Local\Android\sdk\platform-tools\adb.exe devices -l
[  +11 ms] executing: C:\tizen-studio\tools\sdb.exe devices
[ +820 ms] List of devices attached
[ +590 ms] List of devices attached
                    10000000f2770a98            device          rpi4
[   +5 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 capability
[+1052 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 capability
[        ] secure_protocol:disabled
           intershell_support:enabled
           filesync_support:pushpull
           usbproto_support:enabled
           sockproto_support:enabled
           syncwinsz_support:enabled
           sdbd_rootperm:disabled
           rootonoff_support:enabled
           encryption_support:disabled
           zone_support:disabled
           multiuser_support:enabled
           cpu_arch:armv7l
           core_abi:arm_32
           sdk_toolpath:/home/owner/share/tmp/sdk_tools
           profile_name:common
           vendor_name:Tizen
           can_launch:unknown
           device_name:Tizen
           platform_version:9.0
           product_version:unknown
           sdbd_version:2.2.31
           sdbd_plugin_version:unknown
           sdbd_cap_version:1.0
           log_enable:disabled
           log_path:/home/owner/share/sdbdlog
           appcmd_support:enabled
           appid2pid_support:enabled
           pkgcmd_debugmode:enabled
           netcoredbg_support:enabled
           architecture:32
[   +7 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[   +9 ms] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[   +1 ms] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +69 ms] Skipping pub get: version match.
[ +286 ms] Generating C:\workspace\temp\crossapp\android\app\src\main\java\io\flutter\plugins\GeneratedPluginRegistrant.java
[ +194 ms] Launching tizen\flutter\generated_main.dart on Tizen rpi4 in release mode...
[   +9 ms] Building TPK
[  +11 ms] Building a Tizen application in release mode...
[   +2 ms] Initializing file store
[  +10 ms] Done initializing file store
[  +73 ms] Skipping target: gen_localizations
[   +7 ms] Skipping target: gen_dart_plugin_registrant
[  +32 ms] Skipping target: tizen_cpp_embedding
[ +542 ms] Skipping target: kernel_snapshot_program
[   +2 ms] tizen_native_plugins: Starting due to {}
[   +6 ms] Skipping target: native_assets
[   +3 ms] Skipping target: kernel_snapshot_native_assets
[        ] Skipping target: kernel_snapshot
[ +128 ms] Skipping target: tizen_aot_elf
[  +20 ms] tizen_native_plugins: Complete
[  +46 ms] Skipping target: release_tizen_application
[        ] tizen_dotnet_tpk: Starting due to {}
[  +56 ms] The test profile is used for signing.
[+2115 ms] executing: C:\Program Files\dotnet\dotnet.exe build -c Release /p:DefineConstants=COMMON_PROFILE C:\workspace\temp\crossapp\tizen
[+4592 ms]   蹂듭썝???꾨줈?앺듃瑜??뺤씤?섎뒗 以?..
                      蹂듭썝??紐⑤뱺 ?꾨줈?앺듃媛 理쒖떊 ?곹깭?낅땲??
                      Tizen.Flutter.Embedding -> C:\workspace\github\flutter-tizen\embedding\csharp\Tizen.Flutter.Embedding\bin\Release\tizen80\Tizen.Flutter.Embedding.dll
                      Runner -> C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\Runner.dll
                      Configuration :
                      Platform :
                      TargetFramework :
                      TizenTpkFiles : shared\res\ic_launcher.png
                      TizenTpkFiles : tizen-manifest.xml
                      TizenTpkFiles : flutter\ephemeral\lib\libapp.so
                      TizenTpkFiles : flutter\ephemeral\lib\libflutter_engine.so
                      TizenTpkFiles : flutter\ephemeral\lib\libflutter_tizen.so
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\AssetManifest.bin
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\AssetManifest.json
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\FontManifest.json
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\fonts\MaterialIcons-Regular.otf
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\NOTICES.Z
                      TizenTpkFiles : flutter\ephemeral\res\flutter_assets\shaders\ink_sparkle.frag
                      TizenTpkFiles : flutter\ephemeral\res\icudtl.dat
                      Runner is signed with Default Certificates!
                      Runner -> C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk

                    鍮뚮뱶?덉뒿?덈떎.
                        寃쎄퀬 0媛?
                        ?ㅻ쪟 0媛?

                    寃쎄낵 ?쒓컙: 00:00:02.78

                    ?뚰겕濡쒕뱶 ?낅뜲?댄듃瑜??ъ슜?????덉뒿?덈떎. ?먯꽭???댁슜??蹂대젮硫?`dotnet workload list`???ㅽ뻾?섏꽭??
[   +4 ms] executing: C:\tizen-studio\tools\ide\bin\tizen.bat package -t tpk -s test -- C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk
[+7946 ms] Author certficate: C:/tizen-studio-data/keystore/author/test.p12
                    Distributor1 certificate : C:\tizen-studio\tools\certificate-generator\certificates\distributor\sdk-platform\tizen-distributor-signer-new.p12
                    Package( C:\workspace\temp\crossapp\tizen\bin\Release\tizen80\com.example.crossapp-1.0.0.tpk ) is created successfully.
[  +57 ms] tizen_dotnet_tpk: Complete
[   +1 ms] Persisting file store
[   +9 ms] Done persisting file store
[  +11 ms] Building a Tizen application in release mode... (completed in 15.7s)
[   +3 ms] ✓ Built build\tizen\tpk\com.example.crossapp-1.0.0.tpk (6.8MB)
[ +103 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -l
[ +898 ms]      Application List for user 5001
                        User's Application
                         Name    AppID
                        =================================================
                        'Tizen NUI keyboard2'    'org.tizen.ISEDefaultNUI2'
                        'Tizen Web Service Daemon'       'org.tizen.chromium-efl.wrt-service'
                        'Bluetooth Share'        'org.tizen.bluetooth-share-ui'
                        'Vietnamese keyboard'    'org.tizen.ise-engine-unikey'
                        'MusicPlayer'    'org.tizen.MusicPlayer'
                        'CLM english keyboard'   'org.tizen.ise-engine-glm.english'
                        'Wi-Fi'  'wifi-efl-ug'
                        'Thai Keyboard Engine'   'org.tizen.ise-engine-thai'
                        'CLM korean keyboard'    'org.tizen.ise-engine-glm.korean'
                        'CanJie 3 keyboard'      'org.tizen.ise-engine-tables.cangjie3'
                        'Notifications'  'org.tizen.notifications'
                        'TaskBar'        'org.tizen.taskbar'
                        'Bluetooth'      'ug-bluetooth-efl'
                        'screen-reader'  'org.tizen.screen-reader'
                        'Tizen Web Service Launcher'     'org.tizen.chromium-efl.wrt-service-launcher'
                        'Gallery'        'attach-panel-gallery'
                        'SettingCertificates'    'org.tizen.cssetting-certificates'
                        'IME Selector'   'org.tizen.inputmethod-setting-selector'
                        'ScreenMirroringSink'    'org.tizen.ScreenMirroringSink'
                        'Settings'       'org.tizen.cssettings'
                        'Network popup'  'org.tizen.net-popup'
                        'org.tizen.stt-engine-embedded'  'org.tizen.stt-engine-embedded'
                        'service'        'org.tizen.nlp.service'
                        'Bluetooth'      'ug-bluetooth-efl-single'
                        'Application Selection Popup'    'org.tizen.app-selector'
                        'Accounts'       'setting-myaccount-efl'
                        'Wi-Fi Direct System Popup'      'org.tizen.wifi-direct-popup'
                        'Chinese stoke keyboard'         'org.tizen.ise-engine-glm.chinese-stoke'
                        'Hangul keyboard'        'org.tizen.ise-engine-hangul'
                        'hello_f2'       'com.example.hello_f2'
                        'Japanese keyboard'      'org.tizen.ise-engine-anthy'
                        'DefaultDarkTheme'       'org.tizen.default-dark-theme'
                        'crossapp'       'com.example.crossapp'
                        'Wi-Fi Direct Setting'   'ug-setting-wifidirect-efl'
                        'Voice control panel'    'org.tizen.voice-control-panel'
                        'autofill daemon'        'org.tizen.autofilld'
                        'Document'       'attach-panel-document'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp_2'
                        'Oobe'   'org.tizen.oobe'
                        'Tizen keyboard'         'ise-default'
                        'SettingKeyboard'        'org.tizen.cssetting-keyboard'
                        'System popup'   'org.tizen.system-syspopup'
                        'Tizen keyboard setting'         'org.tizen.ise-default-setting'
                        'VolumeApp'      'org.tizen.volume-nui'
                        'Tizen Web Engine based on Chromium'     'org.tizen.chromium-efl'
                        'screen-reader-ui'       'org.tizen.screen-reader-ui'
                        'service'        'wakeup-engine-default'
                        'NUIGadgetViewer'        'org.tizen.NUIGadgetViewer'
                        'org.tizen.stt-engine-default'   'org.tizen.stt-engine-default'
                        'aurum bootstrap daemon'         'org.tizen.aurum-bootstrap'
                        'TizenDotNet1'   'org.tizen.example.TizenDotNet1'
                        'VoiceRecorderUG'        'attach-panel-voicerecorder'
                        'Power key system popup'         'org.tizen.powerkey-syspopup'
                        'Voice setting'  'org.tizen.voice-setting'
                        'CameraUG'       'attach-panel-camera'
                        'share-panel'    'org.tizen.share-panel'
                        'Bluetooth System Popup'         'org.tizen.bt-syspopup'
                        'hello_flutter_cpp'      'com.example.hello_flutter_cpp'
                        'hello_flutter'  'com.example.hello_flutter'
                        'Autofill Setting'       'org.tizen.autofill-setting-mobile'
                        'Multi Assistant Service'        'org.tizen.multi-assistant-service'
                        'mmi-manager'    'mmi-manager'
                        'isf-kbd-mode-changer'   'org.tizen.isf-kbd-mode-changer'
                        'Chinese pinyin keyboard'        'org.tizen.ise-engine-glm.chinese-pinyin'
                        'IME List'       'org.tizen.inputmethod-setting-list'
                        'tts-engine-default'     'org.tizen.tts-engine-default'
                        ''       'org.tizen.secure-erase'
                        'DefaultLightTheme'      'org.tizen.default-light-theme'
                        'nui_layout_test'        'org.tizen.example.nui_layout_test'
                        'Voice Control Elm unittests'    'org.tizen.vc-elm-unittests'
                        'System signal sender'   'org.tizen.system-signal-sender'
                        'HereMaps UC'    'org.tizen.heremaps-uc'
                        'askuser popup'  'org.tizen.askuser-popup'
                        'Tizen NUI keyboard'     'org.tizen.ISEDefaultNUI'
                        'ZhuYin Big keyboard'    'org.tizen.ise-engine-tables.zhuyin-big'
                        'Default keyboard'       'org.tizen.ise-engine-default'
                        =================================================
[  +14 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 pull /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.4dce0edf\35ba6cdc\author-signature.xml
pulled           author-signature.xml   100%       8235 B           0KB/s
                    1 file(s) pulled. 0 file(s) skipped.
                    /opt/usr/home/owner/apps_rw/com.example.crossapp/author-signature.xml   167KB/s (8235 bytes in 0.048s)
[   +2 ms] Latest build already installed.
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[ +971 ms] result: App isn't running
[        ] Tizen rpi4 startApp
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 push C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.4dce0edf\edc725e8\com.example.crossapp.rpm /home/owner/share/tmp/sdk_tools/com.example.crossapp.rpm
[ +983 ms] WARNING: Your data are to be sent over an unencrypted connection and could be read by others.
pushed       com.example.crossapp.rpm   100%         50 B           0KB/s
                    1 file(s) pushed. 0 file(s) skipped.
                    C:\Users\kangho.hur\AppData\Local\Temp\flutter_tools.4dce0edf\edc725e8\com.example.crossapp.rpm   0KB/s (50 bytes in 0.091s)
[        ] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -e com.example.crossapp
[+1442 ms] ... successfully launched pid = 16563 with debug 0
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward tcp:62142 tcp:62142
[ +886 ms] Connecting to localhost:62142...
[  +15 ms] The logging service started at 127.0.0.1:62142.
[   +1 ms] Application running.
[   +3 ms] Flutter run key commands.
[   +2 ms] h List all available interactive commands.
[        ] c Clear the screen
[        ] q Quit (terminate the application on the device).
[ +815 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[ +825 ms]       Kill appId: com.example.crossapp (16563)
[   +3 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 shell app_launcher -k com.example.crossapp
[ +841 ms] result: App isn't running
[   +1 ms] Application finished.
[   +2 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --list
[ +793 ms] Exit code 0 from: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --list
[   +1 ms] List of port forwarding
           SERIAL               LOCAL           REMOTE
           10000000f2770a98     tcp:62142       tcp:62142
[   +1 ms] executing: C:\tizen-studio\tools\sdb.exe -s 10000000f2770a98 forward --remove tcp:62142
[ +790 ms] "flutter run" took 30,608ms.
[   +2 ms] ensureAnalyticsSent: 0ms
[        ] Running 2 shutdown hooks
[  +16 ms] Shutdown hooks complete
[        ] exiting with code 0
```
</details>