### PR TITLE
Support version management commands (`channel`, `upgrade`)

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -64,6 +64,20 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   flutter-tizen build module --device-profile common
   ```
 
+- ### `channel`
+
+  List or switch flutter-tizen releases. A "channel" is a [release tag](https://github.com/flutter-tizen/flutter-tizen/tags) of the flutter-tizen repository.
+
+  ```sh
+  # List the available release tags, marking the one in use.
+  flutter-tizen channel
+
+  # Switch this checkout to a release tag.
+  flutter-tizen channel 3.44.4-tizen.1.0.0
+  ```
+
+  Switching re-runs the toolchain setup. Uncommitted changes block the switch unless `--force` is passed.
+
 - ### `clean`
 
   Remove the current project's build artifacts and intermediate files.
@@ -223,15 +237,25 @@ The following commands from the [Flutter CLI](https://flutter.dev/docs/reference
   flutter-tizen test integration_test
   ```
 
+- ### `upgrade`
+
+  Upgrade the flutter-tizen toolchain to its latest release.
+
+  ```sh
+  # Upgrade to the latest release.
+  flutter-tizen upgrade
+
+  # Only check whether an upgrade is available.
+  flutter-tizen upgrade --verify-only
+  ```
+
 ## Not supported
 
 The following commands from the Flutter CLI are not supported by flutter-tizen.
 
 - `assemble`
 - `bash-completion`
-- `channel`
 - `custom-devices`
 - `downgrade`
 - `logs`
 - `screenshot`
-- `upgrade`

