### PR TITLE
Enable Impeller by default

### DIFF
--- a/embedding/cpp/flutter_engine_arguments.cc
+++ b/embedding/cpp/flutter_engine_arguments.cc
@@ -11,7 +11,7 @@
 
 namespace {
 
-static constexpr const char* kMetadataKeyEnableImepeller =
+static constexpr const char* kMetadataKeyEnableImpeller =
     "http://tizen.org/metadata/flutter_tizen/enable_impeller";
 static constexpr const char* kMetadataKeyEnableFlutterGpu =
     "http://tizen.org/metadata/flutter_tizen/enable_flutter_gpu";
@@ -55,11 +55,12 @@ std::vector<std::string> FlutterEngineArguments::ParseEngineArgs() {
 
   std::map<std::string, std::string> metadata = GetMetadata(app_id);
 
-  is_impeller_enabled_ = ProcessMetadataFlag(
-      engine_args, "--enable-impeller", kMetadataKeyEnableImepeller, metadata);
+  is_impeller_enabled_ =
+      ProcessMetadataFlag(engine_args, "--enable-impeller",
+                          kMetadataKeyEnableImpeller, metadata, true);
   is_flutter_gpu_enabled_ =
       ProcessMetadataFlag(engine_args, "--enable-flutter-gpu",
-                          kMetadataKeyEnableFlutterGpu, metadata);
+                          kMetadataKeyEnableFlutterGpu, metadata, false);
 
   for (const std::string& arg : engine_args) {
     TizenLog::Info("Enabled: %s", arg.c_str());
@@ -95,27 +96,22 @@ std::map<std::string, std::string> FlutterEngineArguments::GetMetadata(
 bool FlutterEngineArguments::ProcessMetadataFlag(
     std::vector<std::string>& engine_args, const std::string& flag,
     const std::string& metadata_key,
-    const std::map<std::string, std::string>& metadata) {
-  bool enabled = false;
-  auto flag_it = std::find(engine_args.begin(), engine_args.end(), flag);
-  bool flag_exists = (flag_it != engine_args.end());
-
-  if (flag_exists) {
-    enabled = true;
+    const std::map<std::string, std::string>& metadata,
+    bool enabled_by_default) {
+  if (std::find(engine_args.begin(), engine_args.end(), flag + "=false") !=
+      engine_args.end()) {
+    return false;
+  }
+  if (std::find(engine_args.begin(), engine_args.end(), flag) !=
+      engine_args.end()) {
+    return true;
   }
 
   auto metadata_it = metadata.find(metadata_key);
-  if (metadata_it != metadata.end()) {
-    bool metadata_enabled = (metadata_it->second == "true");
-
-    if (!flag_exists && metadata_enabled) {
-      enabled = true;
-      engine_args.insert(engine_args.begin(), flag);
-    } else if (flag_exists && !metadata_enabled) {
-      enabled = false;
-      engine_args.erase(flag_it);
-    }
+  bool enabled = metadata_it == metadata.end() ? enabled_by_default
+                                               : metadata_it->second == "true";
+  if (enabled) {
+    engine_args.insert(engine_args.begin(), flag);
   }
-
   return enabled;
 }

--- a/embedding/cpp/include/flutter_engine_arguments.h
+++ b/embedding/cpp/include/flutter_engine_arguments.h
@@ -45,7 +45,8 @@ class FlutterEngineArguments {
   bool ProcessMetadataFlag(std::vector<std::string>& engine_args,
                            const std::string& flag,
                            const std::string& metadata_key,
-                           const std::map<std::string, std::string>& metadata);
+                           const std::map<std::string, std::string>& metadata,
+                           bool enabled_by_default);
 
   // The list of parsed engine arguments.
   std::vector<std::string> engine_args_;

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngineArguments.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterEngineArguments.cs
@@ -14,7 +14,7 @@ namespace Tizen.Flutter.Embedding
     /// </summary>
     public class FlutterEngineArguments
     {
-        private const string MetadataKeyEnableImepeller = "http://tizen.org/metadata/flutter_tizen/enable_impeller";
+        private const string MetadataKeyEnableImpeller = "http://tizen.org/metadata/flutter_tizen/enable_impeller";
         private const string MetadataKeyEnableFlutterGpu = "http://tizen.org/metadata/flutter_tizen/enable_flutter_gpu";
 
         /// <summary>
@@ -71,8 +71,8 @@ namespace Tizen.Flutter.Embedding
                 }
             }
 
-            IsImpellerEnabled = ProcessMetadataFlag(result, "--enable-impeller", MetadataKeyEnableImepeller);
-            IsFlutterGpuEnabled = ProcessMetadataFlag(result, "--enable-flutter-gpu", MetadataKeyEnableFlutterGpu);
+            IsImpellerEnabled = ProcessMetadataFlag(result, "--enable-impeller", MetadataKeyEnableImpeller, true);
+            IsFlutterGpuEnabled = ProcessMetadataFlag(result, "--enable-flutter-gpu", MetadataKeyEnableFlutterGpu, false);
             IsFlutterTizenExperimentalEnabled = result.Contains("--dart-define=USE_FLUTTER_TIZEN_EXPERIMENTAL=true");
 
             foreach (string flag in result)
@@ -85,30 +85,24 @@ namespace Tizen.Flutter.Embedding
         /// <summary>
         /// Processes a metadata flag by checking both engine arguments and application metadata.
         /// </summary>
-        private static bool ProcessMetadataFlag(List<string> result, string flag, string metadataKey)
+        private static bool ProcessMetadataFlag(List<string> result, string flag, string metadataKey, bool enabledByDefault)
         {
             var appInfo = Application.Current.ApplicationInfo;
-            bool enabled = false;
-            bool flagExists = result.Contains(flag);
-            if (flagExists)
+            if (result.Contains(flag + "=false"))
             {
-                enabled = true;
+                return false;
+            }
+            if (result.Contains(flag))
+            {
+                return true;
             }
 
-            if (appInfo.Metadata.TryGetValue(metadataKey, out string metadataValue))
+            bool enabled = appInfo.Metadata.TryGetValue(metadataKey, out string metadataValue)
+                ? metadataValue == "true"
+                : enabledByDefault;
+            if (enabled)
             {
-                bool metadataEnabled = metadataValue == "true";
-
-                if (!flagExists && metadataEnabled)
-                {
-                    enabled = true;
-                    result.Insert(0, flag);
-                }
-                else if (flagExists && !metadataEnabled)
-                {
-                    enabled = false;
-                    result.Remove(flag);
-                }
+                result.Insert(0, flag);
             }
             return enabled;
         }

--- a/lib/tizen_device.dart
+++ b/lib/tizen_device.dart
@@ -406,6 +406,7 @@ class TizenDevice extends Device {
       if (debuggingOptions.profileMicrotasks) '--profile-microtasks',
       if (debuggingOptions.purgePersistentCache) '--purge-persistent-cache',
       if (debuggingOptions.enableImpeller == ImpellerStatus.enabled) '--enable-impeller',
+      if (debuggingOptions.enableImpeller == ImpellerStatus.disabled) '--enable-impeller=false',
       if (debuggingOptions.enableFlutterGpu) '--enable-flutter-gpu',
       if (debuggingOptions.enableVulkanValidation) '--enable-vulkan-validation',
       if (debuggingOptions.debuggingEnabled) ...<String>[

--- a/test/general/tizen_device_test.dart
+++ b/test/general/tizen_device_test.dart
@@ -98,10 +98,16 @@ void main() {
     final LaunchResult launchResult = await device.startApp(
       tpk,
       prebuiltApplication: true,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo.debug,
+        enableImpeller: ImpellerStatus.disabled,
+      ),
       platformArgs: <String, Object>{},
     );
 
+    final List<String> engineArgs =
+        fileSystem.file('/.tmp_rand0/rand0/$appId.rpm').readAsLinesSync();
+    expect(engineArgs, contains('--enable-impeller=false'));
     expect(launchResult.started, isTrue);
     expect(launchResult.hasVmService, isTrue);
     expect(processManager, hasNoRemainingExpectations);


### PR DESCRIPTION
We've supported the impeller renderer(opengl) since [3.27.1-tizen.1.0.0](https://github.com/flutter-tizen/flutter-tizen/releases/tag/3.27.1-tizen.1.0.0).
Currently, there are no specific cases where issues arise due to the impeller renderer.
Therefore, we will now set impeller as the default renderer. If metadata is not specified, the app will always run with the impeller renderer.
If you want to use the skia renderer instead of impeller for compatibility with existing apps, you can use `false` to the value of the `http://tizen.org/metadata/flutter_tizen/enable_impeller` key in tizen-manifest.xml.
```xml
   <metadata key="http://tizen.org/metadata/flutter_tizen/enable_impeller" value= "false"/>
```

If you do not want to use the impeller renderer in the flutter-tizen run command, you can use the `--no-enable-impeller` flag.
```kernel
 $) flutter-tizen run --no-enable-impeller
```

related issue : https://github.com/flutter-tizen/flutter-tizen/issues/692