### PR TITLE
Fix error message when building x64 on API version < 8.0

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -305,6 +305,10 @@ class TizenSdk {
       throwToolExit('Not supported API version: $apiVersion');
     }
 
+    if (versionToDouble(apiVersion) < 8.0 && arch == 'x64') {
+      throwToolExit('x64 is not supported with API version < 8.0.');
+    }
+
     switch (profile) {
       case 'common':
         if (versionToDouble(apiVersion) >= 8.0) {


### PR DESCRIPTION
When building x64, if the API version is < 8.0, an incorrect installation guidance message is output.

[before]
```
exception:Error: The rootstrap iot-headed-6.0-emulator64.core could not be found. To install missing package(s), run:
~/.tizen-extension-platform/server/sdktools/data/package-manager/package-manager-cli.bin install IOT-Headed-6.0-NativeAppDevelopment-CLI
```

[after]
```
exception:Error: x64 is not supported with API version < 8.0.
```