### PR TITLE
Strip debug info from AOT snapshot

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -190,6 +190,7 @@ class TizenAotElf extends AotElfBase {
 
   @override
   List<Source> get inputs => <Source>[
+        const Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/application.dart'),
         const Source.pattern('{BUILD_DIR}/app.dill'),
         const Source.artifact(Artifact.engineDartBinary),
         const Source.artifact(Artifact.skyEnginePath),
@@ -205,6 +206,20 @@ class TizenAotElf extends AotElfBase {
   List<Target> get dependencies => const <Target>[
         TizenKernelSnapshot(),
       ];
+
+  /// gen_snapshot skips stripping for Android target platforms, expecting
+  /// the Android Gradle Plugin to strip later. Tizen has no such step, so
+  /// strip here.
+  @override
+  Future<void> build(Environment environment) async {
+    final List<String> extraGenSnapshotOptions =
+        decodeCommaSeparated(environment.defines, kExtraGenSnapshotOptions);
+    if (!extraGenSnapshotOptions.contains('--no-strip')) {
+      extraGenSnapshotOptions.add('--strip');
+      environment.defines[kExtraGenSnapshotOptions] = extraGenSnapshotOptions.join(',');
+    }
+    await super.build(environment);
+  }
 }
 
 /// Source: [DebugAndroidApplication] in `android.dart`


### PR DESCRIPTION
gen_snapshot skips stripping for Android target platforms assuming the Android Gradle Plugin strips at packaging time. Tizen has no such step, so release TPKs ship app.so with its symbol table and DWARF sections intact. Pass --strip unless --no-strip is given via --extra-gen-snapshot-options. Symbols can still be saved separately with --split-debug-info.

For the default counter app (release, x64), app.so shrinks from 4.1 MB to 2.7 MB and the TPK from 10.0 MB to 9.5 MB.