### PR TITLE
Change screenshot command as unsupported command

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -200,18 +200,6 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   flutter-tizen run --start-paused
   ```
 
-- ### `screenshot`
-
-  Take a screenshot from a connected device.
-
-  ```sh
-  flutter-tizen screenshot --type rasterizer --vm-service-url http://127.0.0.1:43000/Swm0bjIe0ks=/
-  ```
-
-  Both `--type` and `--vm-service-url` must be provided because the default (`device`) screenshot type is not supported by Tizen devices. The VM Service URL can be obtained from the device log output (`flutter-tizen run` or `sdb dlog ConsoleMessage`) after launching an app in either debug or profile mode.
-
-  If you're using a watch device, you can also take a screenshot by swiping the screen from left to right while pressing the Home button.
-
 - ### `symbolize`
 
   Symbolize a stack trace from a Flutter app which has been built with the `--split-debug-info` option.
@@ -242,4 +230,5 @@ The following commands from the Flutter CLI are not supported by flutter-tizen.
 - `custom-devices`
 - `downgrade`
 - `logs`
+- `screenshot`
 - `upgrade`

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -26,7 +26,6 @@ import 'package:flutter_tools/src/commands/emulators.dart';
 import 'package:flutter_tools/src/commands/generate_localizations.dart';
 import 'package:flutter_tools/src/commands/install.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
-import 'package:flutter_tools/src/commands/screenshot.dart';
 import 'package:flutter_tools/src/commands/symbolize.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -123,7 +122,6 @@ Future<void> main(List<String> args) async {
       ),
       InstallCommand(verboseHelp: verboseHelp),
       PackagesCommand(),
-      ScreenshotCommand(fs: globals.fs),
       SymbolizeCommand(stdio: globals.stdio, fileSystem: globals.fs),
       // Commands extended for Tizen.
       TizenAttachCommand(


### PR DESCRIPTION
The screenshot command for the rasterizer type was removed in PR (https://github.com/flutter/flutter/pull/135462).
This patch changes that command to an unsupported one.