### PR TITLE
Fix wrong flutter revision information in .app.deps.json

### DIFF
--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -688,9 +688,18 @@ Future<void> _writeAppDepndencyInfo(
 
   final Map<String, Object> flutter = <String, Object>{};
   flutter['version'] = globals.flutterVersion.frameworkVersion;
+  flutter['revision'] = globals.flutterVersion.frameworkRevisionShort;
 
   final Map<String, Object> flutterTizen = <String, Object>{};
-  flutterTizen['revision'] = globals.flutterVersion.frameworkRevisionShort;
+  final Directory workingDirectory =
+      globals.fs.directory(Cache.flutterRoot).parent;
+  final String frameworkRevision = _runGit(
+    'git -c log.showSignature=false log -n 1 --pretty=format:%H',
+    workingDirectory.path,
+  );
+  // TODO(jsuya): https://github.com/flutter-tizen/flutter-tizen/pull/608 is merged, we can use TizenFlutterVersion.flutterTizenVersion.
+  // flutterTizen['revision'] = (globals.flutterVersion as TizenFlutterVersion).flutterTizenVersion;
+  flutterTizen['revision'] = _shortGitRevision(frameworkRevision);
 
   final Map<String, Object> engine = <String, Object>{};
   engine['revision'] = globals.flutterVersion.engineRevisionShort;
@@ -711,4 +720,20 @@ Future<void> _writeAppDepndencyInfo(
   const JsonEncoder encoder = JsonEncoder.withIndent('  ');
   final String formattedJsonString = encoder.convert(result);
   appDepsJson.writeAsStringSync(formattedJsonString);
+}
+
+/// Source: [_runGit] in `version.dart`
+String _runGit(String command, String? workingDirectory) {
+  return globals.processUtils
+      .runSync(command.split(' '), workingDirectory: workingDirectory)
+      .stdout
+      .trim();
+}
+
+/// Source: [_shortGitRevision] in `version.dart`
+String _shortGitRevision(String? revision) {
+  if (revision == null) {
+    return '';
+  }
+  return revision.length > 10 ? revision.substring(0, 10) : revision;
 }

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -697,8 +697,6 @@ Future<void> _writeAppDepndencyInfo(
     'git -c log.showSignature=false log -n 1 --pretty=format:%H',
     workingDirectory.path,
   );
-  // TODO(jsuya): https://github.com/flutter-tizen/flutter-tizen/pull/608 is merged, we can use TizenFlutterVersion.flutterTizenVersion.
-  // flutterTizen['revision'] = (globals.flutterVersion as TizenFlutterVersion).flutterTizenVersion;
   flutterTizen['revision'] = _shortGitRevision(frameworkRevision);
 
   final Map<String, Object> engine = <String, Object>{};
@@ -731,9 +729,6 @@ String _runGit(String command, String? workingDirectory) {
 }
 
 /// Source: [_shortGitRevision] in `version.dart`
-String _shortGitRevision(String? revision) {
-  if (revision == null) {
-    return '';
-  }
+String _shortGitRevision(String revision) {
   return revision.length > 10 ? revision.substring(0, 10) : revision;
 }


### PR DESCRIPTION
globals.flutterVersion.frameworkRevision is flutter's information, and flutter-tizen's information needs to be taken from flutterRoot's parent by calling the git command again.

before
```
  "flutter": {
    "version": "3.27.1",
  },
  "flutter-tizen": {
    "revision": "17025dd882"
  },
```

after
```
  "flutter": {
    "version": "3.27.1",
    "revision": "17025dd882"
  },
  "flutter-tizen": {
    "revision": "298f3a8843"
  },

```