### PR TITLE
Fix dart analyze issues for flutter_tizen package

### DIFF
--- a/packages/flutter_tizen/.gitignore
+++ b/packages/flutter_tizen/.gitignore
@@ -28,3 +28,10 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+
+# Tizen Core CLI (tz) related files
+tizen_dotnet_project.yaml
+*.csproj.backup
+
+# Flutter-tizen dependency information file
+.app.deps.json

--- a/packages/flutter_tizen/CHANGELOG.md
+++ b/packages/flutter_tizen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7
+
+* Fix dart analyze issues.
+
 ## 0.2.6
 
 * Update readme.md.

--- a/packages/flutter_tizen/README.md
+++ b/packages/flutter_tizen/README.md
@@ -12,7 +12,7 @@ To use this package, add `flutter_tizen` as a dependency in your `pubspec.yaml` 
 
 ```yaml
 dependencies:
-  flutter_tizen: ^0.2.6
+  flutter_tizen: ^0.2.7
 ```
 
 ### Checking Tizen environment

--- a/packages/flutter_tizen/example/.gitignore
+++ b/packages/flutter_tizen/example/.gitignore
@@ -39,3 +39,10 @@ app.*.symbols
 
 # Obfuscation related
 app.*.map.json
+
+# Tizen Core CLI (tz) related files
+tizen_dotnet_project.yaml
+*.csproj.backup
+
+# Flutter-tizen dependency information file
+.app.deps.json

--- a/packages/flutter_tizen/example/lib/main.dart
+++ b/packages/flutter_tizen/example/lib/main.dart
@@ -1,3 +1,9 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 import 'package:flutter_tizen/flutter_tizen.dart';
 
@@ -11,12 +17,12 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String _tizenProfile = 'Unknown';
-  String _isTizen = 'Unknown';
-  String _apiVersion = 'Unknown';
+  var _tizenProfile = 'Unknown';
+  var _isTizen = 'Unknown';
+  var _apiVersion = 'Unknown';
 
   @override
