### PR TITLE
Remove dev dependencies from release builds

### DIFF
--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 
 import '../tizen_build_info.dart';
@@ -60,7 +61,15 @@ class NativePlugins extends Target {
     final TizenProject tizenProject = TizenProject.fromFlutter(project);
 
     // Check if there's anything to build.
-    final List<TizenPlugin> nativePlugins = await findTizenPlugins(project, cppOnly: true);
+    final bool isRelease = buildInfo.buildInfo.mode.isRelease;
+    final bool determineDevDependencies = featureFlags.isExplicitPackageDependenciesEnabled;
+    final bool releaseMode = isRelease && determineDevDependencies;
+    List<TizenPlugin> nativePlugins =
+        await findTizenPlugins(project, cppOnly: true, releaseMode: releaseMode);
+    if (releaseMode) {
+      nativePlugins = nativePlugins.where((TizenPlugin p) => !p.isDevDependency).toList();
+    }
+
     if (nativePlugins.isEmpty) {
       depfileService.writeToFile(
         Depfile(inputs, outputs),


### PR DESCRIPTION
Remove dev dependencies from the GeneratedPluginRegistrant when building in release mode and setting the "explicit-package-dependencies" value to "true".

```
# Opt-in to the feature
flutter-tizen config --explicit-package-dependencies
# Create a tizen_app
flutter-tizen create tizen_app --platforms=tizen

# Try to build the app
cd tizen_app
flutter-tizen build tpk
```
You can opt-out by using `flutter-tizen config --no-explicit-package-dependencies`.

https://github.com/flutter/flutter/pull/161343