### PR TITLE
Report connection interface of remote Tizen devices

### DIFF
--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -145,6 +145,16 @@ class TizenDevice extends Device {
   @override
   String get name => 'Tizen $_modelId';
 
+  /// Matches the device ID of a remote device connected over TCP/IP, such as
+  /// "192.168.0.101:26101" (`sdb connect <IP>`).
+  static final RegExp _remoteDeviceId = RegExp(r'^\d{1,3}(\.\d{1,3}){3}:\d+$');
+
+  /// Source: [AndroidDevice.connectionInterface] in `android_device.dart`
+  @override
+  DeviceConnectionInterface get connectionInterface => _remoteDeviceId.hasMatch(id)
+      ? DeviceConnectionInterface.wireless
+      : DeviceConnectionInterface.attached;
+
   String get deviceProfile => getCapability('profile_name');
 
   bool get usesSecureProtocol => getCapability('secure_protocol') == 'enabled';

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -308,6 +308,27 @@ __return_cb req_id[1] pkg_type[tpk] pkgid[TestPackage] key[end] val[ok]
     expect(await tvDevice.isSupported(), isFalse);
   });
 
+  testWithoutContext('TizenDevice.connectionInterface is wireless for remote devices', () {
+    final TizenDevice usbDevice = _createTizenDevice(
+      processManager: processManager,
+      fileSystem: fileSystem,
+    );
+    expect(usbDevice.connectionInterface, DeviceConnectionInterface.attached);
+    expect(usbDevice.isWirelesslyConnected, isFalse);
+
+    final remoteDevice = TizenDevice(
+      '192.168.0.101:26101',
+      modelId: 'TestModel',
+      logger: logger,
+      processManager: processManager,
+      tizenSdk: FakeTizenSdk(fileSystem),
+      fileSystem: fileSystem,
+    );
+    expect(remoteDevice.connectionInterface, DeviceConnectionInterface.wireless);
+    expect(remoteDevice.isWirelesslyConnected, isTrue);
+    expect(remoteDevice.displayName, equals('Tizen TestModel (wireless)'));
+  });
+
   testWithoutContext('TizenDevicePortForwarder.forwardedPorts can list forwarded ports', () {
     final forwarder = TizenDevicePortForwarder(
       device: _createTizenDevice(


### PR DESCRIPTION
Devices connected over TCP/IP (sdb connect <IP>) were always reported as attached because TizenDevice did not override connectionInterface. The devices command already supports listing wirelessly connected devices separately, but the section was never shown for Tizen devices.

Detect remote devices by their <IP>:<port> style device ID, following the approach of AndroidDevice.connectionInterface.


```
$ flutter-tizen devices
Found 3 connected devices:
  Linux (desktop)     • linux            • linux-x64      • Ubuntu 22.04.5 LTS 6.8.0-124-generic
  Chrome (web)        • chrome           • web-javascript • Google Chrome 149.0.7827.114
  Tizen rpi4 (common) • ********** • tizen-arm64    • Tizen 11.0

Found 1 wirelessly connected device:
  Tizen 0 (wireless) (tv) • **.***.***.***:26101 • tizen-arm • Tizen 10.0

Run "flutter-tizen emulators" to list and start any available device emulators.
```

https://github.com/flutter/flutter/pull/122615