### PR TITLE
Replace deprecated platform name helpers

### DIFF
--- a/lib/build_targets/application.dart
+++ b/lib/build_targets/application.dart
@@ -236,7 +236,7 @@ class TizenAotElf extends AotElfBase {
     if (splitDebugInfo != null && splitDebugInfo.isNotEmpty) {
       final Directory splitDebugInfoDir = environment.fileSystem.directory(splitDebugInfo);
       final File symbolsFile =
-          splitDebugInfoDir.childFile('app.${getNameForTargetPlatform(targetPlatform)}.symbols');
+          splitDebugInfoDir.childFile('app.${targetPlatform.getName()}.symbols');
       if (symbolsFile.existsSync()) {
         symbolsFile.renameSync(splitDebugInfoDir
             .childFile('app.tizen-${getArchForTargetPlatform(targetPlatform)}.symbols')

--- a/lib/build_targets/native_assets.dart
+++ b/lib/build_targets/native_assets.dart
@@ -319,7 +319,7 @@ TargetPlatform _getTargetPlatformFromEnvironment(Environment environment, String
   if (targetPlatformEnvironment == null) {
     throw MissingDefineException(kTargetPlatform, name);
   }
-  return getTargetPlatformForName(targetPlatformEnvironment);
+  return TargetPlatform.fromName(targetPlatformEnvironment);
 }
 
 BuildMode _getBuildModeFromEnvironment(Environment environment, String name) {

--- a/lib/commands/run.dart
+++ b/lib/commands/run.dart
@@ -68,7 +68,7 @@ class TizenDeviceLogger extends DelegatingLogger {
               '(${device.deviceProfile})${device.deviceProfile == 'tv' ? '    ' : ''}',
             )
             .replaceFirst(
-              getNameForTargetPlatform(TargetPlatform.tester),
+              TargetPlatform.tester.getName(),
               'tizen-${device.architecture}${device.architecture == 'arm64' ? '   ' : '     '}',
             );
       }

--- a/lib/tizen_artifacts.dart
+++ b/lib/tizen_artifacts.dart
@@ -38,7 +38,7 @@ class TizenArtifacts extends CachedArtifacts {
   }) {
     if (artifact == Artifact.genSnapshot &&
         platform != null &&
-        getNameForTargetPlatform(platform).startsWith('android')) {
+        platform.getName().startsWith('android')) {
       assert(mode != null, 'Need to specify a build mode.');
       assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
       final String arch = getArchForTargetPlatform(platform);
@@ -46,7 +46,7 @@ class TizenArtifacts extends CachedArtifacts {
       assert(hostPlatform != HostPlatform.linux_arm64,
           'Artifact $artifact not available on Linux arm64.');
       return _getEngineArtifactsDirectory(arch, mode!)
-          .childDirectory(getNameForHostPlatform(hostPlatform))
+          .childDirectory(hostPlatform.cliName)
           .childFile('gen_snapshot')
           .path;
     }

--- a/lib/tizen_build_info.dart
+++ b/lib/tizen_build_info.dart
@@ -21,7 +21,7 @@ class TizenBuildInfo {
   final String? securityProfile;
 }
 
-/// See: [getNameForTargetPlatform] in `build_info.dart`
+/// See: [TargetPlatform.getName] in `build_info.dart`
 String getArchForTargetPlatform(TargetPlatform platform) {
   return switch (platform) {
     TargetPlatform.android_arm => 'arm',
@@ -34,7 +34,7 @@ String getArchForTargetPlatform(TargetPlatform platform) {
   };
 }
 
-/// See: [getTargetPlatformForName] in `build_info.dart`
+/// See: [TargetPlatform.fromName] in `build_info.dart`
 TargetPlatform getTargetPlatformForArch(String arch) {
   return switch (arch) {
     'arm' => TargetPlatform.android_arm,

--- a/lib/tizen_builder.dart
+++ b/lib/tizen_builder.dart
@@ -62,8 +62,7 @@ class TizenBuilder {
     final Directory outputDir =
         project.directory.childDirectory('build').childDirectory('tizen').childDirectory('tpk');
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
-    final String targetPlatform =
-        getNameForTargetPlatform(getTargetPlatformForArch(tizenBuildInfo.targetArch));
+    final String targetPlatform = getTargetPlatformForArch(tizenBuildInfo.targetArch).getName();
 
     final environment = Environment(
       projectDir: project.directory,
@@ -189,8 +188,7 @@ class TizenBuilder {
           .childDirectory('module');
     }
     final BuildInfo buildInfo = tizenBuildInfo.buildInfo;
-    final String targetPlatform =
-        getNameForTargetPlatform(getTargetPlatformForArch(tizenBuildInfo.targetArch));
+    final String targetPlatform = getTargetPlatformForArch(tizenBuildInfo.targetArch).getName();
 
     final environment = Environment(
       projectDir: project.directory,


### PR DESCRIPTION
`getNameForTargetPlatform`, `getTargetPlatformForName` and `getNameForHostPlatform` were deprecated in Flutter 3.47 in favor of `TargetPlatform.getName`, `TargetPlatform.fromName` and `HostPlatform.cliName`.
