### PR TITLE
[ci] Add an action to automatically close long-inactived issues

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Analyze
 
 on: [push, pull_request]
@@ -25,6 +29,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
       - name: Verify formatting
         run: dotnet format --verify-no-changes embedding/csharp

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -27,7 +27,6 @@ jobs:
           exempt-issue-labels: |
             bug
             enhancement
-            feature
             keep
           close-issue-message: >
             This page has been automatically locked since there has not been any recent activity after it was closed. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.

--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -29,7 +29,7 @@ jobs:
             enhancement
             keep
           close-issue-message: >
-            This page has been automatically locked since there has not been any recent activity after it was closed. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.
+            This page has been automatically closed since there has not been any recent activity. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.
           operations-per-run: 100
           stale-pr-message: ""
           days-before-pr-stale: -1

--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Configuration for close stale issues - https://github.com/actions/stale
+
+name: Close stale issues
+
+permissions:
+  issues: write
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 0
+          only-issue-labels: ""
+          exempt-issue-labels: |
+            bug
+            enhancement
+            feature
+            keep
+          close-issue-message: >
+            This page has been automatically locked since there has not been any recent activity after it was closed. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.
+          operations-per-run: 100
+          stale-pr-message: ""
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Release
 
 on: [pull_request, workflow_dispatch]
@@ -36,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
       - name: Build
         working-directory: embedding/csharp/Tizen.Flutter.Embedding
         run: dotnet build -c Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Test
 
 on: [push, pull_request]
@@ -31,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
       - name: Run tests
         run: dotnet test embedding/csharp
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Flutter Authors. All rights reserved.
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 


### PR DESCRIPTION
Close issue pages that have been inactive for more than 60 days.
but do not close issues that have a "bug", "enhancement" or "keep" label.

+) And add license information.