### PR TITLE
Skip pub upgrade when dependency inputs are unchanged

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -52,6 +52,10 @@ GOTO :EOF
 
         REM Invalidate the cache.
         IF EXIST "%cache_dir%" RMDIR /S /Q "%cache_dir%"
+
+        REM Force pub to run again because the dependencies of flutter_tools
+        REM (a path dependency of flutter-tizen) may have changed.
+        IF EXIST "%ROOT_DIR%\pubspec.lock" DEL /F /Q "%ROOT_DIR%\pubspec.lock"
       )
 
       FOR /f %%r IN ('git rev-parse HEAD') DO SET revision=%%r
@@ -100,12 +104,29 @@ GOTO :EOF
 
   :do_update_snapshot
     PUSHD "%ROOT_DIR%"
+      REM Run pub only when the dependency inputs changed. A revision change
+      REM that only touches Dart sources reuses the existing package
+      REM resolution.
+      IF NOT EXIST "%ROOT_DIR%\pubspec.lock" GOTO do_pub_upgrade
+      IF NOT EXIST "%ROOT_DIR%\.dart_tool\package_config.json" GOTO do_pub_upgrade
+      FOR /F %%i IN ('DIR /B /O:D "%ROOT_DIR%\pubspec.yaml" "%ROOT_DIR%\pubspec.lock"') DO SET pub_newer_file=%%i
+      FOR %%i IN (%ROOT_DIR%\pubspec.yaml) DO SET pub_yaml_timestamp=%%~ti
+      FOR %%i IN (%ROOT_DIR%\pubspec.lock) DO SET pub_lock_timestamp=%%~ti
+      IF "%pub_yaml_timestamp%" == "%pub_lock_timestamp%" SET pub_newer_file=""
+      IF "%pub_newer_file%" NEQ "pubspec.yaml" GOTO do_compile_snapshot
+
+    :do_pub_upgrade
       ECHO Running pub upgrade...
       CALL "%flutter_exe%" pub upgrade || (
         ECHO Error: Unable to 'pub upgrade' flutter-tizen. 1>&2
         EXIT /B 1
       )
 
+      REM Touch the pubspec.lock to ensure, even if this was a NOP, it is
+      REM newer than pubspec.yaml.
+      COPY /B /Y "%ROOT_DIR%\pubspec.lock"+,, "%ROOT_DIR%\pubspec.lock" >NUL
+
+    :do_compile_snapshot
       ECHO Compiling flutter-tizen...
       CALL "%dart_exe%" --disable-dart-dev --no-enable-mirrors ^
                         --snapshot="%snapshot_path%" ^

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -95,8 +95,8 @@ GOTO :EOF
     SET pubspec_yaml_path=%ROOT_DIR%\pubspec.yaml
     SET pubspec_lock_path=%ROOT_DIR%\pubspec.lock
     FOR /F %%i IN ('DIR /B /O:D "%pubspec_yaml_path%" "%pubspec_lock_path%"') DO SET newer_file=%%i
-    FOR %%i IN (%pubspec_yaml_path%) DO SET pubspec_yaml_timestamp=%%~ti
-    FOR %%i IN (%pubspec_lock_path%) DO SET pubspec_lock_timestamp=%%~ti
+    FOR %%i IN ("%pubspec_yaml_path%") DO SET pubspec_yaml_timestamp=%%~ti
+    FOR %%i IN ("%pubspec_lock_path%") DO SET pubspec_lock_timestamp=%%~ti
     IF "%pubspec_yaml_timestamp%" == "%pubspec_lock_timestamp%" SET newer_file=""
     IF "%newer_file%" EQU "pubspec.yaml" GOTO do_update_snapshot
   ENDLOCAL

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -110,8 +110,8 @@ GOTO :EOF
       IF NOT EXIST "%ROOT_DIR%\pubspec.lock" GOTO do_pub_upgrade
       IF NOT EXIST "%ROOT_DIR%\.dart_tool\package_config.json" GOTO do_pub_upgrade
       FOR /F %%i IN ('DIR /B /O:D "%ROOT_DIR%\pubspec.yaml" "%ROOT_DIR%\pubspec.lock"') DO SET pub_newer_file=%%i
-      FOR %%i IN (%ROOT_DIR%\pubspec.yaml) DO SET pub_yaml_timestamp=%%~ti
-      FOR %%i IN (%ROOT_DIR%\pubspec.lock) DO SET pub_lock_timestamp=%%~ti
+      FOR %%i IN ("%ROOT_DIR%\pubspec.yaml") DO SET pub_yaml_timestamp=%%~ti
+      FOR %%i IN ("%ROOT_DIR%\pubspec.lock") DO SET pub_lock_timestamp=%%~ti
       IF "%pub_yaml_timestamp%" == "%pub_lock_timestamp%" SET pub_newer_file=""
       IF "%pub_newer_file%" NEQ "pubspec.yaml" GOTO do_compile_snapshot
 

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -54,6 +54,10 @@ function update_flutter() {
 
     # Invalidate the cache.
     rm -fr "$ROOT_DIR/bin/cache"
+
+    # Force pub to run again because the dependencies of flutter_tools
+    # (a path dependency of flutter-tizen) may have changed.
+    rm -f "$ROOT_DIR/pubspec.lock"
   fi
 
   if [[ "$version" != "$(git rev-parse HEAD)" ]]; then
@@ -81,11 +85,16 @@ function update_flutter_tizen() {
 
   if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$stamp_path" || "$revision" != "$(cat "$stamp_path")"
         || "$ROOT_DIR/pubspec.yaml" -nt "$ROOT_DIR/pubspec.lock" ]]; then
-    echo "Running pub upgrade..."
-    (cd "$ROOT_DIR" && "$FLUTTER_EXE" pub upgrade) || {
-      >&2 echo "Error: Unable to 'pub upgrade' flutter-tizen."
-      exit 1
-    }
+    if [[ ! -f "$ROOT_DIR/pubspec.lock" || ! -f "$ROOT_DIR/.dart_tool/package_config.json"
+          || "$ROOT_DIR/pubspec.yaml" -nt "$ROOT_DIR/pubspec.lock" ]]; then
+      echo "Running pub upgrade..."
+      (cd "$ROOT_DIR" && "$FLUTTER_EXE" pub upgrade) || {
+        >&2 echo "Error: Unable to 'pub upgrade' flutter-tizen."
+        exit 1
+      }
+
+      touch "$ROOT_DIR/pubspec.lock"
+    fi
 
     echo "Compiling flutter-tizen..."
     "$DART_EXE" --disable-dart-dev --no-enable-mirrors \


### PR DESCRIPTION
`pub upgrade` ran on every flutter-tizen revision, even for Dart-only changes — re-resolving dependencies each time although the existing pubspec.lock was still valid.
Now run pub only when pubspec.lock or dart_tool/package_config.json is missing, or pubspec.yaml changed since the last resolution.