### PR TITLE
Rename debug symbols file to app.tizen-{arch}.symbols

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -205,7 +205,7 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   Symbolize a stack trace from a Flutter app which has been built with the `--split-debug-info` option.
 
   ```sh
-  flutter-tizen symbolize --debug-info app.android-arm.symbols --input stack_trace.err
+  flutter-tizen symbolize --debug-info app.tizen-arm.symbols --input stack_trace.err
   ```
 
 - ### `test`

--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -210,6 +210,11 @@ class TizenAotElf extends AotElfBase {
   /// gen_snapshot skips stripping for Android target platforms, expecting
   /// the Android Gradle Plugin to strip later. Tizen has no such step, so
   /// strip here.
+  ///
+  /// The debug symbols file emitted by gen_snapshot is named after the Android
+  /// platform (e.g. app.android-arm.symbols) because Tizen reuses Android's
+  /// gen_snapshot. Rename it to a Tizen-specific name to avoid confusion and
+  /// collision with Android builds sharing the same split-debug-info directory.
   @override
   Future<void> build(Environment environment) async {
     final List<String> extraGenSnapshotOptions =
@@ -219,6 +224,18 @@ class TizenAotElf extends AotElfBase {
       environment.defines[kExtraGenSnapshotOptions] = extraGenSnapshotOptions.join(',');
     }
     await super.build(environment);
+
+    final String? splitDebugInfo = environment.defines[kSplitDebugInfo];
+    if (splitDebugInfo != null && splitDebugInfo.isNotEmpty) {
+      final Directory splitDebugInfoDir = environment.fileSystem.directory(splitDebugInfo);
+      final File symbolsFile =
+          splitDebugInfoDir.childFile('app.${getNameForTargetPlatform(targetPlatform)}.symbols');
+      if (symbolsFile.existsSync()) {
+        symbolsFile.renameSync(splitDebugInfoDir
+            .childFile('app.tizen-${getArchForTargetPlatform(targetPlatform)}.symbols')
+            .path);
+      }
+    }
   }
 }
 

--- a/test/general/build_targets/application_test.dart
+++ b/test/general/build_targets/application_test.dart
@@ -59,4 +59,31 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
   });
+
+  testUsingContext('TizenAotElf renames app.android-arm.symbols to app.tizen-arm.symbols',
+      () async {
+    final environment = Environment.test(
+      fileSystem.currentDirectory,
+      defines: <String, String>{
+        kBuildMode: 'release',
+        kTargetPlatform: 'android-arm',
+        kSplitDebugInfo: 'debug_info',
+      },
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: FakeProcessManager.any(),
+    );
+
+    final Directory splitDebugInfoDir = fileSystem.directory('debug_info');
+    splitDebugInfoDir.childFile('app.android-arm.symbols').createSync(recursive: true);
+
+    await TizenAotElf(TargetPlatform.android_arm, BuildMode.release).build(environment);
+
+    expect(splitDebugInfoDir.childFile('app.tizen-arm.symbols'), exists);
+    expect(splitDebugInfoDir.childFile('app.android-arm.symbols'), isNot(exists));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
 }


### PR DESCRIPTION
The symbols file generated by gen_snapshot when building with --split-debug-info is named after the Android target platform (e.g. app.android-arm.symbols) because Tizen reuses Android's gen_snapshot. This is confusing for Tizen apps and can silently overwrite symbols of a real Android build sharing the same split-debug-info directory.

Rename the file to app.tizen-{arch}.symbols after the AOT snapshot is generated. The symbolize command takes an explicit --debug-info path, so this does not affect symbolication.