--- a/lib/commands/channel.dart
+++ b/lib/commands/channel.dart
@@ -1,0 +1,467 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/channel.dart';
+import 'package:flutter_tools/src/git.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:path/path.dart' as path;
+
+import '../tizen_flutter_version.dart';
+
+/// Lists or switches flutter-tizen releases (release tags of this repo).
+///
+/// Source: [ChannelCommand] in `channel.dart`
+class TizenChannelCommand extends ChannelCommand {
+  TizenChannelCommand({
+    super.verboseHelp,
+    Git? git,
+    String? repoRoot,
+    Future<int> Function(List<String> args)? runLauncher,
+  })  : _git = git,
+        _repoRoot = repoRoot,
+        _runLauncher = runLauncher {
+    argParser.addFlag(
+      'force',
+      negatable: false,
+      help: 'Discard local changes in the flutter-tizen checkout (including '
+          'its vendored Flutter SDK and untracked files that conflict with '
+          'the target release) and switch anyway.',
+    );
+  }
+
+  final Git? _git;
+  final String? _repoRoot;
+  final Future<int> Function(List<String> args)? _runLauncher;
+
+  Git get _gitWrapper => _git ?? globals.git;
+
+  /// The flutter-tizen checkout root ([Cache.flutterRoot]'s parent).
+  String get repoRoot => _repoRoot ?? globals.fs.directory(Cache.flutterRoot).parent.path;
+
+  @override
+  String get description => 'List or switch flutter-tizen releases.\n'
+      '\n'
+      'A "channel" is a release tag of the flutter-tizen repository. The\n'
+      'target corresponds 1:1 to "git tag": switching to 3.44.4 checks out\n'
+      'the tag named 3.44.4.\n'
+      '\n'
+      'Common commands:\n'
+      '\n'
+      ' flutter-tizen channel\n'
+      '   List the flutter-tizen release tags.\n'
+      '\n'
+      ' flutter-tizen channel 3.44.4-tizen.1.0.0\n'
+      '   Switch this checkout to the 3.44.4-tizen.1.0.0 release tag.\n'
+      '\n'
+      'Pass "--no-cache-artifacts" to skip downloading engine artifacts\n'
+      'after the switch.';
+
+  @override
+  String get invocation => '${runner?.executableName} $name [<release-tag>]';
+
+  @override
+  bool get shouldUpdateCache => false;
+
+  static String launcherRelativePath(Platform platform, path.Context pathContext) {
+    return pathContext.join('bin', platform.isWindows ? 'flutter-tizen.bat' : 'flutter-tizen');
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    switch (argResults!.rest.length) {
+      case 0:
+        await _listReleases(showAll: boolArg('all'));
+        return FlutterCommandResult.success();
+      case 1:
+        await _switchRelease(argResults!.rest.single);
+        return FlutterCommandResult.success();
+      default:
+        throwToolExit('Too many arguments.\n$usage');
+    }
+  }
+
+  /// Fetches tags (best-effort) and returns the parsed release tags plus
+  /// the raw `git tag` lines.
+  Future<(List<TizenGitTagVersion>, List<String>)> _fetchAndListTags() async {
+    try {
+      // --force so a tag re-pointed upstream does not silently stay stale.
+      await _gitWrapper.run(
+        <String>['fetch', '--tags', '--force'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+    } on ProcessException catch (e) {
+      globals.printWarning(
+        '"git fetch --tags" failed in $repoRoot; showing the releases '
+        'already known locally.\n${e.message}',
+      );
+    }
+
+    RunResult result;
+    try {
+      // Tag name plus its commit's timestamp (`*committerdate` for
+      // annotated tags).
+      result = await _gitWrapper.run(
+        <String>[
+          'tag',
+          '-l',
+          '--format=%(refname:short) %(committerdate:unix)%(*committerdate:unix)',
+        ],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Could not list the flutter-tizen releases: "git tag" failed in '
+        '$repoRoot.\nThis must be a git clone of the flutter-tizen '
+        'repository.\n${e.message}',
+      );
+    }
+
+    // Newest tagged commit first; ties keep git's output order.
+    final entries = <(String, int, int)>[];
+    for (final String line in result.stdout.trim().split('\n')) {
+      final String trimmed = line.trim();
+      if (trimmed.isEmpty) {
+        continue;
+      }
+      final int spaceIndex = trimmed.lastIndexOf(' ');
+      final String name = spaceIndex == -1 ? trimmed : trimmed.substring(0, spaceIndex).trim();
+      final int timestamp =
+          spaceIndex == -1 ? 0 : int.tryParse(trimmed.substring(spaceIndex + 1)) ?? 0;
+      entries.add((name, timestamp, entries.length));
+    }
+    entries.sort(((String, int, int) a, (String, int, int) b) {
+      final int byTime = b.$2.compareTo(a.$2);
+      return byTime != 0 ? byTime : a.$3.compareTo(b.$3);
+    });
+
+    final List<String> lines = entries.map(((String, int, int) entry) => entry.$1).toList();
+    return (
+      lines.map(TizenGitTagVersion.parse).whereType<TizenGitTagVersion>().toList(),
+      lines,
+    );
+  }
+
+  /// Resolves the commit the checkout is currently on.
+  static Future<String> headCommit(Git git, String repoRoot) async {
+    try {
+      final RunResult result = await git.run(
+        <String>['rev-parse', '--verify', 'HEAD'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+      return result.stdout.trim();
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Unable to determine the current flutter-tizen version: could not '
+        'read HEAD in $repoRoot.\n${e.message}',
+      );
+    }
+  }
+
+  /// The exact tag the checkout sits on, or null for a dev checkout.
+  static Future<String?> currentTag(Git git, String repoRoot) async {
+    try {
+      final RunResult result = await git.run(
+        <String>['describe', '--tags', '--exact-match', 'HEAD'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+      return result.stdout.trim();
+    } on ProcessException {
+      return null;
+    }
+  }
+
+  /// Source: `_listChannels` in [ChannelCommand]
+  Future<void> _listReleases({required bool showAll}) async {
+    final (List<TizenGitTagVersion> tags, List<String> rawLines) = await _fetchAndListTags();
+    final List<String> shown =
+        showAll ? rawLines : tags.map((TizenGitTagVersion tag) => tag.tag).toList();
+    if (shown.isEmpty) {
+      globals.printStatus(
+        'No flutter-tizen releases are known. If this checkout was cloned '
+        'without tags, run "git fetch --tags".',
+      );
+      return;
+    }
+
+    final String? current = await currentTag(_gitWrapper, repoRoot);
+
+    for (final line in shown) {
+      final marker = line == current ? '(current)' : '';
+      globals.printStatus('  ${line.padRight(24)}$marker'.trimRight());
+    }
+
+    if (!showAll) {
+      globals.printStatus('');
+      globals.printStatus('Switch with "flutter-tizen channel <release-tag>".');
+    }
+  }
+
+  /// Source: `_switchChannel` in [ChannelCommand]
+  Future<void> _switchRelease(String target) async {
+    final (List<TizenGitTagVersion> tags, _) = await _fetchAndListTags();
+    // Exact tag-name match only; no version resolution.
+    final String wanted = target.trim();
+    TizenGitTagVersion? release;
+    for (final tag in tags) {
+      if (tag.tag == wanted) {
+        release = tag;
+        break;
+      }
+    }
+    if (release == null) {
+      final String available = tags.map((TizenGitTagVersion tag) => '  ${tag.tag}').join('\n');
+      throwToolExit(
+        'No flutter-tizen release tag matches "$target".\n\n'
+        '${available.isEmpty ? 'No release tags are known locally. Check your network connection.' : 'Available release tags:\n$available'}',
+      );
+    }
+
+    final String commit = await peelToCommit(_gitWrapper, repoRoot, release.tag);
+    final String head = await headCommit(_gitWrapper, repoRoot);
+    // Before the dirty-tree guards: naming the current tag is a no-op.
+    if (commit == head) {
+      globals.printStatus('flutter-tizen is already on ${release.tag}.');
+      return;
+    }
+
+    if (!boolArg('force') && !await isTreeClean(_gitWrapper, repoRoot)) {
+      throwToolExit(
+        'Your flutter-tizen checkout in $repoRoot has uncommitted changes.\n'
+        'Commit or stash them first, or re-run with --force to discard them '
+        'and switch anyway.',
+      );
+    }
+
+    if (!boolArg('force') && !await isFlutterSdkClean(_gitWrapper, repoRoot)) {
+      throwToolExit(
+        'The vendored Flutter SDK in '
+        '${globals.fs.path.join(repoRoot, 'flutter')} has uncommitted '
+        'changes, which the post-switch setup would discard.\n'
+        'Commit or stash them first, or re-run with --force to discard them '
+        'and switch anyway.',
+      );
+    }
+
+    final String? branch = await currentBranch(_gitWrapper, repoRoot);
+    final String? pinnedFlutterVersion = readPinnedFlutterVersion(repoRoot);
+    globals.printStatus('Switching flutter-tizen to ${release.tag}...');
+    await checkoutDetached(_gitWrapper, repoRoot, commit, force: boolArg('force'));
+    printRecovery(repoRoot: repoRoot, branch: branch, headCommit: head);
+    await runPostSwitchSetup(
+      repoRoot: repoRoot,
+      targetTag: release.tag,
+      cacheArtifacts: boolArg('cache-artifacts'),
+      previousFlutterVersion: pinnedFlutterVersion,
+      runLauncher: _runLauncher,
+    );
+    globals.printStatus('');
+    globals.printStatus('Now on ${release.tag}.');
+  }
+
+  /// Peels [tag] to its commit; annotated tags resolve to tag objects
+  /// otherwise.
+  static Future<String> peelToCommit(Git git, String repoRoot, String tag) async {
+    try {
+      final RunResult result = await git.run(
+        <String>['rev-parse', '$tag^{commit}'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+      return result.stdout.trim();
+    } on ProcessException catch (e) {
+      throwToolExit('Could not resolve the commit for $tag.\n${e.message}');
+    }
+  }
+
+  /// Whether [repoRoot] has no uncommitted changes; fails closed.
+  static Future<bool> isTreeClean(
+    Git git,
+    String repoRoot, {
+    bool includeUntracked = false,
+  }) async {
+    try {
+      final RunResult result = await git.run(
+        <String>['status', '-s', if (!includeUntracked) '--untracked-files=no'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+      return result.stdout.trim().isEmpty;
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'The tool could not verify the status of the flutter-tizen checkout '
+        'in $repoRoot. Ensure git is installed and in your PATH and try '
+        'again.\n${e.message}',
+      );
+    }
+  }
+
+  /// Whether the vendored `flutter/` SDK has no uncommitted changes; the
+  /// bootstrap resets and cleans it when the pinned Flutter version changes.
+  /// A pristine SDK has no untracked entries (generated files are ignored),
+  /// so untracked files here are user work that `git clean -xdf` would
+  /// delete; ignored files cannot be guarded (bin/cache is always present).
+  static Future<bool> isFlutterSdkClean(Git git, String repoRoot) async {
+    final String flutterDir = globals.fs.path.join(repoRoot, 'flutter');
+    if (!globals.fs.directory(globals.fs.path.join(flutterDir, '.git')).existsSync()) {
+      return true;
+    }
+    return isTreeClean(git, flutterDir, includeUntracked: true);
+  }
+
+  /// The Flutter version this checkout pins, or null when unreadable.
+  static String? readPinnedFlutterVersion(String repoRoot) {
+    final File file =
+        globals.fs.file(globals.fs.path.join(repoRoot, 'bin', 'internal', 'flutter.version'));
+    return file.existsSync() ? file.readAsStringSync().trim() : null;
+  }
+
+  /// The branch HEAD is on, or null when already detached.
+  static Future<String?> currentBranch(Git git, String repoRoot) async {
+    try {
+      final RunResult result = await git.run(
+        <String>['symbolic-ref', '-q', '--short', 'HEAD'],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+      final String branch = result.stdout.trim();
+      return branch.isEmpty ? null : branch;
+    } on ProcessException {
+      return null;
+    }
+  }
+
+  /// Detaches the worktree at [commit]; `--force` only when the user asked
+  /// to discard local changes.
+  static Future<void> checkoutDetached(
+    Git git,
+    String repoRoot,
+    String commit, {
+    required bool force,
+  }) async {
+    try {
+      await git.run(
+        <String>['checkout', if (force) '--force', '--detach', commit],
+        throwOnError: true,
+        workingDirectory: repoRoot,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Could not switch the flutter-tizen checkout in $repoRoot to '
+        '$commit.\n${e.message}'
+        '${force ? '' : '\nIf untracked files conflict with the target release, re-run with --force to overwrite them.'}',
+      );
+    }
+  }
+
+  /// Prints the command that returns to the pre-switch state.
+  static void printRecovery({
+    required String repoRoot,
+    required String? branch,
+    required String headCommit,
+  }) {
+    final command = branch != null
+        ? 'git -C "$repoRoot" checkout --force "$branch"'
+        : 'git -C "$repoRoot" checkout --force --detach $headCommit';
+    globals.printStatus('');
+    globals.printStatus('If anything goes wrong, return to where you were with:');
+    globals.printStatus('  $command', wrap: false);
+    globals.printStatus('');
+  }
+
+  /// Re-invokes the launcher in [repoRoot] for post-checkout setup:
+  /// `--version`, `precache --force` (when [cacheArtifacts]), then `doctor`.
+  static Future<void> runPostSwitchSetup({
+    required String repoRoot,
+    required String targetTag,
+    required bool cacheArtifacts,
+    required String? previousFlutterVersion,
+    Future<int> Function(List<String> args)? runLauncher,
+  }) async {
+    if (globals.platform.isWindows &&
+        (previousFlutterVersion == null ||
+            previousFlutterVersion != readPinnedFlutterVersion(repoRoot))) {
+      // TODO(jsuya): Run inline via an exit-and-restart flow; Windows cannot
+      // replace the running tool's Dart SDK in flutter/bin/cache.
+      globals.printStatus(
+        'The checkout is now on $targetTag. Because the pinned Flutter SDK '
+        'changed, finish the setup by running:',
+      );
+      globals.printStatus('  flutter-tizen --version', wrap: false);
+      if (cacheArtifacts) {
+        globals.printStatus('  flutter-tizen precache --force', wrap: false);
+      }
+      globals.printStatus('  flutter-tizen doctor', wrap: false);
+      return;
+    }
+
+    Future<int> launch(List<String> args) async {
+      if (runLauncher != null) {
+        return runLauncher(args);
+      }
+      return globals.processUtils.stream(
+        <String>[
+          launcherRelativePath(globals.platform, globals.fs.path),
+          '--no-color',
+          '--no-version-check',
+          ...args,
+        ],
+        workingDirectory: repoRoot,
+        allowReentrantFlutter: true,
+        environment: Map<String, String>.of(globals.platform.environment),
+      );
+    }
+
+    int code;
+    try {
+      code = await launch(<String>['--version']);
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Switched to $targetTag, but "bin/flutter-tizen" could not be run '
+        'there.\n$e\nReturn to where you were with the command above.',
+      );
+    }
+    if (code != 0) {
+      throwToolExit(
+        'Switched to $targetTag, but setting up its toolchain did not '
+        'finish.\nIts first run fetches the Flutter SDK and runs '
+        '"pub upgrade", so a network failure and a release that does not '
+        'build look the same here.\nRetry with "flutter-tizen --version". '
+        'If that keeps failing, return to where you were with the command '
+        'above.',
+      );
+    }
+
+    if (cacheArtifacts) {
+      final int code = await launch(<String>['precache', '--force']);
+      if (code != 0) {
+        throwToolExit(
+          'Switched to $targetTag and the toolchain builds, but downloading '
+          'the engine artifacts failed.\nYour checkout is on the new version '
+          'and "flutter-tizen" works, so you can finish with '
+          '"flutter-tizen precache --force", or go back with the command '
+          'printed above.',
+        );
+      }
+    }
+
+    final int doctorCode = await launch(<String>['doctor']);
+    if (doctorCode != 0) {
+      globals.printWarning(
+        'Switched to $targetTag, but "flutter-tizen doctor" reported problems.',
+      );
+    }
+  }
+}

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -123,14 +123,17 @@ class TizenUpgradeCommandRunner extends UpgradeCommandRunner {
     );
     if (!testFlow) {
       globals.persistentToolState?.setShouldRedisplayWelcomeMessage(false);
-      await TizenChannelCommand.runPostSwitchSetup(
-        repoRoot: workingDirectory!,
-        targetTag: upstream.tag,
-        cacheArtifacts: true,
-        previousFlutterVersion: pinnedFlutterVersion,
-        runLauncher: _runLauncher,
-      );
-      globals.persistentToolState?.setShouldRedisplayWelcomeMessage(true);
+      try {
+        await TizenChannelCommand.runPostSwitchSetup(
+          repoRoot: workingDirectory!,
+          targetTag: upstream.tag,
+          cacheArtifacts: true,
+          previousFlutterVersion: pinnedFlutterVersion,
+          runLauncher: _runLauncher,
+        );
+      } finally {
+        globals.persistentToolState?.setShouldRedisplayWelcomeMessage(true);
+      }
     }
     return FlutterCommandResult.success();
   }

--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -1,0 +1,198 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/upgrade.dart';
+import 'package:flutter_tools/src/git.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:meta/meta.dart';
+
+import '../tizen_flutter_version.dart';
+import 'channel.dart';
+
+/// Upgrades the flutter-tizen toolchain to its newest release tag.
+///
+/// Source: [UpgradeCommand] in `upgrade.dart`
+class TizenUpgradeCommand extends UpgradeCommand {
+  TizenUpgradeCommand({required super.verboseHelp});
+
+  @override
+  String get description => 'Upgrade the flutter-tizen toolchain to the latest released version.';
+
+  @override
+  Future<FlutterCommandResult> runCommand() {
+    final commandRunner = TizenUpgradeCommandRunner();
+    // The repo root, not the vendored SDK at Cache.flutterRoot.
+    commandRunner.workingDirectory =
+        stringArg('working-directory') ?? globals.fs.directory(Cache.flutterRoot).parent.path;
+    return commandRunner.run(
+      force: boolArg('force'),
+      testFlow: stringArg('working-directory') != null,
+      verifyOnly: boolArg('verify-only'),
+    );
+  }
+}
+
+/// Runs the tag-based upgrade flow, without upstream's re-entrant
+/// `upgrade --continue` second half.
+///
+/// Source: [UpgradeCommandRunner] in `upgrade.dart`
+@visibleForTesting
+// Subclassing the upstream runner is the seam it exposes for reuse.
+// ignore: invalid_use_of_visible_for_testing_member
+class TizenUpgradeCommandRunner extends UpgradeCommandRunner {
+  TizenUpgradeCommandRunner({
+    Git? git,
+    Future<int> Function(List<String> args)? runLauncher,
+  })  : _git = git,
+        _runLauncher = runLauncher;
+
+  final Git? _git;
+  final Future<int> Function(List<String> args)? _runLauncher;
+
+  Git get _gitWrapper => _git ?? globals.git;
+
+  Future<FlutterCommandResult> run({
+    required bool force,
+    required bool testFlow,
+    required bool verifyOnly,
+  }) async {
+    final TizenGitTagVersion upstream = await _fetchLatestReleaseVersion();
+    final String upstreamCommit =
+        await TizenChannelCommand.peelToCommit(_gitWrapper, workingDirectory!, upstream.tag);
+    final String currentCommit =
+        await TizenChannelCommand.headCommit(_gitWrapper, workingDirectory!);
+
+    if (currentCommit == upstreamCommit) {
+      globals.printStatus('flutter-tizen is already up to date at ${upstream.tag}.');
+      return FlutterCommandResult.success();
+    }
+
+    final String? currentTag = await TizenChannelCommand.currentTag(_gitWrapper, workingDirectory!);
+    final String currentLabel = currentTag ?? _shortRevision(currentCommit);
+
+    if (verifyOnly) {
+      globals.printStatus('A new version of flutter-tizen is available.\n');
+      globals.printStatus('  Latest:  ${upstream.tag}', emphasis: true);
+      globals.printStatus('  Current: $currentLabel\n');
+      globals.printStatus('To upgrade now, run "flutter-tizen upgrade".');
+      return FlutterCommandResult.success();
+    }
+
+    if (!force && !await TizenChannelCommand.isTreeClean(_gitWrapper, workingDirectory!)) {
+      throwToolExit(
+        'Your flutter-tizen checkout in $workingDirectory has uncommitted '
+        'changes.\nCommit or stash them first, or re-run with --force to '
+        'discard them and upgrade anyway.',
+      );
+    }
+
+    if (!force && !await TizenChannelCommand.isFlutterSdkClean(_gitWrapper, workingDirectory!)) {
+      throwToolExit(
+        'The vendored Flutter SDK in '
+        '${globals.fs.path.join(workingDirectory!, 'flutter')} has '
+        'uncommitted changes, which the post-upgrade setup would discard.\n'
+        'Commit or stash them first, or re-run with --force to discard them '
+        'and upgrade anyway.',
+      );
+    }
+
+    final String? branch = await TizenChannelCommand.currentBranch(_gitWrapper, workingDirectory!);
+    final String? pinnedFlutterVersion =
+        TizenChannelCommand.readPinnedFlutterVersion(workingDirectory!);
+    globals.printStatus(
+      'Upgrading flutter-tizen to ${upstream.tag} from $currentLabel in '
+      '$workingDirectory...',
+    );
+    await TizenChannelCommand.checkoutDetached(
+      _gitWrapper,
+      workingDirectory!,
+      upstreamCommit,
+      force: force,
+    );
+    TizenChannelCommand.printRecovery(
+      repoRoot: workingDirectory!,
+      branch: branch,
+      headCommit: currentCommit,
+    );
+    if (!testFlow) {
+      globals.persistentToolState?.setShouldRedisplayWelcomeMessage(false);
+      await TizenChannelCommand.runPostSwitchSetup(
+        repoRoot: workingDirectory!,
+        targetTag: upstream.tag,
+        cacheArtifacts: true,
+        previousFlutterVersion: pinnedFlutterVersion,
+        runLauncher: _runLauncher,
+      );
+      globals.persistentToolState?.setShouldRedisplayWelcomeMessage(true);
+    }
+    return FlutterCommandResult.success();
+  }
+
+  /// Fetches tags and resolves the newest release tag on the remote.
+  Future<TizenGitTagVersion> _fetchLatestReleaseVersion() async {
+    try {
+      await _gitWrapper.run(
+        <String>['fetch', '--tags', '--force'],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(
+        '"git fetch --tags" failed in $workingDirectory, so the latest '
+        'release cannot be determined.\n${e.message}',
+      );
+    }
+
+    RunResult result;
+    try {
+      // Remote tags, not `git tag -l`: local-only tags must not become
+      // targets.
+      result = await _gitWrapper.run(
+        <String>['ls-remote', '--tags', '--sort=-v:refname', 'origin'],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(
+        'Could not list the flutter-tizen releases: "git ls-remote" failed '
+        'in $workingDirectory.\n${e.message}',
+      );
+    }
+    // Lines are `<sha>\t<ref>`; annotated tags add an extra `^{}` line.
+    const prefix = 'refs/tags/';
+    final tags = <TizenGitTagVersion>[];
+    for (final String line in result.stdout.split('\n')) {
+      final int tabIndex = line.indexOf('\t');
+      if (tabIndex == -1) {
+        continue;
+      }
+      final String ref = line.substring(tabIndex + 1).trim();
+      if (!ref.startsWith(prefix) || ref.endsWith('^{}')) {
+        continue;
+      }
+      final TizenGitTagVersion? tag = TizenGitTagVersion.parse(ref.substring(prefix.length));
+      if (tag != null) {
+        tags.add(tag);
+      }
+    }
+    if (tags.isEmpty) {
+      throwToolExit(
+        'Unable to upgrade flutter-tizen: no release tags were found on the '
+        '"origin" remote.\n'
+        'Make sure your flutter-tizen checkout tracks the upstream '
+        'repository.',
+      );
+    }
+    return tags.first;
+  }
+
+  String _shortRevision(String revision) =>
+      revision.length > 10 ? revision.substring(0, 10) : revision;
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -45,6 +45,7 @@ import 'package:path/path.dart';
 import 'build_targets/native_assets.dart';
 import 'commands/attach.dart';
 import 'commands/build.dart';
+import 'commands/channel.dart';
 import 'commands/clean.dart';
 import 'commands/create.dart';
 import 'commands/devices.dart';
@@ -52,6 +53,7 @@ import 'commands/drive.dart';
 import 'commands/precache.dart';
 import 'commands/run.dart';
 import 'commands/test.dart';
+import 'commands/upgrade.dart';
 import 'tizen_application_package.dart';
 import 'tizen_artifacts.dart';
 import 'tizen_build_system.dart';
@@ -149,6 +151,7 @@ Future<void> main(List<String> args) async {
         processInfo: globals.processInfo,
         fileSystem: globals.fs,
       ),
+      TizenChannelCommand(verboseHelp: verboseHelp),
       TizenBuildCommand(
         fileSystem: globals.fs,
         buildSystem: globals.buildSystem,
@@ -170,6 +173,7 @@ Future<void> main(List<String> args) async {
         flutterVersion: globals.flutterVersion,
       ),
       TizenCleanCommand(verbose: verbose),
+      TizenUpgradeCommand(verboseHelp: verboseHelp),
       TizenCreateCommand(verboseHelp: verboseHelp),
       TizenDriveCommand(
         verboseHelp: verboseHelp,

--- a/lib/tizen_flutter_version.dart
+++ b/lib/tizen_flutter_version.dart
@@ -2,11 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/time.dart';
 
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
+import 'package:meta/meta.dart';
 
 /// An implemented [FlutterVersion] for printing Flutter-tizen version.
 class TizenFlutterVersion implements FlutterVersion {
@@ -126,4 +129,54 @@ class TizenFlutterVersion implements FlutterVersion {
 /// Source: [_shortGitRevision] in `version.dart`
 String _shortGitRevision(String revision) {
   return revision.length > 10 ? revision.substring(0, 10) : revision;
+}
+
+/// A flutter-tizen release tag: `<flutter-version>-tizen.<tool-version>`
+/// (e.g. `3.44.4-tizen.1.0.0`) or a legacy bare Flutter version (`3.44.4`).
+///
+/// Source: [GitTagVersion] in `version.dart`
+@immutable
+class TizenGitTagVersion {
+  const TizenGitTagVersion({
+    required this.tag,
+    required this.flutterVersion,
+    this.toolVersion,
+  });
+
+  /// The git tag, e.g. `3.44.4-tizen.1.0.0` or `3.44.4`.
+  final String tag;
+
+  /// The Flutter version this release pins, e.g. `3.44.4`.
+  final String flutterVersion;
+
+  /// The flutter-tizen tool version, or null for legacy bare tags.
+  final String? toolVersion;
+
+  /// Matches release tags of either scheme.
+  static final RegExp tagPattern = RegExp(r'^(\d+\.\d+\.\d+)(?:-tizen\.(\d+\.\d+\.\d+))?$');
+
+  /// Parses [tag], or returns null when it is not a release tag.
+  static TizenGitTagVersion? parse(String tag) {
+    final RegExpMatch? match = tagPattern.firstMatch(tag.trim());
+    if (match == null) {
+      return null;
+    }
+    return TizenGitTagVersion(
+      tag: tag.trim(),
+      flutterVersion: match.group(1)!,
+      toolVersion: match.group(2),
+    );
+  }
+
+  /// Parses `git tag` output, preserving order and dropping non-release tags.
+  static List<TizenGitTagVersion> parseTags(String gitTagOutput) {
+    return const LineSplitter()
+        .convert(gitTagOutput.trim())
+        .map(parse)
+        .whereType<TizenGitTagVersion>()
+        .toList();
+  }
+
+  @override
+  String toString() => tag;
 }

--- a/test/commands/channel_test.dart
+++ b/test/commands/channel_test.dart
@@ -1,0 +1,275 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tizen/commands/channel.dart';
+import 'package:flutter_tizen/tizen_flutter_version.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/git.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:path/path.dart' as path;
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_process_manager.dart';
+import '../src/test_flutter_command_runner.dart';
+
+/// `git tag` output, deliberately not in commit-time order to prove the sort.
+const String _kTags = '3.44.8-tizen.1.0.0 1785985501\n'
+    '3.44.4-tizen.1.0.0 1784512674\n'
+    '3.44.4 1785985999\n'
+    '3.44.1-tizen.1.1.0 1783058282\n'
+    'some-branch-tag 1700000000\n';
+
+const List<String> _kTagCommand = <String>[
+  'git',
+  'tag',
+  '-l',
+  '--format=%(refname:short) %(committerdate:unix)%(*committerdate:unix)',
+];
+
+void main() {
+  late FakeProcessManager processManager;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  tearDownAll(() {
+    Cache.enableLocking();
+  });
+
+  setUp(() {
+    processManager = FakeProcessManager.empty();
+  });
+
+  TizenChannelCommand createCommand({
+    Future<int> Function(List<String> args)? runLauncher,
+  }) {
+    return TizenChannelCommand(
+      git: Git(
+        currentPlatform: FakePlatform(),
+        runProcessWith: ProcessUtils(
+          processManager: processManager,
+          logger: BufferLogger.test(),
+        ),
+      ),
+      repoRoot: '/repo',
+      runLauncher: runLauncher,
+    );
+  }
+
+  testUsingContext('lists release tags by tagged commit time, marking the current one', () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+      const FakeCommand(command: _kTagCommand, stdout: _kTags),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--tags', '--exact-match', 'HEAD'],
+        stdout: '3.44.4',
+      ),
+    ]);
+    await createTestCommandRunner(createCommand()).run(<String>['channel']);
+    // Newest tagged commit first, not version order.
+    final List<String> rows = testLogger.statusText
+        .split('\n')
+        .map((String line) => line.trim().split(' ').first)
+        .where(TizenGitTagVersion.tagPattern.hasMatch)
+        .toList();
+    expect(rows, <String>[
+      '3.44.4',
+      '3.44.8-tizen.1.0.0',
+      '3.44.4-tizen.1.0.0',
+      '3.44.1-tizen.1.1.0',
+    ]);
+    expect(RegExp(r'3\.44\.4\s+\(current\)').hasMatch(testLogger.statusText), isTrue);
+    expect(testLogger.statusText, isNot(contains('some-branch-tag')));
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  group('switch', () {
+    void addSwitchCommands({required String tag, required String peeled}) {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+        const FakeCommand(command: _kTagCommand, stdout: _kTags),
+        FakeCommand(
+          command: <String>['git', 'rev-parse', '$tag^{commit}'],
+          stdout: peeled,
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: 'abc1234',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'status', '-s', '--untracked-files=no'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'symbolic-ref', '-q', '--short', 'HEAD'],
+          stdout: 'master',
+        ),
+        FakeCommand(
+          command: <String>['git', 'checkout', '--detach', peeled],
+        ),
+      ]);
+    }
+
+    testUsingContext('switches to the exact tag given and prints recovery', () async {
+      addSwitchCommands(tag: '3.44.4-tizen.1.0.0', peeled: 'def5678');
+      final launcherCalls = <List<String>>[];
+      final TizenChannelCommand command = createCommand(runLauncher: (List<String> args) async {
+        launcherCalls.add(args);
+        return 0;
+      });
+      await createTestCommandRunner(command).run(<String>['channel', '3.44.4-tizen.1.0.0']);
+      expect(testLogger.statusText, contains('git -C "/repo" checkout --force "master"'));
+      expect(launcherCalls, <List<String>>[
+        <String>['--version'],
+        <String>['precache', '--force'],
+        <String>['doctor'],
+      ]);
+      expect(processManager, hasNoRemainingExpectations);
+    }, overrides: <Type, Generator>{
+      // Keep the inline setup path regardless of the host OS.
+      Platform: () => FakePlatform(),
+    });
+
+    testUsingContext('a legacy bare tag is checked out as-is, not resolved', () async {
+      addSwitchCommands(tag: '3.44.4', peeled: 'aaa1111');
+      final TizenChannelCommand command =
+          createCommand(runLauncher: (List<String> args) async => 0);
+      await createTestCommandRunner(command).run(<String>['channel', '3.44.4']);
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    testUsingContext('unknown target exits listing available tags', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+        const FakeCommand(command: _kTagCommand, stdout: _kTags),
+      ]);
+      await expectToolExitLater(
+        createTestCommandRunner(createCommand()).run(<String>['channel', '9.9.9']),
+        contains('No flutter-tizen release tag matches "9.9.9"'),
+      );
+    });
+
+    testUsingContext('--force skips the guards and passes --force to checkout', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+        const FakeCommand(command: _kTagCommand, stdout: _kTags),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '3.44.4-tizen.1.0.0^{commit}'],
+          stdout: 'def5678',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: 'abc1234',
+        ),
+        // No `git status`: --force skips the dirty-tree guards.
+        const FakeCommand(
+          command: <String>['git', 'symbolic-ref', '-q', '--short', 'HEAD'],
+          stdout: 'master',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'checkout', '--force', '--detach', 'def5678'],
+        ),
+      ]);
+      final TizenChannelCommand command =
+          createCommand(runLauncher: (List<String> args) async => 0);
+      await createTestCommandRunner(command)
+          .run(<String>['channel', '3.44.4-tizen.1.0.0', '--force']);
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    testUsingContext('uncommitted changes in the vendored Flutter SDK block the switch', () async {
+      globals.fs.directory('/repo/flutter/.git').createSync(recursive: true);
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+        const FakeCommand(command: _kTagCommand, stdout: _kTags),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '3.44.4-tizen.1.0.0^{commit}'],
+          stdout: 'def5678',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: 'abc1234',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'status', '-s', '--untracked-files=no'],
+          workingDirectory: '/repo',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'status', '-s'],
+          workingDirectory: '/repo/flutter',
+          stdout: '?? engine_patch.diff',
+        ),
+      ]);
+      await expectToolExitLater(
+        createTestCommandRunner(createCommand()).run(<String>['channel', '3.44.4-tizen.1.0.0']),
+        contains('vendored Flutter SDK'),
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('on Windows a Flutter pin change defers setup to the next run', () async {
+      addSwitchCommands(tag: '3.44.4-tizen.1.0.0', peeled: 'def5678');
+      final launcherCalls = <List<String>>[];
+      final TizenChannelCommand command = createCommand(runLauncher: (List<String> args) async {
+        launcherCalls.add(args);
+        return 0;
+      });
+      await createTestCommandRunner(command).run(<String>['channel', '3.44.4-tizen.1.0.0']);
+      // An unreadable pinned flutter.version counts as a pin change.
+      expect(launcherCalls, isEmpty);
+      expect(testLogger.statusText, contains('finish the setup'));
+      expect(testLogger.statusText, contains('flutter-tizen --version'));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
+    });
+
+    testUsingContext('dirty tree blocks the switch', () async {
+      processManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+        const FakeCommand(command: _kTagCommand, stdout: _kTags),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '3.44.4-tizen.1.0.0^{commit}'],
+          stdout: 'def5678',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+          stdout: 'abc1234',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'status', '-s', '--untracked-files=no'],
+          stdout: ' M lib/foo.dart',
+        ),
+      ]);
+      await expectToolExitLater(
+        createTestCommandRunner(createCommand()).run(<String>['channel', '3.44.4-tizen.1.0.0']),
+        contains('uncommitted changes'),
+      );
+    });
+  });
+
+  testWithoutContext('launcherRelativePath uses .bat on Windows', () {
+    expect(
+      TizenChannelCommand.launcherRelativePath(
+        FakePlatform(operatingSystem: 'windows'),
+        path.Context(style: path.Style.windows),
+      ),
+      r'bin\flutter-tizen.bat',
+    );
+    expect(
+      TizenChannelCommand.launcherRelativePath(
+        FakePlatform(),
+        path.Context(style: path.Style.posix),
+      ),
+      'bin/flutter-tizen',
+    );
+  });
+}

