### PR TITLE
Support -? and /? help aliases

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -73,6 +73,16 @@ Future<void> main(List<String> args) async {
   final bool verbose = args.contains('-v') || args.contains('--verbose') || veryVerbose;
   final bool prefixedErrors = args.contains('--prefixed-errors');
 
+  // Support universal help idioms.
+  final int powershellHelpIndex = args.indexOf('-?');
+  if (powershellHelpIndex != -1) {
+    args[powershellHelpIndex] = '-h';
+  }
+  final int slashQuestionHelpIndex = args.indexOf('/?');
+  if (slashQuestionHelpIndex != -1) {
+    args[slashQuestionHelpIndex] = '-h';
+  }
+
   final bool doctor = (args.isNotEmpty && args.first == 'doctor') ||
       (args.length == 2 && verbose && args.last == 'doctor');
   final bool help = args.contains('-h') ||


### PR DESCRIPTION
Translate PowerShell-style help flags (-?, /?) into -h to match upstream flutter_tools behavior.

https://github.com/flutter/flutter/pull/172328