### PR TITLE
Remove pre-created window support from C# embedding

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -164,16 +164,6 @@ namespace Tizen.Flutter.Embedding
                 throw new Exception("Vulkan renderer requires USE_FLUTTER_TIZEN_EXPERIMENTAL. Enable flutter tizen experimental using the --dart-define=USE_FLUTTER_TIZEN_EXPERIMENTAL=true.");
             }
 
-            var daliApp = ApplicationNewManual4(0, "", "", 1 /* transparent */);
-            var daliWindow = GetWindow(daliApp);
-            IntPtr wlWindow = IntPtr.Zero;
-            // FIXME(jsuya): There is an issue where window geometry settings are not applied when using precreated windows.
-            // Precreated windows are only used when the window size and position have not been set.
-            if (WindowOffsetX == 0 && WindowOffsetY == 0 && WindowWidth == 0 && WindowHeight == 0 && HasBody(daliWindow))
-            {
-                wlWindow = GetNativeWindowHandler(daliWindow);
-            }
-
             var windowProperties = new FlutterDesktopWindowProperties
             {
                 x = WindowOffsetX,
@@ -185,7 +175,7 @@ namespace Tizen.Flutter.Embedding
                 top_level = IsTopLevel,
                 renderer_type = (FlutterDesktopRendererType)RendererType,
                 user_pixel_ratio = UserPixelRatio < 0.0 ? 0.0 : UserPixelRatio,
-                window_handle = wlWindow,
+                window_handle = IntPtr.Zero,
                 pointing_device_support = IsPointingDeviceSupport,
                 floating_menu_support = IsFloatingMenuSupport,
             };

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -194,18 +194,5 @@ namespace Tizen.Flutter.Embedding
         public static extern FlutterDesktopMessenger FlutterDesktopPluginRegistrarGetMessenger(
             FlutterDesktopPluginRegistrar registrar);
         #endregion
-
-        [DllImport("libdali2-csharp-binder.so", EntryPoint = "CSharp_Dali_Application_New__MANUAL_4")]
-        public static extern IntPtr ApplicationNewManual4(int jarg1, string jarg2, string jarg3, int jarg4);
-
-        [DllImport("libdali2-csharp-binder.so", EntryPoint = "CSharp_Dali_Application_GetWindow")]
-        public static extern IntPtr GetWindow(IntPtr jarg1);
-
-        [DllImport("libdali2-csharp-binder.so", EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]
-        public static extern IntPtr GetNativeWindowHandler(IntPtr Window);
-
-        [DllImport("libdali2-csharp-binder.so", EntryPoint = "CSharp_Dali_BaseHandle_HasBody")]
-        [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool HasBody(IntPtr jarg1);
     }
 }


### PR DESCRIPTION
Remove the logic that looks up a pre-created DALi window before running the engine and passes its native handle to the view. FlutterApplication now always passes a null window_handle, so the engine always creates a new window.

This deletes the libdali2-csharp-binder.so P/Invokes (ApplicationNewManual4, GetWindow, GetNativeWindowHandler, HasBody), removing the NUI/DALi runtime dependency from FlutterApplication.

The window_handle field is kept in FlutterDesktopWindowProperties to match the native struct layout in flutter_tizen.h; it can be dropped together with the engine-side removal.

related issue: https://github.com/flutter-tizen/flutter-tizen/issues/788