### PR TITLE
Fix Tizen native asset hook target OS

### DIFF
--- a/lib/build_targets/native_assets.dart
+++ b/lib/build_targets/native_assets.dart
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:code_assets/code_assets.dart';
+import 'package:data_assets/data_assets.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -12,10 +14,11 @@ import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
-import 'package:flutter_tools/src/isolated/native_assets/linux/native_assets.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
-import 'package:flutter_tools/src/isolated/native_assets/targets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:hooks_runner/hooks_runner.dart' as native;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
@@ -34,8 +37,6 @@ class TizenDartBuild extends Target {
   @override
   Future<void> build(Environment environment) async {
     final FileSystem fileSystem = environment.fileSystem;
-    final DartHooksResult result;
-
     final TargetPlatform targetPlatform =
         specifiedTargetPlatform ?? _getTargetPlatformFromEnvironment(environment, name);
 
@@ -64,7 +65,7 @@ class TizenDartBuild extends Target {
     final buildMode = BuildMode.fromCliName(buildModeEnvironment);
     final bool includeDevDependencies = !buildMode.isRelease;
     final FlutterNativeAssetsBuildRunner buildRunner = _buildRunner ??
-        TizenFlutterNativeAssetsBuildRunnerImpl(
+        FlutterNativeAssetsBuildRunnerImpl(
           environment.packageConfigPath,
           packageConfig,
           fileSystem,
@@ -73,12 +74,12 @@ class TizenDartBuild extends Target {
           includeDevDependencies: includeDevDependencies,
           pubspecPath,
         );
-    result = await runFlutterSpecificHooks(
-      environmentDefines: environment.defines,
+    final DartHooksResult result = await _runTizenSpecificHooks(
       buildRunner: buildRunner,
       targetPlatform: targetPlatform,
       projectUri: projectUri,
       fileSystem: fileSystem,
+      buildMode: buildMode,
     );
     final File dartHookResultJsonFile = environment.buildDir.childFile(dartHookResultFilename);
     if (!dartHookResultJsonFile.parent.existsSync()) {
@@ -219,27 +220,107 @@ TargetPlatform _getTargetPlatformFromEnvironment(Environment environment, String
   return getTargetPlatformForName(targetPlatformEnvironment);
 }
 
-class TizenFlutterNativeAssetsBuildRunnerImpl extends FlutterNativeAssetsBuildRunnerImpl {
-  TizenFlutterNativeAssetsBuildRunnerImpl(
-    super.packageConfigPath,
-    super.packageConfig,
-    super.fileSystem,
-    super.logger,
-    super.runPackageName,
-    super.pubspecPath, {
-    required super.includeDevDependencies,
-  });
+Future<DartHooksResult> _runTizenSpecificHooks({
+  required FlutterNativeAssetsBuildRunner buildRunner,
+  required TargetPlatform targetPlatform,
+  required Uri projectUri,
+  required FileSystem fileSystem,
+  required BuildMode buildMode,
+}) async {
+  final Directory buildDir = fileSystem.directory(nativeAssetsBuildUri(projectUri, OS.linux.name));
+  if (!buildDir.existsSync()) {
+    buildDir.createSync(recursive: true);
+  }
 
-  // TODO(JSUYA): Tizen uses Android's arm and arm64 TargetPlatforms. This caused the native_asset
-  // of flutter_tools to recognize the TargetOS as Android and use the NDK CCompiler. So, I added
-  // TizenFlutterNativeAssetsBuildRunnerImpl to modify the NativeAssetBuilder to use the Linux
-  // CCompiler(Tizen embedder) even when the asset is Android.
-  @override
-  Future<void> setCCompilerConfig(CodeAssetTarget target) async {
-    if (target is AndroidAssetTarget) {
-      target.cCompilerConfigSync = await cCompilerConfigLinux(throwIfNotFound: true);
-    } else {
-      await target.setCCompilerConfig();
+  final List<String> packagesWithNativeAssets = await buildRunner.packagesWithNativeAssets();
+  if (packagesWithNativeAssets.isEmpty) {
+    return DartHooksResult.empty();
+  }
+  if (!featureFlags.isNativeAssetsEnabled && !featureFlags.isDartDataAssetsEnabled) {
+    throwToolExit(
+      'Package(s) ${packagesWithNativeAssets.join(' ')} require the dart assets feature to be enabled.\n'
+      '  Enable code assets using `flutter-tizen config --enable-native-assets`.\n'
+      '  Enable data assets using `flutter-tizen config --enable-dart-data-assets`.',
+    );
+  }
+
+  final Architecture architecture = _getTizenNativeArchitecture(targetPlatform);
+  // Do not call setCCompilerConfig here. Flutter's Linux compiler discovery
+  // would return a host compiler, not a Tizen rootstrap-aware compiler.
+  final extensions = <ProtocolExtension>[
+    if (featureFlags.isNativeAssetsEnabled)
+      CodeAssetExtension(
+        targetArchitecture: architecture,
+        linkModePreference: LinkModePreference.dynamic,
+        targetOS: OS.linux,
+      ),
+    if (featureFlags.isDartDataAssetsEnabled) DataAssetsExtension(),
+  ];
+  final linkingEnabled = buildMode != BuildMode.debug;
+  final buildStart = DateTime.now();
+
+  final native.BuildResult? buildResult =
+      await buildRunner.build(extensions: extensions, linkingEnabled: linkingEnabled);
+  if (buildResult == null) {
+    throwToolExit('Building native assets failed. See the logs for more details.');
+  }
+
+  native.LinkResult? linkResult;
+  if (linkingEnabled) {
+    linkResult = await buildRunner.link(extensions: extensions, buildResult: buildResult);
+    if (linkResult == null) {
+      throwToolExit('Linking native assets failed. See the logs for more details.');
     }
   }
+
+  final target = native.Target.fromArchitectureAndOS(architecture, OS.linux);
+  final encodedAssets = <EncodedAsset>[
+    ...buildResult.encodedAssets,
+    if (linkResult != null) ...linkResult.encodedAssets,
+  ];
+  final codeAssets = <FlutterCodeAsset>[
+    for (final EncodedAsset asset in encodedAssets)
+      if (asset.isCodeAsset) FlutterCodeAsset(codeAsset: asset.asCodeAsset, target: target),
+  ];
+  final dataAssets = <DataAsset>[
+    for (final EncodedAsset asset in encodedAssets)
+      if (asset.isDataAsset) DataAsset.fromEncoded(asset),
+  ];
+  if (dataAssets.map((DataAsset asset) => asset.id).toSet().length != dataAssets.length) {
+    throwToolExit(
+      'Found duplicates in the data assets: '
+      '${dataAssets.map((DataAsset asset) => asset.id).toList()} '
+      'while compiling for linux_${architecture.name}.',
+    );
+  }
+  if (codeAssets.toSet().length != codeAssets.length) {
+    throwToolExit(
+      'Found duplicates in the code assets: '
+      '${codeAssets.map((FlutterCodeAsset asset) => asset.codeAsset.id).toList()} '
+      'while compiling for linux_${architecture.name}.',
+    );
+  }
+
+  return DartHooksResult(
+    buildStart: buildStart,
+    buildEnd: DateTime.now(),
+    codeAssets: codeAssets,
+    dataAssets: dataAssets,
+    dependencies: <Uri>{
+      ...buildResult.dependencies,
+      if (linkResult != null) ...linkResult.dependencies,
+    }.toList(),
+  );
+}
+
+/// Tizen reuses Flutter's Android/tester target platforms as architecture
+/// aliases. Dart hooks must see the actual Tizen runtime OS, which is Linux.
+Architecture _getTizenNativeArchitecture(TargetPlatform targetPlatform) {
+  return switch (targetPlatform) {
+    TargetPlatform.android_arm => Architecture.arm,
+    TargetPlatform.android_arm64 => Architecture.arm64,
+    TargetPlatform.android_x64 => Architecture.x64,
+    TargetPlatform.tester => Architecture.ia32,
+    _ => throwToolExit('Native assets are not supported for $targetPlatform on Tizen.'),
+  };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,14 @@ environment:
 dependencies:
   analyzer:
   archive:
+  code_assets:
+  data_assets:
   fake_async:
   flutter_tools:
     path: flutter/packages/flutter_tools
   file:
+  hooks:
+  hooks_runner:
   http:
   meta:
   package_config:

--- a/test/general/build_targets/native_assets_test.dart
+++ b/test/general/build_targets/native_assets_test.dart
@@ -1,0 +1,159 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:code_assets/code_assets.dart';
+import 'package:data_assets/data_assets.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/build_targets/native_assets.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
+import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:hooks_runner/hooks_runner.dart' as native;
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fakes.dart';
+import '../../src/package_config.dart';
+
+void main() {
+  late FileSystem fileSystem;
+  late FakeProcessManager processManager;
+  late Logger logger;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    processManager = FakeProcessManager.any();
+    logger = BufferLogger.test();
+  });
+
+  const cases = <String, Architecture>{
+    'android-arm': Architecture.arm,
+    'android-arm64': Architecture.arm64,
+    'android-x64': Architecture.x64,
+    'flutter-tester': Architecture.ia32,
+  };
+
+  for (final MapEntry<String, Architecture> entry in cases.entries) {
+    testUsingContext('Tizen hooks use Linux OS for ${entry.key}', () async {
+      final Directory projectDir = fileSystem.currentDirectory;
+      writePackageConfigFiles(directory: projectDir, mainLibName: 'my_app');
+      final environment = Environment.test(
+        projectDir,
+        defines: <String, String>{
+          kBuildMode: 'debug',
+          kTargetPlatform: entry.key,
+        },
+        fileSystem: fileSystem,
+        logger: logger,
+        artifacts: Artifacts.test(),
+        processManager: processManager,
+      );
+      final runner = _RecordingRunner();
+
+      await TizenDartBuild(buildRunner: runner).build(environment);
+
+      final CodeAssetExtension codeExtension =
+          runner.extensions!.whereType<CodeAssetExtension>().single;
+      expect(codeExtension.targetOS, OS.linux);
+      expect(codeExtension.targetArchitecture, entry.value);
+      expect(codeExtension.android, isNull);
+      expect(runner.setCCompilerConfigCalls, 0);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
+      ProcessManager: () => processManager,
+    });
+  }
+
+  testUsingContext('Tizen hooks preserve data assets when enabled', () async {
+    final Directory projectDir = fileSystem.currentDirectory;
+    writePackageConfigFiles(directory: projectDir, mainLibName: 'my_app');
+    final File dataFile = projectDir.childFile('data.txt')..writeAsStringSync('data');
+    final environment = Environment.test(
+      projectDir,
+      defines: <String, String>{
+        kBuildMode: 'debug',
+        kTargetPlatform: 'android-arm64',
+      },
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: Artifacts.test(),
+      processManager: processManager,
+    );
+    final runner = _RecordingRunner(
+      buildResult: _BuildResult(<EncodedAsset>[
+        DataAsset(package: 'native_package', name: 'data.txt', file: dataFile.uri).encode(),
+      ]),
+    );
+
+    await TizenDartBuild(buildRunner: runner).build(environment);
+
+    expect(runner.extensions!.whereType<CodeAssetExtension>(), hasLength(1));
+    expect(runner.extensions!.whereType<DataAssetsExtension>(), hasLength(1));
+    final DartHooksResult result = await TizenDartBuild.loadHookResult(environment);
+    expect(result.dataAssets, hasLength(1));
+    expect(result.dataAssets.single.id, 'package:native_package/data.txt');
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    FeatureFlags: () => TestFeatureFlags(
+          isNativeAssetsEnabled: true,
+          isDartDataAssetsEnabled: true,
+        ),
+    ProcessManager: () => processManager,
+  });
+}
+
+class _RecordingRunner implements FlutterNativeAssetsBuildRunner {
+  _RecordingRunner({native.BuildResult buildResult = const _BuildResult()})
+      : _buildResult = buildResult;
+
+  final native.BuildResult _buildResult;
+  List<ProtocolExtension>? extensions;
+  int setCCompilerConfigCalls = 0;
+
+  @override
+  Future<List<String>> packagesWithNativeAssets() async => <String>['native_package'];
+
+  @override
+  Future<native.BuildResult?> build({
+    required List<ProtocolExtension> extensions,
+    required bool linkingEnabled,
+  }) async {
+    this.extensions = extensions;
+    return _buildResult;
+  }
+
+  @override
+  Future<native.LinkResult?> link({
+    required List<ProtocolExtension> extensions,
+    required native.BuildResult buildResult,
+  }) async {
+    throw StateError('Link hooks should not run for debug builds.');
+  }
+
+  @override
+  Future<void> setCCompilerConfig(Object target) async {
+    setCCompilerConfigCalls++;
+  }
+}
+
+class _BuildResult implements native.BuildResult {
+  const _BuildResult([this.encodedAssets = const <EncodedAsset>[]]);
+
+  @override
+  final List<EncodedAsset> encodedAssets;
+
+  @override
+  Map<String, List<EncodedAsset>> get encodedAssetsForLinking =>
+      const <String, List<EncodedAsset>>{};
+
+  @override
+  List<Uri> get dependencies => const <Uri>[];
+}


### PR DESCRIPTION
Flutter-tizen reuses Flutter's android-* and tester TargetPlatform values as architecture aliases. That made native asset hooks see Android target metadata even though the runtime target is Tizen's Linux-based environment.

So, reimplement `runFlutterSpecificHooks()`(-> `_runTizenSpecificHooks()`) for Tizen.
Run Tizen native asset hooks with OS.linux and the mapped target architecture so hook outputs are recorded as linux_<arch>.

https://github.com/flutter-tizen/flutter-tizen/issues/760