### PR TITLE
Fix type cast crash in attach --machine

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -93,7 +93,7 @@ Future<void> main(List<String> args) async {
   final bool verboseHelp = help && verbose;
   final bool daemon = args.contains('daemon');
   final bool widgetPreviews = args.contains(WidgetPreviewCommand.kWidgetPreview);
-  final bool runMachine = args.contains('--machine') && args.contains('run');
+  final bool runMachine = args.contains('--machine');
 
   Cache.flutterRoot = join(rootPath, 'flutter');
 


### PR DESCRIPTION
The machine logger detection in the tool entrypoint only covered the run command, so attach --machine was given a StdoutLogger and crashed in AttachCommand._attachDaemon with:

  type 'StdoutLogger' is not a subtype of type 'MachineOutputLogger' in type cast

The attach case was dropped from the condition when the attach command was temporarily removed in 2021 and was never restored when the command came back. Upstream flutter_tools now creates a machine logger whenever --machine is passed, so mirror that behavior.

upstream : https://github.com/flutter/flutter/pull/174301