### PR TITLE
Expose ui_thread_policy on FlutterEngine/FlutterApplication/FlutterApp

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -11,7 +11,7 @@
 bool FlutterApp::OnCreate() {
   TizenLog::Debug("Launching a Flutter application...");
 
-  engine_ = FlutterEngine::Create(dart_entrypoint_);
+  engine_ = FlutterEngine::Create(dart_entrypoint_, {}, ui_thread_policy_);
   if (!engine_) {
     TizenLog::Error("Could not create a Flutter engine.");
     return false;

--- a/embedding/cpp/flutter_engine.cc
+++ b/embedding/cpp/flutter_engine.cc
@@ -10,19 +10,22 @@
 
 std::unique_ptr<FlutterEngine> FlutterEngine::Create(
     const std::string& dart_entrypoint,
-    const std::vector<std::string>& dart_entrypoint_args) {
+    const std::vector<std::string>& dart_entrypoint_args,
+    FlutterDesktopUIThreadPolicy ui_thread_policy) {
   return FlutterEngine::Create("../res/flutter_assets", "../res/icudtl.dat",
                                "../lib/libapp.so", dart_entrypoint,
-                               dart_entrypoint_args);
+                               dart_entrypoint_args, ui_thread_policy);
 }
 
 std::unique_ptr<FlutterEngine> FlutterEngine::Create(
     const std::string& assets_path, const std::string& icu_data_path,
     const std::string& aot_library_path, const std::string& dart_entrypoint,
-    const std::vector<std::string>& dart_entrypoint_args) {
+    const std::vector<std::string>& dart_entrypoint_args,
+    FlutterDesktopUIThreadPolicy ui_thread_policy) {
   FlutterEngine* engine =
       new FlutterEngine(assets_path, icu_data_path, aot_library_path,
-                        dart_entrypoint, dart_entrypoint_args);
+                        dart_entrypoint, dart_entrypoint_args,
+                        ui_thread_policy);
   if (engine->engine_) {
     return std::unique_ptr<FlutterEngine>(engine);
   } else {
@@ -34,7 +37,8 @@ std::unique_ptr<FlutterEngine> FlutterEngine::Create(
 FlutterEngine::FlutterEngine(
     const std::string& assets_path, const std::string& icu_data_path,
     const std::string& aot_library_path, const std::string& dart_entrypoint,
-    const std::vector<std::string>& dart_entrypoint_args) {
+    const std::vector<std::string>& dart_entrypoint_args,
+    FlutterDesktopUIThreadPolicy ui_thread_policy) {
   engine_arguments_ = std::make_unique<FlutterEngineArguments>();
 
   FlutterDesktopEngineProperties engine_prop = {};
@@ -61,7 +65,7 @@ FlutterEngine::FlutterEngine(
 
   engine_prop.dart_entrypoint_argc = entrypoint_args.size();
   engine_prop.dart_entrypoint_argv = entrypoint_args.data();
-  engine_prop.ui_thread_policy = FlutterDesktopUIThreadPolicy::kDefault;
+  engine_prop.ui_thread_policy = ui_thread_policy;
 
   engine_ = FlutterDesktopEngineCreate(engine_prop);
 }

--- a/embedding/cpp/flutter_service_app.cc
+++ b/embedding/cpp/flutter_service_app.cc
@@ -11,7 +11,7 @@
 bool FlutterServiceApp::OnCreate() {
   TizenLog::Debug("Launching a Flutter service application...");
 
-  engine_ = FlutterEngine::Create(dart_entrypoint_);
+  engine_ = FlutterEngine::Create(dart_entrypoint_, {}, ui_thread_policy_);
   if (!engine_) {
     TizenLog::Error("Could not create a Flutter engine.");
     return false;

--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -132,6 +132,22 @@ class FlutterApp : public flutter::PluginRegistry {
   // It only works on TV.
   bool is_floating_menu_support = true;
 
+  // The thread policy for running the UI isolate.
+  //
+  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|, which merges the UI
+  // isolate onto the platform thread. If the UI isolate is blocked by a
+  // long-running synchronous native call (e.g. via FFI), the platform thread
+  // can no longer respond to the Tizen app framework (app control/resume
+  // requests), which may cause the app to be killed by the platform
+  // watchdog.
+  //
+  // |FlutterDesktopUIThreadPolicy::kRunOnSeparateThread| is available for
+  // apps that need it, but apps must still make sure their Dart code never
+  // blocks indefinitely, whichever policy is used. Apps that choose this
+  // policy are responsible for any issues that result from doing so.
+  FlutterDesktopUIThreadPolicy ui_thread_policy_ =
+      FlutterDesktopUIThreadPolicy::kDefault;
+
  private:
   // The optional entrypoint in the Dart project.
   //

--- a/embedding/cpp/include/flutter_engine.h
+++ b/embedding/cpp/include/flutter_engine.h
@@ -24,16 +24,35 @@ class FlutterEngine : public flutter::PluginRegistry {
 
   // Creates a |FlutterEngine| with an optional entrypoint name and entrypoint
   // arguments.
+  //
+  // |ui_thread_policy| controls which thread the UI isolate runs on. Defaults
+  // to |FlutterDesktopUIThreadPolicy::kDefault|, which merges the UI isolate
+  // onto the platform thread. If the UI isolate is blocked by a long-running
+  // synchronous native call (e.g. via FFI), the platform thread can no
+  // longer respond to the Tizen app framework (app control/resume
+  // requests), which may cause the app to be killed by the platform
+  // watchdog.
+  //
+  // |FlutterDesktopUIThreadPolicy::kRunOnSeparateThread| is available for
+  // apps that need it, but apps must still make sure their Dart code never
+  // blocks indefinitely, whichever policy is used. Apps that choose this
+  // policy are responsible for any issues that result from doing so.
   static std::unique_ptr<FlutterEngine> Create(
       const std::string& dart_entrypoint = "",
-      const std::vector<std::string>& dart_entrypoint_args = {});
+      const std::vector<std::string>& dart_entrypoint_args = {},
+      FlutterDesktopUIThreadPolicy ui_thread_policy =
+          FlutterDesktopUIThreadPolicy::kDefault);
 
   // Creates a |FlutterEngine| with the given arguments.
+  //
+  // See the other |Create| overload for the meaning of |ui_thread_policy|.
   static std::unique_ptr<FlutterEngine> Create(
       const std::string& assets_path, const std::string& icu_data_path,
       const std::string& aot_library_path,
       const std::string& dart_entrypoint = "",
-      const std::vector<std::string>& dart_entrypoint_args = {});
+      const std::vector<std::string>& dart_entrypoint_args = {},
+      FlutterDesktopUIThreadPolicy ui_thread_policy =
+          FlutterDesktopUIThreadPolicy::kDefault);
 
   // Prevent copying.
   FlutterEngine(FlutterEngine const&) = delete;
@@ -98,7 +117,8 @@ class FlutterEngine : public flutter::PluginRegistry {
                 const std::string& icu_data_path,
                 const std::string& aot_library_path,
                 const std::string& dart_entrypoint,
-                const std::vector<std::string>& dart_entrypoint_args);
+                const std::vector<std::string>& dart_entrypoint_args,
+                FlutterDesktopUIThreadPolicy ui_thread_policy);
 
   // Handle for interacting with the C API's engine reference.
   FlutterDesktopEngineRef engine_ = nullptr;

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -59,6 +59,23 @@ class FlutterServiceApp : public flutter::PluginRegistry {
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string &plugin_name) override;
 
+ protected:
+  // The thread policy for running the UI isolate.
+  //
+  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|, which merges the UI
+  // isolate onto the platform thread. If the UI isolate is blocked by a
+  // long-running synchronous native call (e.g. via FFI), the platform thread
+  // can no longer respond to the Tizen app framework (app control/resume
+  // requests), which may cause the app to be killed by the platform
+  // watchdog.
+  //
+  // |FlutterDesktopUIThreadPolicy::kRunOnSeparateThread| is available for
+  // apps that need it, but apps must still make sure their Dart code never
+  // blocks indefinitely, whichever policy is used. Apps that choose this
+  // policy are responsible for any issues that result from doing so.
+  FlutterDesktopUIThreadPolicy ui_thread_policy_ =
+      FlutterDesktopUIThreadPolicy::kDefault;
+
  private:
   // The optional entrypoint in the Dart project.
   //

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -110,6 +110,18 @@ namespace Tizen.Flutter.Embedding
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
 
         /// <summary>
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
+        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
+        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
+        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
+        ///
+        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
+        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
+        /// choose this policy are responsible for any issues that result from doing so.
+        /// </summary>
+        protected FlutterUIThreadPolicy UIThreadPolicy { get; set; } = FlutterUIThreadPolicy.Default;
+
+        /// <summary>
         /// The user-defined pixel ratio. Defaults to the device pixel ratio if the value is 0.
         /// </summary>
         protected double UserPixelRatio { get; set; } = 0.0;
@@ -142,7 +154,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnCreate();
 
-            Engine = new FlutterEngine(DartEntrypoint);
+            Engine = new FlutterEngine(DartEntrypoint, uiThreadPolicy: UIThreadPolicy);
             if (!Engine.IsValid)
             {
                 throw new Exception("Could not create a Flutter engine.");

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -9,6 +9,25 @@ using static Tizen.Flutter.Embedding.Interop;
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
+    /// Enumeration for the thread policy of the Flutter engine's UI isolate.
+    /// </summary>
+    public enum FlutterUIThreadPolicy
+    {
+        /// <summary>
+        /// Currently runs the UI isolate on the platform thread. Equivalent to <see cref="RunOnPlatformThread"/>.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Runs the UI isolate on the platform thread.
+        /// </summary>
+        RunOnPlatformThread,
+        /// <summary>
+        /// Runs the UI isolate on a separate thread.
+        /// </summary>
+        RunOnSeparateThread,
+    }
+
+    /// <summary>
     /// The engine for Flutter execution.
     /// </summary>
     public class FlutterEngine : IPluginRegistry
@@ -18,17 +37,34 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// Creates a <see cref="FlutterEngine"/> with an optional entrypoint name and entrypoint arguments.
         /// </summary>
-        public FlutterEngine(string dartEntrypoint = "", List<string> dartEntrypointArgs = null)
-            : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so", dartEntrypoint, dartEntrypointArgs)
+        /// <param name="dartEntrypoint">The optional entrypoint in the Dart project. Defaults to main() if empty.</param>
+        /// <param name="dartEntrypointArgs">The optional entrypoint arguments.</param>
+        /// <param name="uiThreadPolicy">
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
+        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
+        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
+        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
+        ///
+        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
+        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
+        /// choose this policy are responsible for any issues that result from doing so.
+        /// </param>
+        public FlutterEngine(
+            string dartEntrypoint = "", List<string> dartEntrypointArgs = null,
+            FlutterUIThreadPolicy uiThreadPolicy = FlutterUIThreadPolicy.Default)
+            : this("../res/flutter_assets", "../res/icudtl.dat", "../lib/libapp.so", dartEntrypoint,
+                  dartEntrypointArgs, uiThreadPolicy)
         {
         }
 
         /// <summary>
         /// Creates a <see cref="FlutterEngine"/> with the given arguments.
         /// </summary>
+        /// <remarks>See the other constructor for the meaning of <paramref name="uiThreadPolicy"/>.</remarks>
         public FlutterEngine(
             string assetsPath, string icuDataPath, string aotLibraryPath, string dartEntrypoint = "",
-            List<string> dartEntrypointArgs = null)
+            List<string> dartEntrypointArgs = null,
+            FlutterUIThreadPolicy uiThreadPolicy = FlutterUIThreadPolicy.Default)
         {
             dartEntrypointArgs = dartEntrypointArgs ?? new List<string>();
             _engineArguments = new FlutterEngineArguments();
@@ -46,7 +82,7 @@ namespace Tizen.Flutter.Embedding
                     entrypoint = dartEntrypoint,
                     dart_entrypoint_argc = entrypointArgs.Length,
                     dart_entrypoint_argv = entrypointArgs.Handle,
-                    ui_thread_policy = FlutterDesktopUIThreadPolicy.kDefault,
+                    ui_thread_policy = (FlutterDesktopUIThreadPolicy)uiThreadPolicy,
                 };
 
                 Engine = FlutterDesktopEngineCreate(ref engineProperties);

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -19,6 +19,18 @@ namespace Tizen.Flutter.Embedding
         public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
+        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
+        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
+        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
+        ///
+        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
+        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
+        /// choose this policy are responsible for any issues that result from doing so.
+        /// </summary>
+        protected FlutterUIThreadPolicy UIThreadPolicy { get; set; } = FlutterUIThreadPolicy.Default;
+
+        /// <summary>
         /// Whether the app has started.
         /// </summary>
         public bool IsRunning => Engine != null;
@@ -56,7 +68,7 @@ namespace Tizen.Flutter.Embedding
         {
             base.OnCreate();
 
-            Engine = new FlutterEngine(DartEntrypoint);
+            Engine = new FlutterEngine(DartEntrypoint, uiThreadPolicy: UIThreadPolicy);
             if (!Engine.IsValid)
             {
                 throw new Exception("Could not create a Flutter engine.");


### PR DESCRIPTION
Since #774, the UI isolate's thread policy has been hardcoded to kDefault (merged onto the platform thread). On Tizen, the platform thread is also the app framework's main loop thread, so a long-blocking synchronous call on the UI isolate (e.g. via FFI) can leave the app unable to respond to app control/resume requests and get killed by the platform watchdog (see #784).

Add an optional ui_thread_policy parameter/property to FlutterEngine (C++ and C#), FlutterApp, and FlutterServiceApp, defaulting to kDefault to preserve existing behavior. Apps that need kRunOnSeparateThread can now opt into it, though the app remains responsible for making sure its Dart code never blocks indefinitely regardless of the policy chosen.