### PR TITLE
Modify device list of run command to fit Tizen

### DIFF
--- a/lib/commands/run.dart
+++ b/lib/commands/run.dart
@@ -2,11 +2,82 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/commands/run.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/runner/target_devices.dart';
 
 import '../tizen_cache.dart';
+import '../tizen_device.dart';
 import '../tizen_plugins.dart';
 
 class TizenRunCommand extends RunCommand with DartPluginRegistry, TizenRequiredArtifacts {
   TizenRunCommand({super.verboseHelp});
+
+  @override
+  Future<List<Device>?> findAllTargetDevices({
+    bool includeDevicesUnsupportedByProject = false,
+  }) async {
+    final tizenDeviceLogger = TizenDeviceLogger(
+      logger: globals.logger,
+      deviceManager: globals.deviceManager!,
+    );
+    return TargetDevices(
+      deviceManager: globals.deviceManager!,
+      logger: tizenDeviceLogger,
+      deviceConnectionInterface: deviceConnectionInterface,
+      platform: globals.platform,
+    ).findAllTargetDevices(
+      deviceDiscoveryTimeout: deviceDiscoveryTimeout,
+      includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+    );
+  }
+}
+
+/// A [Logger] that fixes the device information for Tizen devices.
+class TizenDeviceLogger extends DelegatingLogger {
+  TizenDeviceLogger({
+    required Logger logger,
+    required DeviceManager deviceManager,
+  })  : _deviceManager = deviceManager,
+        super(logger);
+
+  final DeviceManager _deviceManager;
+
+  @override
+  Future<void> printStatus(
+    String message, {
+    bool? emphasis,
+    TerminalColor? color,
+    bool? newline,
+    int? indent,
+    int? hangingIndent,
+    bool? wrap,
+  }) async {
+    for (final Device device in await _deviceManager.getDevices()) {
+      if (device is TizenDevice) {
+        if (message.contains(device.name) && message.contains('Tizen')) {
+          message = message
+              .replaceFirst('(${Category.mobile})',
+                  '(${device.deviceProfile})${device.deviceProfile == 'tv' ? '    ' : ''}')
+              .replaceFirst(
+                getNameForTargetPlatform(TargetPlatform.tester),
+                'tizen-${device.architecture}${device.architecture == 'arm64' ? '   ' : '     '}',
+              );
+        }
+      }
+    }
+    super.printStatus(
+      message,
+      emphasis: emphasis,
+      color: color,
+      newline: newline,
+      indent: indent,
+      hangingIndent: hangingIndent,
+      wrap: wrap,
+    );
+  }
 }


### PR DESCRIPTION
Modify that the list output when executing the `flutter-tizen run` command correctly displays Tizen device information, similar to `flutter-tizen devices`.(https://github.com/flutter-tizen/flutter-tizen/pull/701)

[before]
```
$ flutter-tizen run
Connected devices:
IM H091 (mobile)             • H09124J1G04564       • android-arm64  • Android 14 (API 34)
Linux (desktop)              • linux                • linux-x64      • Ubuntu 22.04.5 LTS 6.8.0-87-generic
Chrome (web)                 • chrome               • web-javascript • Google Chrome 142.0.7444.175
Tizen QBQ70 (mobile)         • xx.xxx.xxx.xx:xxxxx • flutter-tester • Tizen 9.0
Tizen rpi4 (mobile)          • xx.xxx.xxx.xx:xxxxx  • flutter-tester • Tizen 10.0
Tizen T-9.0-x86 (mobile)     • emulator-26111       • flutter-tester • Tizen 9.0 (emulator)
Tizen T-10.0-x86_64 (mobile) • emulator-26101       • flutter-tester • Tizen 10.0 (emulator)
[1]: IM H091 (H09124J1G04564)
[2]: Linux (linux)
[3]: Chrome (chrome)
[4]: Tizen QBQ70 (xx.xxx.xxx.xx:xxxxx)
[5]: Tizen rpi4 (xx.xxx.xxx.xx:xxxxx)
[6]: Tizen T-9.0-x86 (emulator-26111)
[7]: Tizen T-10.0-x86_64 (emulator-26101)

```
[after]
```
$ flutter-tizen run
Connected devices:
IM H091 (mobile)             • H09124J1G04564       • android-arm64  • Android 14 (API 34)
Linux (desktop)              • linux                • linux-x64      • Ubuntu 22.04.5 LTS 6.8.0-87-generic
Chrome (web)                 • chrome               • web-javascript • Google Chrome 142.0.7444.175
Tizen QBQ70 (tv)             • xx.xxx.xxx.xx:xxxxx • tizen-arm      • Tizen 9.0
Tizen rpi4 (common)          • xx.xxx.xxx.xx:xxxxx  • tizen-arm64    • Tizen 10.0
Tizen T-9.0-x86 (common)     • emulator-26111       • tizen-x86      • Tizen 9.0 (emulator)
Tizen T-10.0-x86_64 (common) • emulator-26101       • tizen-x64      • Tizen 10.0 (emulator)
[1]: IM H091 (H09124J1G04564)
[2]: Linux (linux)
[3]: Chrome (chrome)
[4]: Tizen QBQ70 (xx.xxx.xxx.xx:xxxxx)
[5]: Tizen rpi4 (xx.xxx.xxx.xx:xxxxx)
[6]: Tizen T-9.0-x86 (emulator-26111)
[7]: Tizen T-10.0-x86_64 (emulator-26101)
Please choose one (or "q" to quit):
```

+) https://github.com/flutter-tizen/flutter-tizen/pull/707