### PR TITLE
Change the app type "capp" to "capp-flutter"

### DIFF
--- a/templates/module/cpp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/cpp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
+    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp-flutter" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
     </ui-application>

--- a/templates/multi-app/cpp/service/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/cpp/service/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <service-application appid="{{tizenIdentifier}}_service" exec="runner_service" type="capp" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
+    <service-application appid="{{tizenIdentifier}}_service" exec="runner_service" type="capp-flutter" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
         <label>{{projectName}}</label>
         <background-category value="media"/>
     </service-application>

--- a/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
+    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp-flutter" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
     </ui-application>

--- a/templates/service-app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/cpp/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <service-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
+    <service-application appid="{{tizenIdentifier}}" exec="runner" type="capp-flutter" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <background-category value="media"/>

--- a/templates/ui-app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/cpp/tizen-manifest.xml.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="{{tizenIdentifier}}" version="1.0.0" api-version="6.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
+    <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp-flutter" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
     </ui-application>

--- a/test/general/tizen_tpk_test.dart
+++ b/test/general/tizen_tpk_test.dart
@@ -52,14 +52,15 @@ void main() {
       ..writeAsStringSync('''
 <manifest package="package_id" version="9.9.9" api-version="4.0">
     <profile name="common"/>
-    <ui-application appid="app_id_1" exec="runner" type="capp"/>
-    <service-application appid="app_id_2" exec="runner" type="capp"/>
-    <service-application appid="app_id_3" exec="runner" type="capp"/>
+    <ui-application appid="app_id_1" exec="runner" type="capp-flutter"/>
+    <service-application appid="app_id_2" exec="runner" type="capp-flutter"/>
+    <service-application appid="app_id_3" exec="runner" type="capp-flutter"/>
 </manifest>
 ''');
 
     final TizenManifest manifest = TizenManifest.parseFromXml(xmlFile);
     expect(manifest.applicationId, equals('app_id_1'));
+    expect(manifest.applicationType, equals('capp-flutter'));
     expect(logger.traceText, contains('tizen-manifest.xml: Found 3 application declarations.'));
   }, overrides: <Type, Generator>{
     Logger: () => logger,


### PR DESCRIPTION
Loader uses the dotnet loader when the type is "dotnet", otherwise it uses the native loader.
So change it to a type that recognizes flutter app, since the loader don't rely on the "capp" keyword.

related issue: https://github.com/flutter-tizen/flutter-tizen/issues/623