--- a/test/commands/upgrade_test.dart
+++ b/test/commands/upgrade_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/git.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -129,6 +130,49 @@ void main() {
       <String>['precache', '--force'],
       <String>['doctor'],
     ]);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    // Keep the inline setup path regardless of the host OS.
+    Platform: () => FakePlatform(),
+  });
+
+  testUsingContext('restores the welcome message state when the setup fails', () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+      const FakeCommand(
+        command: <String>['git', 'ls-remote', '--tags', '--sort=-v:refname', 'origin'],
+        stdout: 'fff0001\trefs/tags/3.44.8-tizen.1.0.0\n'
+            'fff0002\trefs/tags/3.44.8-tizen.1.0.0^{}\n',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '3.44.8-tizen.1.0.0^{commit}'],
+        stdout: 'def5678',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+        stdout: 'abc1234',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--tags', '--exact-match', 'HEAD'],
+        exitCode: 128,
+      ),
+      const FakeCommand(
+        command: <String>['git', 'status', '-s', '--untracked-files=no'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'symbolic-ref', '-q', '--short', 'HEAD'],
+        stdout: 'master',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'checkout', '--detach', 'def5678'],
+      ),
+    ]);
+    await expectLater(
+      createRunner(runLauncher: (List<String> args) async => 1)
+          .run(force: false, testFlow: false, verifyOnly: false),
+      throwsToolExit(),
+    );
+    expect(globals.persistentToolState?.shouldRedisplayWelcomeMessage, true);
     expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     // Keep the inline setup path regardless of the host OS.

