### PR TITLE
Add flutter_embedding metadata key

### DIFF
--- a/templates/module/cpp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/cpp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -4,6 +4,7 @@
     <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
+++ b/templates/module/csharp/.tizen.tmpl/tizen-manifest.xml.tmpl
@@ -6,6 +6,7 @@
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
         <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/cpp/service/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/cpp/service/tizen-manifest.xml.tmpl
@@ -4,6 +4,7 @@
     <service-application appid="{{tizenIdentifier}}_service" exec="runner_service" type="capp" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
         <label>{{projectName}}</label>
         <background-category value="media"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/cpp/ui/tizen-manifest.xml.tmpl
@@ -8,6 +8,7 @@
     <privileges>
         <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
         <privilege>http://tizen.org/privilege/appmanager.kill.bgapp</privilege>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </privileges>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/service/tizen-manifest.xml.tmpl
@@ -6,6 +6,7 @@
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
         <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
+++ b/templates/multi-app/csharp/ui/tizen-manifest.xml.tmpl
@@ -6,6 +6,7 @@
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
         <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </ui-application>
     <privileges>
         <privilege>http://tizen.org/privilege/appmanager.launch</privilege>

--- a/templates/service-app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/cpp/tizen-manifest.xml.tmpl
@@ -5,6 +5,7 @@
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
         <background-category value="media"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/service-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/service-app/csharp/tizen-manifest.xml.tmpl
@@ -7,6 +7,7 @@
         <background-category value="media"/>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
         <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </service-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/ui-app/cpp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/cpp/tizen-manifest.xml.tmpl
@@ -4,6 +4,7 @@
     <ui-application appid="{{tizenIdentifier}}" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>{{projectName}}</label>
         <icon>ic_launcher.png</icon>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/templates/ui-app/csharp/tizen-manifest.xml.tmpl
+++ b/templates/ui-app/csharp/tizen-manifest.xml.tmpl
@@ -6,6 +6,7 @@
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
         <metadata key="http://tizen.org/metadata/prefer_nuget_cache" value="true"/>
+        <metadata key="http://tizen.org/metadata/flutter_tizen/flutter_embedding" value="true"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>


### PR DESCRIPTION
This metadata key is used to identify apps written in flutter. It may be used for statistics in the store.
And in tizen runtime loader, loader can use this key to determine whether to optimize or not.

related issue: #623