-  initState() {
+  void initState() {
     super.initState();
     setState(() {
       _tizenProfile = isTvProfile ? 'TV' : (isTizenProfile ? 'Tizen' : 'Unknown');
@@ -35,7 +41,6 @@ class _MyAppState extends State<MyApp> {
         body: SizedBox.expand(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               Text('isTizen : $_isTizen\n'),
               Text('apiVersion : $_apiVersion\n'),

--- a/packages/flutter_tizen/lib/src/rendering/platform_view.dart
+++ b/packages/flutter_tizen/lib/src/rendering/platform_view.dart
@@ -47,7 +47,7 @@ class RenderTizenView extends PlatformViewRenderBox {
 
   Size? _currentTextureSize;
 
-  bool _isDisposed = false;
+  var _isDisposed = false;
 
   @override
   TextureTizenViewController get controller => _viewController;
@@ -164,7 +164,7 @@ class RenderTizenView extends PlatformViewRenderBox {
     _paintTexture(context, offset);
   }
 
-  final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();
+  final _clipRectLayer = LayerHandle<ClipRectLayer>();
 
   @override
   void dispose() {

--- a/packages/flutter_tizen/lib/src/services/platform_views.dart
+++ b/packages/flutter_tizen/lib/src/services/platform_views.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, comment_references
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -48,8 +48,7 @@ abstract class TizenViewController extends PlatformViewController {
 
   final MessageCodec<dynamic>? _creationParamsCodec;
 
-  final List<PlatformViewCreatedCallback> _platformViewCreatedCallbacks =
-      <PlatformViewCreatedCallback>[];
+  final _platformViewCreatedCallbacks = <PlatformViewCreatedCallback>[];
 
   Future<void> _sendDisposeMessage();
 
@@ -140,7 +139,7 @@ abstract class TizenViewController extends PlatformViewController {
       return;
     }
 
-    int eventType = 0;
+    var eventType = 0;
     if (event is PointerDownEvent) {
       eventType = 0;
     } else if (event is PointerMoveEvent) {
@@ -151,7 +150,7 @@ abstract class TizenViewController extends PlatformViewController {
       throw UnimplementedError('Not Implemented');
     }
 
-    final Map<String, dynamic> args = <String, dynamic>{
+    final args = <String, dynamic>{
       'id': viewId,
       'event': <dynamic>[
         eventType,
@@ -260,7 +259,7 @@ class TextureTizenViewController extends TizenViewController {
     assert(!size.isEmpty,
         'trying to create $TextureTizenViewController without setting a valid size.');
 
-    final Map<String, dynamic> args = <String, dynamic>{
+    final args = <String, dynamic>{
       'id': viewId,
       'viewType': _viewType,
       'width': size.width,
@@ -298,16 +297,15 @@ class PlatformViewsServiceTizen {
   PlatformViewsServiceTizen._() {
     SystemChannels.platform_views.setMethodCallHandler(_onMethodCall);
   }
-  static final PlatformViewsServiceTizen _instance = PlatformViewsServiceTizen._();
+  static final _instance = PlatformViewsServiceTizen._();
 
   Future<void> _onMethodCall(MethodCall call) {
     switch (call.method) {
       case 'viewFocused':
-        final int id = call.arguments as int;
+        final id = call.arguments as int;
         if (_focusCallbacks.containsKey(id)) {
           _focusCallbacks[id]!();
         }
-        break;
       default:
         throw UnimplementedError(
             "${call.method} was invoked but isn't implemented by PlatformViewsService");
@@ -315,7 +313,7 @@ class PlatformViewsServiceTizen {
     return Future<void>.value();
   }
 
-  final Map<int, VoidCallback> _focusCallbacks = <int, VoidCallback>{};
+  final _focusCallbacks = <int, VoidCallback>{};
 
   static TextureTizenViewController initTizenView({
     required int id,
@@ -330,7 +328,7 @@ class PlatformViewsServiceTizen {
     assert(layoutDirection != null);
     assert(creationParams == null || creationParamsCodec != null);
 
-    final TextureTizenViewController controller = TextureTizenViewController._(
+    final controller = TextureTizenViewController._(
       viewId: id,
       viewType: viewType,
       layoutDirection: layoutDirection,

--- a/packages/flutter_tizen/lib/src/widgets/platform_view.dart
+++ b/packages/flutter_tizen/lib/src/widgets/platform_view.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, comment_references
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -52,11 +52,10 @@ class _TizenViewState extends State<TizenView> {
   int? _id;
   late TextureTizenViewController _controller;
   TextDirection? _layoutDirection;
-  bool _initialized = false;
+  var _initialized = false;
   FocusNode? _focusNode;
 
-  static final Set<Factory<OneSequenceGestureRecognizer>> _emptyRecognizersSet =
-      <Factory<OneSequenceGestureRecognizer>>{};
+  static final _emptyRecognizersSet = <Factory<OneSequenceGestureRecognizer>>{};
 
   @override
   Widget build(BuildContext context) {
@@ -85,7 +84,7 @@ class _TizenViewState extends State<TizenView> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final TextDirection newLayoutDirection = _findLayoutDirection();
-    final bool didChangeLayoutDirection = _layoutDirection != newLayoutDirection;
+    final didChangeLayoutDirection = _layoutDirection != newLayoutDirection;
     _layoutDirection = newLayoutDirection;
 
     _initializeOnce();
@@ -99,7 +98,7 @@ class _TizenViewState extends State<TizenView> {
     super.didUpdateWidget(oldWidget);
 
     final TextDirection newLayoutDirection = _findLayoutDirection();
-    final bool didChangeLayoutDirection = _layoutDirection != newLayoutDirection;
+    final didChangeLayoutDirection = _layoutDirection != newLayoutDirection;
     _layoutDirection = newLayoutDirection;
 
     if (widget.viewType != oldWidget.viewType) {

--- a/packages/flutter_tizen/pubspec.yaml
+++ b/packages/flutter_tizen/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_tizen
 description: Tizen utilities for Dart and Flutter.
-homepage: https://github.com/flutter-tizen/flutter-tizen/
-repository: https://github.com/flutter-tizen/flutter-tizen/tree/master/packages/flutter_tizen
-version: 0.2.6
+homepage: https://github.com/flutter-tizen/
+repository: https://github.com/flutter-tizen/flutter-tizen/
+version: 0.2.7
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
- Update gitignore
- Fix dart analyze issues
  - example/lib/main.dart
    - always_declare_return_types • 1 fix
    - avoid_redundant_argument_values • 1 fix
    - omit_obvious_property_types • 3 fixes
  - lib/src/rendering/platform_view.dart
    - omit_obvious_property_types • 2 fixes
  - lib/src/services/platform_views.dart
    - omit_obvious_local_variable_types • 5 fixes
    - omit_obvious_property_types • 3 fixes
    - unnecessary_breaks • 1 fix
  - lib/src/widgets/platform_view.dart
    - omit_obvious_local_variable_types • 2 fixes
    - omit_obvious_property_types • 2 fixes