--- a/test/commands/upgrade_test.dart
+++ b/test/commands/upgrade_test.dart
@@ -1,0 +1,137 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tizen/commands/upgrade.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/git.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/fake_process_manager.dart';
+
+void main() {
+  late FakeProcessManager processManager;
+
+  setUp(() {
+    processManager = FakeProcessManager.empty();
+  });
+
+  TizenUpgradeCommandRunner createRunner({
+    Future<int> Function(List<String> args)? runLauncher,
+  }) {
+    final runner = TizenUpgradeCommandRunner(
+      git: Git(
+        currentPlatform: FakePlatform(),
+        runProcessWith: ProcessUtils(
+          processManager: processManager,
+          logger: BufferLogger.test(),
+        ),
+      ),
+      runLauncher: runLauncher,
+    );
+    runner.workingDirectory = '/repo';
+    return runner;
+  }
+
+  testUsingContext('already up to date short-circuits', () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+      const FakeCommand(
+        command: <String>['git', 'ls-remote', '--tags', '--sort=-v:refname', 'origin'],
+        stdout: 'fff0001\trefs/tags/3.44.8-tizen.1.0.0\n'
+            'fff0002\trefs/tags/3.44.8-tizen.1.0.0^{}\n',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '3.44.8-tizen.1.0.0^{commit}'],
+        stdout: 'abc1234',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+        stdout: 'abc1234',
+      ),
+    ]);
+    await createRunner().run(force: false, testFlow: true, verifyOnly: false);
+    expect(testLogger.statusText, contains('already up to date'));
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testUsingContext('--verify-only reports and changes nothing', () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+      const FakeCommand(
+        command: <String>['git', 'ls-remote', '--tags', '--sort=-v:refname', 'origin'],
+        stdout: 'fff0001\trefs/tags/3.44.8-tizen.1.0.0\n'
+            'fff0002\trefs/tags/3.44.8-tizen.1.0.0^{}\n',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '3.44.8-tizen.1.0.0^{commit}'],
+        stdout: 'def5678',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+        stdout: 'abc1234',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--tags', '--exact-match', 'HEAD'],
+        stdout: '3.44.4-tizen.1.0.0',
+      ),
+      // No status/checkout: verify-only stops here.
+    ]);
+    await createRunner().run(force: false, testFlow: true, verifyOnly: true);
+    expect(testLogger.statusText, contains('3.44.8-tizen.1.0.0'));
+    expect(testLogger.statusText, contains('3.44.4-tizen.1.0.0'));
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testUsingContext('moves the checkout, prints recovery, and finishes with precache and doctor',
+      () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(command: <String>['git', 'fetch', '--tags', '--force']),
+      const FakeCommand(
+        command: <String>['git', 'ls-remote', '--tags', '--sort=-v:refname', 'origin'],
+        stdout: 'fff0001\trefs/tags/3.44.8-tizen.1.0.0\n'
+            'fff0002\trefs/tags/3.44.8-tizen.1.0.0^{}\n',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '3.44.8-tizen.1.0.0^{commit}'],
+        stdout: 'def5678',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--verify', 'HEAD'],
+        stdout: 'abc1234',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--tags', '--exact-match', 'HEAD'],
+        exitCode: 128,
+      ),
+      const FakeCommand(
+        command: <String>['git', 'status', '-s', '--untracked-files=no'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'symbolic-ref', '-q', '--short', 'HEAD'],
+        stdout: 'master',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'checkout', '--detach', 'def5678'],
+      ),
+    ]);
+    final launcherCalls = <List<String>>[];
+    await createRunner(runLauncher: (List<String> args) async {
+      launcherCalls.add(args);
+      return 0;
+    }).run(force: false, testFlow: false, verifyOnly: false);
+    expect(testLogger.statusText, contains('git -C "/repo" checkout --force "master"'));
+    expect(launcherCalls, <List<String>>[
+      <String>['--version'],
+      <String>['precache', '--force'],
+      <String>['doctor'],
+    ]);
+    expect(processManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    // Keep the inline setup path regardless of the host OS.
+    Platform: () => FakePlatform(),
+  });
+}

