### PR TITLE
Improve `flutter-tizen --version` command

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -39,6 +39,7 @@ import 'package:flutter_tools/src/isolated/build_targets.dart';
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/project_validator.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:path/path.dart';
 
 import 'commands/attach.dart';
@@ -60,6 +61,7 @@ import 'tizen_emulator.dart';
 import 'tizen_osutils.dart';
 import 'tizen_pub.dart';
 import 'tizen_sdk.dart';
+import 'tizen_flutter_version.dart';
 
 /// Main entry point for commands.
 ///
@@ -204,6 +206,10 @@ Future<void> main(List<String> args) async {
             fileSystem: globals.fs,
             logger: globals.logger,
             processManager: globals.processManager,
+          ),
+      FlutterVersion: () => TizenFlutterVersion(
+            fs: globals.fs,
+            flutterRoot: Cache.flutterRoot!,
           ),
       Logger: () {
         final LoggerFactory loggerFactory = LoggerFactory(

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -58,10 +58,10 @@ import 'tizen_cache.dart';
 import 'tizen_device_manager.dart';
 import 'tizen_doctor.dart';
 import 'tizen_emulator.dart';
+import 'tizen_flutter_version.dart';
 import 'tizen_osutils.dart';
 import 'tizen_pub.dart';
 import 'tizen_sdk.dart';
-import 'tizen_flutter_version.dart';
 
 /// Main entry point for commands.
 ///

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -20,24 +20,38 @@ class TizenFlutterVersion implements FlutterVersion {
         );
   final FlutterVersion flutterVersion;
 
+  String _flutterTizenTagVersion = '';
+  String get flutterTizenTag {
+    if (_flutterTizenTagVersion.isEmpty) {
+      final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
+      final String lastTagRevision = _runGit(
+        'git rev-list --tags --max-count=1',
+        workingDirectory.path,
+      );
+
+      _flutterTizenTagVersion = _runGit(
+        'git describe --tags $lastTagRevision',
+        workingDirectory.path,
+      );
+    }
+    return _flutterTizenTagVersion;
+  }
+
+  String _flutterTizenLatestRevision = '';
+  String get flutterTizenLatestRevision {
+    if (_flutterTizenLatestRevision.isEmpty) {
+      final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
+      _flutterTizenLatestRevision = _runGit(
+        'git -c log.showSignature=false log -n 1 --pretty=format:%H',
+        workingDirectory.path,
+      );
+    }
+    return _flutterTizenLatestRevision;
+  }
+
   @override
   String toString() {
-    final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
-    final String lastTagRevision = _runGit(
-      'git rev-list --tags --max-count=1',
-      workingDirectory.path,
-    );
-
-    final String flutterTizenVersion = _runGit(
-      'git describe --tags $lastTagRevision',
-      workingDirectory.path,
-    );
-
-    final String flutterTizenRevision = _runGit(
-      'git -c log.showSignature=false log -n 1 --pretty=format:%H',
-      workingDirectory.path,
-    );
-    return 'Flutter-Tizen $flutterTizenVersion • revision ${_shortGitRevision(flutterTizenRevision)}\n$flutterVersion';
+    return 'Flutter-Tizen $flutterTizenTag • revision ${_shortGitRevision(flutterTizenLatestRevision)}\n$flutterVersion';
   }
 
   @override

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -5,7 +5,6 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/time.dart';
 
-import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -41,7 +41,8 @@ class TizenFlutterVersion implements FlutterVersion {
   String get channel => flutterVersion.channel;
 
   @override
-  Future<void> checkFlutterVersionFreshness() => flutterVersion.checkFlutterVersionFreshness();
+  Future<void> checkFlutterVersionFreshness() =>
+      flutterVersion.checkFlutterVersionFreshness();
 
   @override
   String get dartSdkVersion => flutterVersion.dartSdkVersion;
@@ -87,7 +88,8 @@ class TizenFlutterVersion implements FlutterVersion {
   FileSystem get fs => flutterVersion.fs;
 
   @override
-  String getBranchName({bool redactUnknownBranches = false}) => flutterVersion.getBranchName();
+  String getBranchName({bool redactUnknownBranches = false}) =>
+      flutterVersion.getBranchName();
 
   @override
   String getVersionString({bool redactUnknownBranches = false}) =>

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -23,7 +23,7 @@ class TizenFlutterVersion implements FlutterVersion {
   String _flutterTizenLatestRevision = '';
   String get flutterTizenLatestRevision {
     if (_flutterTizenLatestRevision.isEmpty) {
-      final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
+      final Directory workingDirectory = fs.directory(flutterRoot).parent;
       _flutterTizenLatestRevision = _runGit(
         'git -c log.showSignature=false log -n 1 --pretty=format:%H',
         workingDirectory.path,
@@ -88,12 +88,13 @@ class TizenFlutterVersion implements FlutterVersion {
   FileSystem get fs => flutterVersion.fs;
 
   @override
-  String getBranchName({bool redactUnknownBranches = false}) =>
-      flutterVersion.getBranchName();
+  String getBranchName({bool redactUnknownBranches = false}) => flutterVersion
+      .getBranchName(redactUnknownBranches: redactUnknownBranches);
 
   @override
   String getVersionString({bool redactUnknownBranches = false}) =>
-      flutterVersion.getVersionString();
+      flutterVersion.getVersionString(
+          redactUnknownBranches: redactUnknownBranches);
 
   @override
   GitTagVersion get gitTagVersion => flutterVersion.gitTagVersion;
@@ -114,9 +115,6 @@ String _runGit(String command, String? workingDirectory) {
 }
 
 /// Source: [_shortGitRevision] in `version.dart`
-String _shortGitRevision(String? revision) {
-  if (revision == null) {
-    return '';
-  }
+String _shortGitRevision(String revision) {
   return revision.length > 10 ? revision.substring(0, 10) : revision;
 }

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -20,23 +20,6 @@ class TizenFlutterVersion implements FlutterVersion {
         );
   final FlutterVersion flutterVersion;
 
-  String _flutterTizenTagVersion = '';
-  String get flutterTizenTag {
-    if (_flutterTizenTagVersion.isEmpty) {
-      final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
-      final String lastTagRevision = _runGit(
-        'git rev-list --tags --max-count=1',
-        workingDirectory.path,
-      );
-
-      _flutterTizenTagVersion = _runGit(
-        'git describe --tags $lastTagRevision',
-        workingDirectory.path,
-      );
-    }
-    return _flutterTizenTagVersion;
-  }
-
   String _flutterTizenLatestRevision = '';
   String get flutterTizenLatestRevision {
     if (_flutterTizenLatestRevision.isEmpty) {
@@ -51,15 +34,14 @@ class TizenFlutterVersion implements FlutterVersion {
 
   @override
   String toString() {
-    return 'Flutter-Tizen $flutterTizenTag • revision ${_shortGitRevision(flutterTizenLatestRevision)}\n$flutterVersion';
+    return 'Flutter-Tizen • revision ${_shortGitRevision(flutterTizenLatestRevision)}\n$flutterVersion';
   }
 
   @override
   String get channel => flutterVersion.channel;
 
   @override
-  Future<void> checkFlutterVersionFreshness() =>
-      flutterVersion.checkFlutterVersionFreshness();
+  Future<void> checkFlutterVersionFreshness() => flutterVersion.checkFlutterVersionFreshness();
 
   @override
   String get dartSdkVersion => flutterVersion.dartSdkVersion;
@@ -105,8 +87,7 @@ class TizenFlutterVersion implements FlutterVersion {
   FileSystem get fs => flutterVersion.fs;
 
   @override
-  String getBranchName({bool redactUnknownBranches = false}) =>
-      flutterVersion.getBranchName();
+  String getBranchName({bool redactUnknownBranches = false}) => flutterVersion.getBranchName();
 
   @override
   String getVersionString({bool redactUnknownBranches = false}) =>

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -1,0 +1,125 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/time.dart';
+
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/version.dart';
+
+/// An implemented [FlutterVersion] for printing Flutter-tizen version.
+class TizenFlutterVersion implements FlutterVersion {
+  TizenFlutterVersion({
+    required FileSystem fs,
+    required String flutterRoot,
+  }) : flutterVersion = FlutterVersion(
+          fs: fs,
+          flutterRoot: flutterRoot,
+        );
+  final FlutterVersion flutterVersion;
+
+  @override
+  String toString() {
+    final Directory workingDirectory = fs.directory(Cache.flutterRoot).parent;
+    final String lastTagRevision = _runGit(
+      'git rev-list --tags --max-count=1',
+      workingDirectory.path,
+    );
+
+    final String flutterTizenVersion = _runGit(
+      'git describe --tags $lastTagRevision',
+      workingDirectory.path,
+    );
+
+    final String flutterTizenRevision = _runGit(
+      'git -c log.showSignature=false log -n 1 --pretty=format:%H',
+      workingDirectory.path,
+    );
+    return 'Flutter-Tizen $flutterTizenVersion • revision ${_shortGitRevision(flutterTizenRevision)}\n$flutterVersion';
+  }
+
+  @override
+  String get channel => flutterVersion.channel;
+
+  @override
+  Future<void> checkFlutterVersionFreshness() =>
+      flutterVersion.checkFlutterVersionFreshness();
+
+  @override
+  String get dartSdkVersion => flutterVersion.dartSdkVersion;
+
+  @override
+  String get devToolsVersion => flutterVersion.devToolsVersion;
+
+  @override
+  String get engineRevision => flutterVersion.engineRevision;
+
+  @override
+  String get engineRevisionShort => flutterVersion.engineRevisionShort;
+
+  @override
+  void ensureVersionFile() => flutterVersion.ensureVersionFile();
+
+  /// See: [fetchTagsAndGetVersion] in `version.dart`
+  @override
+  FlutterVersion fetchTagsAndGetVersion({
+    SystemClock clock = const SystemClock(),
+  }) =>
+      this;
+
+  @override
+  String get flutterRoot => flutterVersion.flutterRoot;
+
+  @override
+  String get frameworkAge => flutterVersion.frameworkAge;
+
+  @override
+  String get frameworkCommitDate => flutterVersion.frameworkCommitDate;
+
+  @override
+  String get frameworkRevision => flutterVersion.frameworkRevision;
+
+  @override
+  String get frameworkRevisionShort => flutterVersion.frameworkRevisionShort;
+
+  @override
+  String get frameworkVersion => flutterVersion.frameworkVersion;
+
+  @override
+  FileSystem get fs => flutterVersion.fs;
+
+  @override
+  String getBranchName({bool redactUnknownBranches = false}) =>
+      flutterVersion.getBranchName();
+
+  @override
+  String getVersionString({bool redactUnknownBranches = false}) =>
+      flutterVersion.getVersionString();
+
+  @override
+  GitTagVersion get gitTagVersion => flutterVersion.gitTagVersion;
+
+  @override
+  String? get repositoryUrl => flutterVersion.repositoryUrl;
+
+  @override
+  Map<String, Object> toJson() => flutterVersion.toJson();
+}
+
+/// Source: [_runGit] in `version.dart`
+String _runGit(String command, String? workingDirectory) {
+  return globals.processUtils
+      .runSync(command.split(' '), workingDirectory: workingDirectory)
+      .stdout
+      .trim();
+}
+
+/// Source: [_shortGitRevision] in `version.dart`
+String _shortGitRevision(String? revision) {
+  if (revision == null) {
+    return '';
+  }
+  return revision.length > 10 ? revision.substring(0, 10) : revision;
+}

--- a/test/general/tizen_flutter_version.dart
+++ b/test/general/tizen_flutter_version.dart
@@ -1,0 +1,27 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tizen/tizen_flutter_version.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  setUpAll(() {
+    Cache.flutterRoot = 'flutter';
+  });
+
+  testUsingContext('Detects flutter-tizen tag and revision.', () async {
+    final TizenFlutterVersion tizenFlutterVersion = TizenFlutterVersion(
+      fs: globals.fs,
+      flutterRoot: Cache.flutterRoot!,
+    );
+
+    expect(tizenFlutterVersion.flutterTizenTag, isEmpty);
+    expect(tizenFlutterVersion.flutterTizenLatestRevision, isNotEmpty);
+  }, overrides: <Type, Generator>{});
+}

--- a/test/general/tizen_flutter_version.dart
+++ b/test/general/tizen_flutter_version.dart
@@ -21,7 +21,6 @@ void main() {
       flutterRoot: Cache.flutterRoot!,
     );
 
-    expect(tizenFlutterVersion.flutterTizenTag, isEmpty);
     expect(tizenFlutterVersion.flutterTizenLatestRevision, isNotEmpty);
   }, overrides: <Type, Generator>{});
 }


### PR DESCRIPTION
Add the revision information of HEAD to the flutter-tizen --version command.

before)
```
$ flutter-tizen --version
Flutter 3.27.1 • channel [user-branch] • unknown source
Framework • revision 17025dd882 (4 months ago) • 2024-12-17 03:23:09 +0900
Engine • revision cb4b5fff73
Tools • Dart 3.6.0 • DevTools 2.40.2
```

ex)
```
$ flutter-tizen --version
Flutter-Tizen • revision 43fc5f1ffa
Flutter 3.27.1 • channel [user-branch] • unknown source
Framework • revision 17025dd882 (4 months ago) • 2024-12-17 03:23:09 +0900
Engine • revision cb4b5fff73
Tools • Dart 3.6.0 • DevTools 2.40.2
```

https://github.com/flutter-tizen/flutter-tizen/issues/607