### PR TITLE
Add `isTvProfile` and `isTizenProfile` APIs that can check Tizen Profile

### DIFF
--- a/packages/flutter_tizen/CHANGELOG.md
+++ b/packages/flutter_tizen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+* Add `isTvProfile` and `isTizenProfile` APIs that can check Tizen Profile.
+
 ## 0.2.4
 
 * Add apiVersion to flutter-tizen.dart.

--- a/packages/flutter_tizen/example/lib/main.dart
+++ b/packages/flutter_tizen/example/lib/main.dart
@@ -11,6 +11,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  String _tizenProfile = 'Unknown';
   String _isTizen = 'Unknown';
   String _apiVersion = 'Unknown';
 
@@ -18,6 +19,7 @@ class _MyAppState extends State<MyApp> {
   initState() {
     super.initState();
     setState(() {
+      _tizenProfile = isTvProfile ? 'TV' : (isTizenProfile ? 'Tizen' : 'Unknown');
       _isTizen = isTizen.toString();
       _apiVersion = apiVersion;
     });
@@ -37,6 +39,7 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               Text('isTizen : $_isTizen\n'),
               Text('apiVersion : $_apiVersion\n'),
+              Text('Profile : $_tizenProfile\n'),
             ],
           ),
         ),

--- a/packages/flutter_tizen/lib/flutter_tizen.dart
+++ b/packages/flutter_tizen/lib/flutter_tizen.dart
@@ -4,6 +4,18 @@
 
 import 'dart:io';
 
+/// Whether the current profile is TV profile.
+bool get isTvProfile {
+  return Platform.environment['ELM_PROFILE'] == 'tv';
+}
+
+// TODO(jsuya): With Tizen Studio 5.5, the 'Common' profile is now called the 'Tizen' profile.
+// https://developer.tizen.org/blog/announcing-tizen-studio-5.5-release
+/// Whether the current profile is Tizen profile.
+bool get isTizenProfile {
+  return Platform.environment['ELM_PROFILE'] == 'common';
+}
+
 /// Whether the current operating system is Tizen.
 bool get isTizen {
   return Platform.environment.containsKey('TIZEN_API_VERSION');
@@ -13,5 +25,5 @@ bool get isTizen {
 ///
 /// If the operating system is not Tizen, return "none".
 String get apiVersion {
-  return Platform.environment['TIZEN_API_VERSION'] ?? "none";
+  return Platform.environment['TIZEN_API_VERSION'] ?? 'none';
 }

--- a/packages/flutter_tizen/pubspec.yaml
+++ b/packages/flutter_tizen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tizen
 description: Tizen utilities for Dart and Flutter.
-version: 0.2.4
+version: 0.2.5
 homepage: https://github.com/flutter-tizen/flutter-tizen/tree/master/packages/flutter_tizen
 
 environment:


### PR DESCRIPTION
isTizenProfile is a profile based on RPI and emulator, formerly known as common profile.
Starting with Tizen Studio 5.5 , Common profile has been changed to Tizen profile.
(https://developer.tizen.org/blog/announcing-tizen-studio-5.5-release)