--- a/test/general/tizen_flutter_version_test.dart
+++ b/test/general/tizen_flutter_version_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tizen/tizen_flutter_version.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('TizenGitTagVersion.parse', () {
+    testWithoutContext('parses current-scheme release tags', () {
+      final TizenGitTagVersion? tag = TizenGitTagVersion.parse('3.44.4-tizen.1.0.0');
+      expect(tag, isNotNull);
+      expect(tag!.flutterVersion, '3.44.4');
+      expect(tag.toolVersion, '1.0.0');
+    });
+
+    testWithoutContext('parses legacy bare release tags', () {
+      final TizenGitTagVersion? tag = TizenGitTagVersion.parse('3.44.4');
+      expect(tag, isNotNull);
+      expect(tag!.tag, '3.44.4');
+      expect(tag.flutterVersion, '3.44.4');
+      expect(tag.toolVersion, isNull);
+    });
+
+    testWithoutContext('ignores non-release tags', () {
+      expect(TizenGitTagVersion.parse('v3.44.4-tizen.1.0.0'), isNull);
+      expect(TizenGitTagVersion.parse('3.44'), isNull);
+      expect(TizenGitTagVersion.parse('nightly'), isNull);
+    });
+  });
+
+  group('TizenGitTagVersion.parseTags', () {
+    testWithoutContext('keeps newest-first order, keeps bare tags, drops others', () {
+      final List<TizenGitTagVersion> tags = TizenGitTagVersion.parseTags(
+        '3.44.8-tizen.1.0.0\n3.44.4-tizen.1.0.0\n3.44.4\n3.44.1-tizen.1.1.0\nsome-branch-tag\n',
+      );
+      expect(tags.map((TizenGitTagVersion tag) => tag.tag), <String>[
+        '3.44.8-tizen.1.0.0',
+        '3.44.4-tizen.1.0.0',
+        '3.44.4',
+        '3.44.1-tizen.1.1.0',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
 Adds version management to command(`channel`, `upgrade`), replacing manual `git checkout` of release tags.

  - `flutter-tizen channel` — lists release tags (newest tagged commit first), marking the current one.
  - `flutter-tizen channel <tag>` — checks out that tag (1:1 with `git tag`, e.g. `3.44.4-tizen.1.0.0` or legacy `3.44.4`), then re-runs
  bootstrap, `precache --force`, and `doctor`.
  - `flutter-tizen upgrade` — moves to the newest release tag. `--verify-only` only reports.
  
