### PR TITLE
Add vulkan renderer type

### DIFF
--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -18,6 +18,8 @@
 enum class FlutterRendererType {
   // The renderer based on EGL.
   kEGL,
+  // The renderer based on Vulkan.
+  kEVulkan,
 };
 
 // The app base class for headed Flutter execution.

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -18,6 +18,10 @@ namespace Tizen.Flutter.Embedding
         /// The renderer based on EGL.
         /// </summary>
         EGL,
+        /// <summary>
+        /// The renderer based on Vulkan.
+        /// </summary>
+        EVulkan,
     }
 
     /// <summary>
@@ -147,6 +151,11 @@ namespace Tizen.Flutter.Embedding
             if (Engine.Arguments.IsFlutterGpuEnabled && !Engine.Arguments.IsImpellerEnabled)
             {
                 throw new Exception("flutter_gpu requires Impeller. Enable Impeller using the --enable-impeller flag.");
+            }
+
+            if (RendererType == FlutterRendererType.EVulkan && !Engine.Arguments.IsFlutterTizenExperimentalEnabled)
+            {
+                throw new Exception("Vulkan renderer requires USE_FLUTTER_TIZEN_EXPERIMENTAL. Enable flutter tizen experimental using the --dart-define=USE_FLUTTER_TIZEN_EXPERIMENTAL=true.");
             }
 
             var daliApp = ApplicationNewManual4(0, "", "", 1 /* transparent */);

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngineArguments.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngineArguments.cs
@@ -33,6 +33,11 @@ namespace Tizen.Flutter.Embedding
         public bool IsFlutterGpuEnabled { get; private set; } = false;
 
         /// <summary>
+        /// Gets whether the flutter tizen experimental is enabled or not.
+        /// </summary>
+        public bool IsFlutterTizenExperimentalEnabled { get; private set; } = false;
+
+        /// <summary>
         /// Creates a <see cref="FlutterEngineArguments"/> instance and parses engine arguments.
         /// </summary>
         public FlutterEngineArguments()
@@ -68,6 +73,7 @@ namespace Tizen.Flutter.Embedding
 
             IsImpellerEnabled = ProcessMetadataFlag(result, "--enable-impeller", MetadataKeyEnableImepeller);
             IsFlutterGpuEnabled = ProcessMetadataFlag(result, "--enable-flutter-gpu", MetadataKeyEnableFlutterGpu);
+            IsFlutterTizenExperimentalEnabled = result.Contains("--dart-define=USE_FLUTTER_TIZEN_EXPERIMENTAL=true");
 
             foreach (string flag in result)
             {

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -418,6 +418,8 @@ class TizenDevice extends Device {
         '--tizen-logging-port',
         logReader.hostPort.toString(),
       ],
+      if (debuggingOptions.buildInfo.dartDefines.contains('$kUseFlutterTizenExperimental=true'))
+        '--dart-define=$kUseFlutterTizenExperimental=true',
     ];
 
     // Pass engine arguments to the app by writing to a temporary file.


### PR DESCRIPTION
Add `EVulkan` to `RendererType`.
`EVulkan` is currently an experimental feature and requires including the `USE_FLUTTER_TIZEN_EXPERIMENTAL=true` flag in the run command via `--dart-define`.

tizen/App.cs
```cs
RendererType = FlutterRendererType.EVulkan;
```
command
```
flutter-tizen run --enable-impeller --dart-define=USE_FLUTTER_TIZEN_EXPERIMENTAL=true
```

https://github.com/flutter-tizen/embedder/pull/110
