### PR TITLE
Validate Tizen plugin identifiers in pubspec.yaml

### DIFF
--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -46,6 +46,11 @@ const kFilePath = 'filePath';
 /// Constant for 'libName' key in plugin maps.
 const kLibName = 'libName';
 
+final RegExp _identifierPattern = RegExp(
+  r'^[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)*$',
+);
+final RegExp _fileNamePattern = RegExp(r'^\w[\w.-]*$');
+
 /// Contains the parameters to template a Tizen plugin.
 ///
 /// The [name] of the plugin is required. Either [dartPluginClass] or
@@ -65,28 +70,53 @@ class TizenPlugin extends PluginPlatform implements NativeOrDartPlugin {
     this.dartPluginClass,
     this.fileName,
     required this.isDevDependency,
-  }) : assert(pluginClass != null || dartPluginClass != null);
+  });
 
+  /// See: [WebPlugin.fromYaml] in `platform_plugins.dart`
   static TizenPlugin fromYaml(
     String name,
     Directory directory,
     YamlMap yaml, {
     required bool isDevDependency,
   }) {
-    assert(validate(yaml));
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+    final Object? namespace = yaml[kNamespace];
+    final Object? fileName = yaml[kFileName];
+    if (pluginClass is! String &&
+        dartPluginClass is! String &&
+        yaml[kFfiPlugin] != true &&
+        yaml[kDefaultPackage] is! String) {
+      throwToolExit(
+        'The plugin `$name` is missing `pluginClass` or `dartPluginClass` '
+        'in its tizen plugin declaration.',
+      );
+    }
+    for (final MapEntry<String, Object?> entry in <String, Object?>{
+      kPluginClass: pluginClass,
+      kDartPluginClass: dartPluginClass,
+      kNamespace: namespace,
+    }.entries) {
+      final Object? value = entry.value;
+      if (value is String && !_identifierPattern.hasMatch(value)) {
+        throwToolExit(
+          'The plugin `$name` has an invalid `${entry.key}` in its tizen plugin declaration.',
+        );
+      }
+    }
+    if (fileName is String && !_fileNamePattern.hasMatch(fileName)) {
+      throwToolExit(
+          'The plugin `$name` has an invalid `fileName` in its tizen plugin declaration.');
+    }
     return TizenPlugin(
       name: name,
       directory: directory,
-      namespace: yaml[kNamespace] as String?,
-      pluginClass: yaml[kPluginClass] as String?,
-      dartPluginClass: yaml[kDartPluginClass] as String?,
-      fileName: yaml[kFileName] as String?,
+      namespace: namespace as String?,
+      pluginClass: pluginClass as String?,
+      dartPluginClass: dartPluginClass as String?,
+      fileName: fileName as String?,
       isDevDependency: isDevDependency,
     );
-  }
-
-  static bool validate(YamlMap yaml) {
-    return yaml[kPluginClass] is String || yaml[kDartPluginClass] is String;
   }
 
   static const kConfigKey = 'tizen';

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -13,7 +13,9 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:yaml/yaml.dart';
 
+import '../src/common.dart';
 import '../src/context.dart';
 import '../src/test_flutter_command_runner.dart';
 
@@ -525,6 +527,44 @@ type = staticLib
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
   }, testOn: 'posix');
+
+  TizenPlugin pluginFromYaml(String yaml) => TizenPlugin.fromYaml(
+        'some_plugin',
+        fileSystem.directory('/some_plugin/tizen'),
+        loadYaml(yaml) as YamlMap,
+        isDevDependency: false,
+      );
+
+  testWithoutContext('Accepts valid plugin specifications', () {
+    expect(pluginFromYaml('pluginClass: SomePlugin\nfileName: some_plugin.h').isDotnet(), isFalse);
+    expect(
+      pluginFromYaml('namespace: Some.Plugin\npluginClass: SomePlugin\nfileName: Some.csproj')
+          .isDotnet(),
+      isTrue,
+    );
+    expect(pluginFromYaml('dartPluginClass: SomePlugin').hasDart(), isTrue);
+    expect(pluginFromYaml('ffiPlugin: true').hasMethodChannel(), isFalse);
+    expect(pluginFromYaml('default_package: some_plugin_tizen').hasDart(), isFalse);
+  });
+
+  testWithoutContext('Rejects invalid plugin specifications', () {
+    const invalid = <String, String>{
+      'fileName: some_plugin.h': 'is missing `pluginClass` or `dartPluginClass`',
+      'pluginClass: "SomePlugin(); evil(); //"': 'has an invalid `pluginClass`',
+      'dartPluginClass: "Evil(); class Evil"': 'has an invalid `dartPluginClass`',
+      'namespace: "Some; using Evil"\npluginClass: SomePlugin': 'has an invalid `namespace`',
+      'pluginClass: SomePlugin\nfileName: "some_plugin.h\\"\\n#include \\"/etc/passwd"':
+          'has an invalid `fileName`',
+      'pluginClass: SomePlugin\nfileName: ../../evil.h': 'has an invalid `fileName`',
+    };
+    for (final MapEntry<String, String> entry in invalid.entries) {
+      expect(
+        () => pluginFromYaml(entry.key),
+        throwsToolExit(message: 'The plugin `some_plugin` ${entry.value}'),
+        reason: entry.key,
+      );
+    }
+  });
 }
 
 class _DummyFlutterCommand extends FlutterCommand with DartPluginRegistry {


### PR DESCRIPTION
Flutter 3.47.1 validates plugin identifiers to prevent code injection into the generated registrants, but not the `tizen` block that flutter-tizen reads. Apply the same rules here and replace the assert, which is stripped in the snapshot, with a tool exit.

https://github.com/flutter/flutter/pull/189156