### PR TITLE
Sync AI rules with upstream fixes

### DIFF
--- a/doc/flutter-tizen-ai_rules.md
+++ b/doc/flutter-tizen-ai_rules.md
@@ -41,8 +41,7 @@ You are an expert in Flutter, Dart and Flutter-Tizen development. Your goal is t
 * **Widgets are for UI:** Everything in Flutter's UI is a widget. Compose
   complex UIs from smaller, reusable widgets.
 * **Navigation:** Use a modern routing package like `auto_route` or `go_router`.
-  See the [navigation guide](./navigation.md) for a detailed example using
-  `go_router`.
+  For more guidelines around navigation, see the section on [routing](#routing).
 
 ## Package Management
 * **Pub Tool:** To manage packages, use the `pub` tool, if available.
@@ -83,7 +82,8 @@ You are an expert in Flutter, Dart and Flutter-Tizen development. Your goal is t
     * Use `PascalCase` for classes, `camelCase` for
       members/variables/functions/enums, and `snake_case` for files.
 * **Functions:**
-    * Functions short and with a single purpose (strive for less than 20 lines).
+    * Keep functions short and with a single purpose.
+      Strive for less than 20 lines.
 * **Testing:** Write code with testing in mind. Use the `file`, `process`, and
   `platform` packages, if appropriate, so you can inject in-memory and fake
   versions of the objects.
@@ -159,7 +159,7 @@ When building reusable APIs, such as a library, follow these principles.
 ## Lint Rules
 
 Include the package in the `analysis_options.yaml` file. Use the following
-analysis_options.yaml file as a starting point:
+`analysis_options.yaml` file as a starting point:
 
 ```yaml
 include: package:flutter_lints/flutter.yaml
@@ -443,38 +443,27 @@ linter:
   always include `loadingBuilder` and `errorBuilder` for a better user
   experience.
 
-    ```dart
-    Image.network(
-      'https://picsum.photos/200/300',
-      loadingBuilder: (context, child, progress) {
-        if (progress == null) return child;
-        return const Center(child: CircularProgressIndicator());
-      },
-      errorBuilder: (context, error, stackTrace) {
-        return const Icon(Icons.error);
-      },
-    )
-    ```
+  ```dart
+  // When using network images, always provide an errorBuilder.
+  Image.network(
+    'https://picsum.photos/200/300',
+    loadingBuilder: (context, child, progress) {
+      if (progress == null) return child;
+      return const Center(child: CircularProgressIndicator());
+    },
+    errorBuilder: (context, error, stackTrace) {
+      return const Icon(Icons.error);
+    },
+  )
+  ```
+
 ## UI Theming and Styling Code
 
 * **Responsiveness:** Use `LayoutBuilder` or `MediaQuery` to create responsive
   UIs.
 * **Text:** Use `Theme.of(context).textTheme` for text styles.
 * **Text Fields:** Configure `textCapitalization`, `keyboardType`, and
-* **Responsiveness:** Use `LayoutBuilder` or `MediaQuery` to create responsive
-  UIs.
-* **Text:** Use `Theme.of(context).textTheme` for text styles.
-  remote images.
-
-```dart
-// When using network images, always provide an errorBuilder.
-Image.network(
-  'https://example.com/image.png',
-  errorBuilder: (context, error, stackTrace) {
-    return const Icon(Icons.error); // Show an error icon
-  },
-);
-```
+  `placeholder`.
 
 ## Material Theming Best Practices
 


### PR DESCRIPTION
`doc/flutter-tizen-ai_rules.md` was branched from `flutter/flutter` `docs/rules/rules.md` before upstream commit [`46fb721`](https://github.com/flutter/flutter/commit/46fb721) (flutter/flutter#182725, "Fix a few issues in the full-length rules file") landed. This PR applies the same fixes so the Tizen rules file no longer carries the pre-fix bugs.

### Fixes applied

1. **Broken navigation link** — the bullet pointed at `./navigation.md`, a file that does not exist in this repository (would 404). Replaced with the in-document anchor `[routing](#routing)` upstream uses.
2. **Functions style typo** — `Functions short and with a single purpose ...` was missing its verb. Restored to `Keep functions short and with a single purpose.` and split onto two lines, matching upstream.
3. **`analysis_options.yaml` formatting** — wrapped the second occurrence in backticks (the first occurrence in the same sentence is already in backticks).
4. **Duplicated / corrupted `## UI Theming and Styling Code` block** — the section contained:
   - a duplicated `Responsiveness` / `Text` bullet pair,
   - an orphan `remote images.` line,
   - a second `Image.network` example placed under the wrong heading.

   Removed the duplicates, completed the `Text Fields` bullet with `placeholder`, and moved the corrected `Image.network` example back under the `Network Images` bullet with 2-space code-fence indentation, as upstream does.

### Reference

Upstream fix: flutter/flutter#182725 / commit `46fb721` (2026-03-02).
