### PR TITLE
Guide users to update api-version when x64 build fails

### DIFF
--- a/lib/tizen_sdk.dart
+++ b/lib/tizen_sdk.dart
@@ -391,7 +391,11 @@ class TizenSdk {
     }
 
     if (versionToDouble(apiVersion) < 8.0 && arch == 'x64') {
-      throwToolExit('x64 is not supported with API version < 8.0.');
+      throwToolExit(
+        'x64 is not supported with API version < 8.0.\n'
+        'To build for x64 (e.g. an x86_64 emulator), set the api-version to '
+        '8.0 or higher in tizen/tizen-manifest.xml.',
+      );
     }
 
     switch (profile) {


### PR DESCRIPTION
When building for x64 with an API version below 8.0, the tool exited with 'x64 is not supported with API version < 8.0.' without telling the user how to fix it. Extend the message to point at the api-version field in tizen/tizen-manifest.xml, as reported in #786.