### PR TITLE
Support native-assets build with hooks package

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/build_system/targets/android.dart';
 import 'package:flutter_tools/src/build_system/targets/assets.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/icon_tree_shaker.dart';
+import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:package_config/src/package_config.dart';
@@ -126,6 +127,7 @@ abstract class TizenAssetBundle extends Target {
   @override
   List<Target> get dependencies => const <Target>[
         TizenKernelSnapshot(),
+        InstallCodeAssets(),
       ];
 
   @override


### PR DESCRIPTION
Supports the `native-assets` feature using the [hooks](https://pub.dev/packages/hooks) package.
(For versions prior to 3.35, [native_assets_cli](https://pub.dev/packages/native_assets_cli) was available, but is currently discontinued.)
The hooks package is supported from 3.35 and it is currently in preview. Therefore, there may be changes to related features in the future.

commands:
flutter-tizen config --enable-native-assets
flutter-tizen config --no-enable-native-assets