### PR TITLE
Update links in ai_rules.md

### DIFF
--- a/doc/ai_rules.md
+++ b/doc/ai_rules.md
@@ -1,7 +1,7 @@
 # AI rules for Flutter-Tizen
 This guide covers how you can leverage AI rules to streamline your Flutter-Tizen.
 
-_This AI rules guide is based on [AI ​​rules for Flutter and Dart page](https://docs.flutter.dev/ai/ai-rules) and [ai_rules.md](https://github.com/flutter/flutter/blob/master/docs/rules/rules.md)._
+_This AI rules guide is based on the [AI rules page](https://docs.flutter.dev/ai/ai-rules) and [rules.md](https://github.com/flutter/flutter/blob/master/docs/rules/rules.md)._
 
 You can provide the AI-powered editor with ai_rules.md to give the LLM context and instructions. It can help you write Flutter applications for TizenOS TV and Raspberry Pi using flutter-tizen.
 
@@ -13,6 +13,6 @@ You can provide the AI-powered editor with ai_rules.md to give the LLM context a
 
 # Environments that support rules
 
-This guide covers environments not mentioned on the [flutter's "AI Rules" guide page](https://docs.flutter.dev/ai/ai-rules#environments-that-support-rules).
+This guide covers environments not listed in the ["Device and editor specific limits" table](https://docs.flutter.dev/ai/ai-rules#device-and-editor-specific-limits) of flutter's "AI rules" guide page.
 
 * Cline - https://docs.cline.bot/features/cline-rules


### PR DESCRIPTION
The flutter AI rules page was restructured: the page title is now "AI rules" and the "Environments that support rules" section was replaced by the "Device and editor specific limits" table, so the old anchor no longer resolves.