### PR TITLE
Deduplicate ui_thread_policy API documentation

### DIFF
--- a/embedding/cpp/include/flutter_app.h
+++ b/embedding/cpp/include/flutter_app.h
@@ -134,17 +134,8 @@ class FlutterApp : public flutter::PluginRegistry {
 
   // The thread policy for running the UI isolate.
   //
-  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|, which merges the UI
-  // isolate onto the platform thread. If the UI isolate is blocked by a
-  // long-running synchronous native call (e.g. via FFI), the platform thread
-  // can no longer respond to the Tizen app framework (app control/resume
-  // requests), which may cause the app to be killed by the platform
-  // watchdog.
-  //
-  // |FlutterDesktopUIThreadPolicy::kRunOnSeparateThread| is available for
-  // apps that need it, but apps must still make sure their Dart code never
-  // blocks indefinitely, whichever policy is used. Apps that choose this
-  // policy are responsible for any issues that result from doing so.
+  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|. See
+  // |FlutterEngine::Create| for the meaning of each policy.
   FlutterDesktopUIThreadPolicy ui_thread_policy_ =
       FlutterDesktopUIThreadPolicy::kDefault;
 

--- a/embedding/cpp/include/flutter_service_app.h
+++ b/embedding/cpp/include/flutter_service_app.h
@@ -62,17 +62,8 @@ class FlutterServiceApp : public flutter::PluginRegistry {
  protected:
   // The thread policy for running the UI isolate.
   //
-  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|, which merges the UI
-  // isolate onto the platform thread. If the UI isolate is blocked by a
-  // long-running synchronous native call (e.g. via FFI), the platform thread
-  // can no longer respond to the Tizen app framework (app control/resume
-  // requests), which may cause the app to be killed by the platform
-  // watchdog.
-  //
-  // |FlutterDesktopUIThreadPolicy::kRunOnSeparateThread| is available for
-  // apps that need it, but apps must still make sure their Dart code never
-  // blocks indefinitely, whichever policy is used. Apps that choose this
-  // policy are responsible for any issues that result from doing so.
+  // Defaults to |FlutterDesktopUIThreadPolicy::kDefault|. See
+  // |FlutterEngine::Create| for the meaning of each policy.
   FlutterDesktopUIThreadPolicy ui_thread_policy_ =
       FlutterDesktopUIThreadPolicy::kDefault;
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -110,14 +110,8 @@ namespace Tizen.Flutter.Embedding
         protected FlutterRendererType RendererType { get; set; } = FlutterRendererType.EGL;
 
         /// <summary>
-        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
-        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
-        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
-        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
-        ///
-        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
-        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
-        /// choose this policy are responsible for any issues that result from doing so.
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>.
+        /// See <see cref="FlutterUIThreadPolicy"/> for details.
         /// </summary>
         protected FlutterUIThreadPolicy UIThreadPolicy { get; set; } = FlutterUIThreadPolicy.Default;
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngine.cs
@@ -11,6 +11,15 @@ namespace Tizen.Flutter.Embedding
     /// <summary>
     /// Enumeration for the thread policy of the Flutter engine's UI isolate.
     /// </summary>
+    /// <remarks>
+    /// If the UI isolate runs on the platform thread and is blocked by a long-running synchronous native call
+    /// (e.g. via FFI), the platform thread can no longer respond to the Tizen app framework (app control/resume
+    /// requests), which may cause the app to be killed by the platform watchdog.
+    ///
+    /// <see cref="RunOnSeparateThread"/> is available for apps that need it, but apps must still make sure
+    /// their Dart code never blocks indefinitely, whichever policy is used. Apps that choose this policy are
+    /// responsible for any issues that result from doing so.
+    /// </remarks>
     public enum FlutterUIThreadPolicy
     {
         /// <summary>
@@ -40,14 +49,8 @@ namespace Tizen.Flutter.Embedding
         /// <param name="dartEntrypoint">The optional entrypoint in the Dart project. Defaults to main() if empty.</param>
         /// <param name="dartEntrypointArgs">The optional entrypoint arguments.</param>
         /// <param name="uiThreadPolicy">
-        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
-        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
-        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
-        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
-        ///
-        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
-        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
-        /// choose this policy are responsible for any issues that result from doing so.
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>.
+        /// See <see cref="FlutterUIThreadPolicy"/> for details.
         /// </param>
         public FlutterEngine(
             string dartEntrypoint = "", List<string> dartEntrypointArgs = null,

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterServiceApplication.cs
@@ -19,14 +19,8 @@ namespace Tizen.Flutter.Embedding
         public string DartEntrypoint { get; set; } = string.Empty;
 
         /// <summary>
-        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>,
-        /// which merges the UI isolate onto the platform thread. If the UI isolate is blocked by a long-running
-        /// synchronous native call (e.g. via FFI), the platform thread can no longer respond to the Tizen app
-        /// framework (app control/resume requests), which may cause the app to be killed by the platform watchdog.
-        ///
-        /// <see cref="FlutterUIThreadPolicy.RunOnSeparateThread"/> is available for apps that need it, but apps
-        /// must still make sure their Dart code never blocks indefinitely, whichever policy is used. Apps that
-        /// choose this policy are responsible for any issues that result from doing so.
+        /// The thread policy for running the UI isolate. Defaults to <see cref="FlutterUIThreadPolicy.Default"/>.
+        /// See <see cref="FlutterUIThreadPolicy"/> for details.
         /// </summary>
         protected FlutterUIThreadPolicy UIThreadPolicy { get; set; } = FlutterUIThreadPolicy.Default;
 


### PR DESCRIPTION
Follow-up to #785. The same watchdog warning was repeated in five places. Keep the full explanation in one canonical location and reference it from everywhere else:

- C++: FlutterEngine::Create keeps the full description. The ui_thread_policy_ fields of FlutterApp and FlutterServiceApp now reference it.
- C#: the FlutterUIThreadPolicy enum docs hold the full description. The FlutterEngine constructor parameter and the UIThreadPolicy properties of FlutterApplication and FlutterServiceApplication now reference it.