### PR TITLE
Restore FlutterDesktopViewGetNativeHandle interop API

### DIFF
--- a/bin/internal/embedder.version
+++ b/bin/internal/embedder.version
@@ -1,1 +1,1 @@
-bcc65fcf6a28f151e3e61f8a5dfa9cfbae80e6f5
+6a76ba444957dec4efbfed97ddc49a62e34ee6f7

--- a/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Interop/Interop.cs
@@ -103,6 +103,9 @@ namespace Tizen.Flutter.Embedding
         public static extern void FlutterDesktopViewDestroy(
             FlutterDesktopView view);
 
+        [DllImport("flutter_tizen.so")]
+        public static extern IntPtr FlutterDesktopViewGetNativeHandle(FlutterDesktopView view);
+
         #endregion
 
         #region flutter_messenger.h


### PR DESCRIPTION
The P/Invoke entry was removed along with the NUIFlutterView embedding support in #789, but the underlying embedder API is not NUI-specific: it returns the Ecore_Wl2_Window* backing a window-based view. 


Issue: #796