### PR TITLE
[ci] Fix stale issue label exemptions

### DIFF
--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -24,10 +24,7 @@ jobs:
           days-before-stale: 60
           days-before-close: 0
           only-issue-labels: ""
-          exempt-issue-labels: |
-            bug
-            enhancement
-            keep
+          exempt-issue-labels: bug,enhancement,keep,announcement
           close-issue-message: >
             This page has been automatically closed since there has not been any recent activity. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.
           operations-per-run: 100


### PR DESCRIPTION
Change the labels used as exception conditions for determining stale issues to be comma-separated.

https://github.com/actions/stale/blob/5bef64f19d7facfb25b37b414482c7164d639639/src/functions/words-to-list.ts#L17-L23