### PR TITLE
Fix `tz set` command failure

### DIFF
--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -178,6 +178,24 @@ class DotnetTpk extends TizenPackage {
         'Install the latest .NET SDK from: https://dotnet.microsoft.com/download',
       );
     }
+
+    // TODO(jsuya): Due to a bug in the `tz set` command, it fails
+    // to automatically generate tizen_dotnet_project.yaml. So
+    // create it manually and `tz set` command. This will be fixed
+    // in the next version of Tizen SDK.
+    // https://github.com/flutter-tizen/flutter-tizen/issues/610
+    if (!tizenProject.hostAppRoot
+        .childFile('tizen_dotnet_project.yaml')
+        .existsSync()) {
+      await _processUtils.run(
+        <String>[
+          'touch',
+          'tizen_dotnet_project.yaml',
+        ],
+        workingDirectory: tizenProject.hostAppRoot.path,
+      );
+    }
+
     final RunResult result = await tizenSdk!.tzBuild(
       tizenProject.hostAppRoot.path,
       buildType: buildConfig,

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -184,17 +184,9 @@ class DotnetTpk extends TizenPackage {
     // create it manually and `tz set` command. This will be fixed
     // in the next version of Tizen SDK.
     // https://github.com/flutter-tizen/flutter-tizen/issues/610
-    if (!tizenProject.hostAppRoot
+    tizenProject.hostAppRoot
         .childFile('tizen_dotnet_project.yaml')
-        .existsSync()) {
-      await _processUtils.run(
-        <String>[
-          'touch',
-          'tizen_dotnet_project.yaml',
-        ],
-        workingDirectory: tizenProject.hostAppRoot.path,
-      );
-    }
+        .createSync(recursive: true);
 
     final RunResult result = await tizenSdk!.tzBuild(
       tizenProject.hostAppRoot.path,

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -253,25 +253,27 @@ class TizenSdk {
     String workingDirectory, {
     String? buildType,
     String? signingProfile,
-  }) {
-    _processUtils.run(
+  }) async {
+    final RunResult result = await _processUtils.run(
       <String>[
         tzCli.path,
         'set',
         if (buildType != null) ...<String>['-b', buildType],
         if (signingProfile != null) ...<String>['-s', signingProfile],
-        '-w',
-        workingDirectory,
       ],
+      workingDirectory: workingDirectory,
     );
+
+    if (result.exitCode != 0) {
+      throwToolExit('Failed to build .NET application:\n$result');
+    }
 
     return _processUtils.run(
       <String>[
         tzCli.path,
         'build',
-        '-w',
-        workingDirectory,
       ],
+      workingDirectory: workingDirectory,
     );
   }
 

--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -265,7 +265,7 @@ class TizenSdk {
     );
 
     if (result.exitCode != 0) {
-      throwToolExit('Failed to build .NET application:\n$result');
+      return result;
     }
 
     return _processUtils.run(

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -102,25 +102,29 @@ void main() {
           .createSync(recursive: true);
 
       processManager.addCommands(<FakeCommand>[
-        FakeCommand(
+        const FakeCommand(
           command: <String>[
+            'touch',
+            'tizen_dotnet_project.yaml',
+          ],
+        ),
+        FakeCommand(
+          command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',
             'set',
             '-b',
             'Release',
             '-s',
             'test_profile',
-            '-w',
-            '${projectDir.path}/tizen',
           ],
+          workingDirectory: '${projectDir.path}/tizen',
         ),
         FakeCommand(
-          command: <String>[
+          command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',
             'build',
-            '-w',
-            '${projectDir.path}/tizen',
           ],
+          workingDirectory: '${projectDir.path}/tizen',
           onRun: (_) {
             projectDir
                 .childFile('tizen/bin/Release/tizen80/package_id-1.0.0.tpk')
@@ -191,25 +195,29 @@ void main() {
           .createSync(recursive: true);
 
       processManager.addCommands(<FakeCommand>[
-        FakeCommand(
+        const FakeCommand(
           command: <String>[
+            'touch',
+            'tizen_dotnet_project.yaml',
+          ],
+        ),
+        FakeCommand(
+          command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',
             'set',
             '-b',
             'Release',
             '-s',
             'test_profile',
-            '-w',
-            '${projectDir.path}/tizen',
           ],
+          workingDirectory: '${projectDir.path}/tizen',
         ),
         FakeCommand(
-          command: <String>[
+          command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',
             'build',
-            '-w',
-            '${projectDir.path}/tizen',
           ],
+          workingDirectory: '${projectDir.path}/tizen',
           onRun: (_) {
             projectDir
                 .childFile('tizen/bin/Release/tizen80/package_id-1.0.0.tpk')

--- a/test/general/build_targets/package_test.dart
+++ b/test/general/build_targets/package_test.dart
@@ -102,12 +102,6 @@ void main() {
           .createSync(recursive: true);
 
       processManager.addCommands(<FakeCommand>[
-        const FakeCommand(
-          command: <String>[
-            'touch',
-            'tizen_dotnet_project.yaml',
-          ],
-        ),
         FakeCommand(
           command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',
@@ -195,12 +189,6 @@ void main() {
           .createSync(recursive: true);
 
       processManager.addCommands(<FakeCommand>[
-        const FakeCommand(
-          command: <String>[
-            'touch',
-            'tizen_dotnet_project.yaml',
-          ],
-        ),
         FakeCommand(
           command: const <String>[
             '/tizen-studio/tools/tizen-core/tz',


### PR DESCRIPTION
Due to a bug in the `tz set` command, it fails to automatically generate tizen_dotnet_project.yaml.
So create it manually and call `tz set` command. This will be fixed in the next version of Tizen SDK.

https://github.com/flutter-tizen/flutter-tizen/issues/610