### PR TITLE
Add --enable-flutter-gpu flag

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -400,6 +400,7 @@ class TizenDevice extends Device {
       if (debuggingOptions.endlessTraceBuffer) '--endless-trace-buffer',
       if (debuggingOptions.purgePersistentCache) '--purge-persistent-cache',
       if (debuggingOptions.enableImpeller == ImpellerStatus.enabled) '--enable-impeller',
+      if (debuggingOptions.enableFlutterGpu) '--enable-flutter-gpu',
       if (debuggingOptions.enableVulkanValidation) '--enable-vulkan-validation',
       if (debuggingOptions.debuggingEnabled) ...<String>[
         '--enable-checked-mode',


### PR DESCRIPTION
Enable support for the --enable-flutter-gpu flag.
`flutter-tizen run --enable-flutter-gpu`

+) This does not apply when re-launching an already installed app. So we need adding a metadata key or a separate value