### PR TITLE
Fix `inputs` of plugins of the build system

### DIFF
--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -32,7 +32,7 @@ class NativePlugins extends Target {
   List<Source> get inputs => const <Source>[
         Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/plugins.dart'),
         Source.pattern('{FLUTTER_ROOT}/../lib/tizen_sdk.dart'),
-        Source.pattern('{PROJECT_DIR}/.packages'),
+        Source.pattern('{WORKSPACE_DIR}/.dart_tool/package_config_subset'),
       ];
 
   @override


### PR DESCRIPTION
Fix `inputs`'s list that determine whether to build the tizen native plugin.

```
[   +2 ms] invalidated build due to missing files: /home/junsu/dev/os/f-project/plugins/packages/video_player_avplay/example/.packages
[ +111 ms] tizen_native_plugins: Starting due to {InvalidatedReasonKind.inputMissing: The following inputs were missing: /home/junsu/dev/os/f-project/plugins/packages/video_player_avplay/example/.packages}
```

related issue: https://github.com/flutter-tizen/flutter-tizen/issues/641#issuecomment-3050739785