### PR TITLE
Change ui thread policy to SeparateThread

### DIFF
--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -61,7 +61,8 @@ FlutterEngine::FlutterEngine(
 
   engine_prop.dart_entrypoint_argc = entrypoint_args.size();
   engine_prop.dart_entrypoint_argv = entrypoint_args.data();
-  engine_prop.ui_thread_policy = FlutterDesktopUIThreadPolicy::kDefault;
+  engine_prop.ui_thread_policy =
+      FlutterDesktopUIThreadPolicy::kRunOnSeparateThread;
 
   engine_ = FlutterDesktopEngineCreate(engine_prop);
 }

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -46,7 +46,7 @@ namespace Tizen.Flutter.Embedding
                     entrypoint = dartEntrypoint,
                     dart_entrypoint_argc = entrypointArgs.Length,
                     dart_entrypoint_argv = entrypointArgs.Handle,
-                    ui_thread_policy = FlutterDesktopUIThreadPolicy.kDefault,
+                    ui_thread_policy = FlutterDesktopUIThreadPolicy.kRunOnSeparateThread,
                 };
 
                 Engine = FlutterDesktopEngineCreate(ref engineProperties);


### PR DESCRIPTION
This commit reverts part of #678.
The default value of UI thread policy on other platforms(such as Linux) is PlatformThread(merged thread). Since most examples(plugins) on Tizen worked without any issues, we applied the same policy. However, an issue was discovered in `tizen_interop_callbacks`. A thread error occurred even when calling blocking APIs from an isolate. While improvements are needed for the tizen_interop_callbacks package, we will first apply a hotfix to revert to the previous UI thread policy. This patch may be reverted once the issue is resolved.