### PR TITLE
Support hot reloading hook-generated assets

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/build_targets.dart';
+import 'package:flutter_tools/src/build_system/targets/hook_runner_native.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/commands/config.dart';
@@ -34,6 +35,7 @@ import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/hook_runner.dart';
 import 'package:flutter_tools/src/isolated/build_targets.dart';
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/project_validator.dart';
@@ -233,6 +235,7 @@ Future<void> main(List<String> args) async {
             logger: globals.logger,
             processManager: globals.processManager,
           ),
+      FlutterHookRunner: () => FlutterHookRunnerNative(),
       FlutterVersion: () => TizenFlutterVersion(
             fs: globals.fs,
             flutterRoot: Cache.flutterRoot!,


### PR DESCRIPTION
Register FlutterHookRunner in the tool's context overrides, mirroring flutter_tools' executable.dart. Without this registration, the resident runner's dartBuilder is null, so build hooks are not re-run when the asset bundle is rebuilt during hot reload and changes to hook-generated data assets are never delivered to the running app.