### PR TITLE
Prevent blocking in Inspector pub root registration

### DIFF
--- a/lib/forwarding_log_reader.dart
+++ b/lib/forwarding_log_reader.dart
@@ -57,6 +57,8 @@ class ForwardingLogReader extends DeviceLogReader {
   static const _inspectorPubRootDirectoriesExtensionName =
       'ext.flutter.inspector.addPubRootDirectories';
 
+  static const _kInspectorFindIsolateTimeout = Duration(seconds: 3);
+
   // For Inspector pub root registration on hot restart
   StreamSubscription<vm_service.Event>? _isolateEventSubscription;
 
@@ -221,7 +223,7 @@ class ForwardingLogReader extends DeviceLogReader {
     try {
       final String? maybeIsolateId = (await vmService
               .findExtensionIsolate(_inspectorPubRootDirectoriesExtensionName)
-              .timeout(const Duration(seconds: 3)))
+              .timeout(_kInspectorFindIsolateTimeout))
           .id;
 
       if (maybeIsolateId case final isolateId?) {


### PR DESCRIPTION
Add timeout to findExtensionIsolate call and use unawaited to avoid blocking the device log reader. This ensures the app doesn't freeze when DevTools Inspector fails to respond or times out.

- Add 3-second timeout to findExtensionIsolate VM service call
- Wrap _setupInspectorPubRootRegistration with unawaited to avoid awaiting the Future