### PR TITLE
Remove meta dependency override

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,5 +35,3 @@ dev_dependencies:
   pubspec_parse:
   test:
 
-dependency_overrides:
-  meta: ^1.17.0


### PR DESCRIPTION
The override was added in 0c0a385 (Flutter 3.35.3) because flutter_tools pinned meta 1.17.0 while flutter_test pinned meta 1.16.0, making version solving fail. As of Flutter 3.44.8 both packages pin meta 1.18.0, so the override is no longer needed and meta now resolves to the SDK-pinned version instead of a newer one.