### PR TITLE
Initialize the Tizen Core lifecycle for Tizen 11.0 or later

### DIFF
--- a/embedding/cpp/flutter_app.cc
+++ b/embedding/cpp/flutter_app.cc
@@ -6,6 +6,10 @@
 
 #include <cassert>
 
+#ifdef TIZEN_CORE
+#include <tizen_core.h>
+#endif
+
 #include "tizen_log.h"
 
 bool FlutterApp::OnCreate() {
@@ -89,6 +93,10 @@ void FlutterApp::OnRegionFormatChanged(app_event_info_h event_info) {
 }
 
 int FlutterApp::Run(int argc, char **argv) {
+#ifdef TIZEN_CORE
+  tizen_core_init();
+#endif
+
   ui_app_lifecycle_callback_s lifecycle_cb = {};
   lifecycle_cb.create = [](void *data) -> bool {
     auto *app = reinterpret_cast<FlutterApp *>(data);
@@ -152,6 +160,10 @@ int FlutterApp::Run(int argc, char **argv) {
   if (ret != APP_ERROR_NONE) {
     TizenLog::Error("Could not launch an application. (%d)", ret);
   }
+
+#ifdef TIZEN_CORE
+  tizen_core_shutdown();
+#endif
   return ret;
 }
 

--- a/embedding/csharp/FlutterApplication.props
+++ b/embedding/csharp/FlutterApplication.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>tizen80</TargetFramework>
+    <TargetFramework Condition="'$(TizenCoreEnabled)' == 'true'">net8.0-tizen10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TizenCoreEnabled)' != 'true'">
+    <PackageReference Include="Tizen.NET.Sdk" Version="1.1.7" PrivateAssets="All" />
+    <PackageReference Include="Tizen.NET" Version="9.0.0.16760" PrivateAssets="All" ExcludeAssets="Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(FlutterEmbeddingPath)" />
+  </ItemGroup>
+
+</Project>

--- a/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/FlutterApplication.cs
@@ -7,6 +7,10 @@ using System.Diagnostics;
 using Tizen.Applications;
 using static Tizen.Flutter.Embedding.Interop;
 
+#if TIZEN_CORE
+using Tizen.Core;
+#endif
+
 namespace Tizen.Flutter.Embedding
 {
     /// <summary>
@@ -130,7 +134,19 @@ namespace Tizen.Flutter.Embedding
                 TizenLog.Error($"Unhandled exception: {exception}");
             };
 
+#if TIZEN_CORE
+            TizenCore.Initialize();
+            try
+            {
+                base.Run(args);
+            }
+            finally
+            {
+                TizenCore.Shutdown();
+            }
+#else
             base.Run(args);
+#endif
         }
 
         /// <InheritDoc/>

--- a/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFrameworks>netstandard2.0;tizen40;tizen80;tizen90</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TizenCoreEnabled)' != 'true'">netstandard2.0;tizen40;tizen80;tizen90</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TizenCoreEnabled)' == 'true'">net8.0-tizen10.0</TargetFrameworks>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
@@ -20,12 +21,16 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TizenCoreEnabled)' == 'true'">
+    <DefineConstants>$(DefineConstants);TIZEN_CORE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="Tizen.Flutter.Embedding.targets" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="9.0.0.16760" />
+    <PackageReference Include="Tizen.NET" Version="9.0.0.16760" Condition="'$(TizenCoreEnabled)' != 'true'" />
   </ItemGroup>
 
 </Project>

--- a/lib/build_targets/embedding.dart
+++ b/lib/build_targets/embedding.dart
@@ -28,6 +28,7 @@ class NativeEmbedding extends Target {
   @override
   List<Source> get inputs => const <Source>[
         Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/embedding.dart'),
+        Source.pattern('{FLUTTER_ROOT}/../lib/build_targets/utils.dart'),
         Source.pattern('{FLUTTER_ROOT}/../lib/tizen_sdk.dart'),
       ];
 
@@ -109,6 +110,7 @@ class NativeEmbedding extends Target {
       arch: getTizenCliArch(buildInfo.targetArch),
       predefines: <String>[
         '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+        if (usesTizenCoreEmbedder(apiVersion)) 'TIZEN_CORE',
       ],
       extraOptions: <String>['-fPIC'],
       rootstrap: rootstrap.id,

--- a/lib/build_targets/package.dart
+++ b/lib/build_targets/package.dart
@@ -372,12 +372,13 @@ class NativeTpk extends TizenPackage {
 
     final Directory embeddingDir = environment.buildDir.childDirectory('tizen_embedding');
     final File embeddingLib = embeddingDir.childFile('libembedding_cpp.a');
-    const embeddingDependencies = <String>[
+    final embeddingDependencies = <String>[
       'appcore-agent',
       'capi-appfw-app-common',
       'capi-appfw-application',
       'capi-appfw-app-manager',
       'dlog',
+      if (usesTizenCoreEmbedder(apiVersion)) 'tizen-core',
     ];
 
     final Directory buildDir = tizenProject.hostAppRoot.childDirectory(buildConfig);

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -137,6 +137,7 @@ class NativePlugins extends Target {
             '-l${getLibNameForFileName(embedder.basename)}',
             '-L${embedderDir.path.toPosixPath()}',
             embeddingLib.path.toPosixPath(),
+            if (usesTizenCoreEmbedder(apiVersion)) '-ltizen-core',
           ],
         ],
         rootstrap: rootstrap.id,

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -38,13 +38,22 @@ Directory getEngineArtifactsDirectory(String arch, BuildMode mode) {
       : globals.cache.getArtifactDirectory('engine').childDirectory('tizen-$arch-${mode.name}');
 }
 
+final Version kTizenCoreApiVersion = Version(11, 0, 0);
+
+bool usesTizenCoreEmbedder(String? apiVersion) {
+  final Version version = Version.parse(apiVersion) ?? Version(6, 0, 0);
+  return version >= kTizenCoreApiVersion;
+}
+
 Directory getEmbedderArtifactsDirectory(String? apiVersion, String arch) {
   final Version version = Version.parse(apiVersion) ?? Version(6, 0, 0);
   if (arch == 'x86_64') {
     arch = 'x64';
   }
 
-  if (arch == 'x64' && version >= Version(8, 0, 0)) {
+  if (version >= kTizenCoreApiVersion) {
+    apiVersion = '11.0';
+  } else if (arch == 'x64' && version >= Version(8, 0, 0)) {
     apiVersion = '8.0';
   } else if (version >= Version(6, 5, 0)) {
     apiVersion = '6.5';

--- a/lib/tizen_plugins.dart
+++ b/lib/tizen_plugins.dart
@@ -611,19 +611,12 @@ Future<void> _writeTizenPluginRegistrant(
   }
 }
 
-// Reserved for future use.
-const _intermediateDotnetPropsTemplate = '''
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-</Project>
-''';
-
-const _intermediateDotnetTargetsTemplate = '''
+const _intermediateDotnetTargetsTemplate = r'''
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
   {{#dotnetPlugins}}
-    <ProjectReference Include="{{filePath}}" />
+    <ProjectReference Include="{{filePath}}" AdditionalProperties="TizenCoreEnabled=$(TizenCoreEnabled)" />
   {{/dotnetPlugins}}
   </ItemGroup>
 </Project>
@@ -640,11 +633,6 @@ Future<void> _writeIntermediateDotnetFiles(
   final String projectFileName = project.projectFile!.basename;
   final Directory intermediateDirectory = project.hostAppRoot.childDirectory('obj');
   await renderTemplateToFile(
-    _intermediateDotnetPropsTemplate,
-    context,
-    intermediateDirectory.childFile('$projectFileName.flutter.props'),
-  );
-  await renderTemplateToFile(
     _intermediateDotnetTargetsTemplate,
     context,
     intermediateDirectory.childFile('$projectFileName.flutter.targets'),
@@ -654,11 +642,6 @@ Future<void> _writeIntermediateDotnetFiles(
     final File? serviceProjectFile = findDotnetProjectFile(project.serviceAppDirectory);
     final String projectFileName = serviceProjectFile!.basename;
     final Directory intermediateDirectory = project.serviceAppDirectory.childDirectory('obj');
-    await renderTemplateToFile(
-      _intermediateDotnetPropsTemplate,
-      context,
-      intermediateDirectory.childFile('$projectFileName.flutter.props'),
-    );
     await renderTemplateToFile(
       _intermediateDotnetTargetsTemplate,
       context,

--- a/lib/tizen_project.dart
+++ b/lib/tizen_project.dart
@@ -15,6 +15,7 @@ import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
 
+import 'build_targets/utils.dart';
 import 'tizen_plugins.dart';
 import 'tizen_tpk.dart';
 
@@ -228,24 +229,76 @@ void updateDotnetUserProjectFile(File projectFile) {
       .childDirectory('csharp')
       .childDirectory('Tizen.Flutter.Embedding')
       .childFile('Tizen.Flutter.Embedding.csproj');
-  final Iterable<XmlElement> elements = document.findAllElements('FlutterEmbeddingPath');
-  if (elements.isEmpty) {
-    // Create an element if not exists.
-    final builder = XmlBuilder();
-    builder.element('PropertyGroup', nest: () {
-      builder.element(
-        'FlutterEmbeddingPath',
-        nest: embeddingProjectFile.absolute.path,
-      );
-    });
-    document.rootElement.children.add(builder.buildFragment());
-  } else {
-    // Update existing element(s).
-    for (final element in elements) {
-      element.innerText = embeddingProjectFile.absolute.path;
+
+  void setProperty(String name, String value, {String? condition}) {
+    final Iterable<XmlElement> elements = document.findAllElements(name);
+    if (elements.isEmpty) {
+      final builder = XmlBuilder();
+      builder.element('PropertyGroup', nest: () {
+        builder.element(name,
+            attributes: <String, String>{if (condition != null) 'Condition': condition},
+            nest: value);
+      });
+      document.rootElement.children.add(builder.buildFragment());
+    } else {
+      for (final element in elements) {
+        element.innerText = value;
+        if (condition != null) {
+          element.setAttribute('Condition', condition);
+        }
+      }
     }
   }
+
+  final bool tizenCoreEnabled = _readsTizenCoreManifest(projectFile);
+  final propsBuilder = XmlBuilder();
+  propsBuilder.element('Project', nest: () {
+    propsBuilder.element('PropertyGroup', nest: () {
+      propsBuilder.element('TizenCoreEnabled', nest: tizenCoreEnabled.toString());
+    });
+    propsBuilder.element('Import', attributes: <String, String>{
+      'Project':
+          embeddingProjectFile.parent.parent.childFile('FlutterApplication.props').absolute.path,
+    });
+  });
+  final File propsFile = projectFile.parent.childDirectory('obj').childFile('Flutter.props');
+  propsFile
+    ..createSync(recursive: true)
+    ..writeAsStringSync(propsBuilder.buildDocument().toXmlString(pretty: true, indent: '  '));
+
+  setProperty('FlutterEmbeddingPath', embeddingProjectFile.absolute.path);
+  setProperty('TizenCoreEnabled', tizenCoreEnabled.toString());
+  setProperty('RestoreUseStaticGraphEvaluation', 'true',
+      condition: r"'$(TizenCoreEnabled)' == 'true'");
+  setProperty('ImportProjectExtensionTargets', 'true');
+
+  if (!document.findAllElements('ProjectReference').any(
+        (XmlElement element) => element.getAttribute('Update') == r'@(ProjectReference)',
+      )) {
+    final builder = XmlBuilder();
+    builder.element('ItemGroup', nest: () {
+      builder.element('ProjectReference', attributes: <String, String>{
+        'Update': r'@(ProjectReference)',
+        'AdditionalProperties':
+            r'%(ProjectReference.AdditionalProperties);TizenCoreEnabled=$(TizenCoreEnabled)',
+      });
+    });
+    document.rootElement.children.add(builder.buildFragment());
+  }
+
   userFile.writeAsStringSync(
     document.toXmlString(pretty: true, indent: '  '),
   );
+}
+
+bool _readsTizenCoreManifest(File projectFile) {
+  final File manifestFile = projectFile.parent.childFile('tizen-manifest.xml');
+  if (!manifestFile.existsSync()) {
+    return false;
+  }
+  try {
+    return usesTizenCoreEmbedder(TizenManifest.parseFromXml(manifestFile).apiVersion);
+  } on Exception {
+    return false;
+  }
 }

--- a/templates/multi-app/csharp/service/RunnerService.csproj
+++ b/templates/multi-app/csharp/service/RunnerService.csproj
@@ -1,12 +1,5 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>tizen80</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(FlutterEmbeddingPath)" />
-  </ItemGroup>
+  <Import Project="obj/Flutter.props" />
 
 </Project>

--- a/templates/multi-app/csharp/ui/Runner.csproj
+++ b/templates/multi-app/csharp/ui/Runner.csproj
@@ -1,13 +1,6 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>tizen80</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(FlutterEmbeddingPath)" />
-  </ItemGroup>
+  <Import Project="obj/Flutter.props" />
 
   <ItemGroup>
     <FlutterEphemeral Include="flutter\ephemeral\**\*" />

--- a/templates/plugin/csharp/pluginClass.csproj
+++ b/templates/plugin/csharp/pluginClass.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TizenCoreEnabled)' == 'true'">net8.0-tizen10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/service-app/csharp/Runner.csproj
+++ b/templates/service-app/csharp/Runner.csproj
@@ -1,13 +1,6 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>tizen80</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(FlutterEmbeddingPath)" />
-  </ItemGroup>
+  <Import Project="obj/Flutter.props" />
 
   <ItemGroup>
     <FlutterEphemeral Include="flutter\ephemeral\**\*" />

--- a/templates/ui-app/csharp/Runner.csproj
+++ b/templates/ui-app/csharp/Runner.csproj
@@ -1,13 +1,6 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>tizen80</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(FlutterEmbeddingPath)" />
-  </ItemGroup>
+  <Import Project="obj/Flutter.props" />
 
   <ItemGroup>
     <FlutterEphemeral Include="flutter\ephemeral\**\*" />

--- a/test/general/tizen_plugins_test.dart
+++ b/test/general/tizen_plugins_test.dart
@@ -401,7 +401,7 @@ internal class GeneratedPluginRegistrant
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectReference Include="${pluginDir.path}/tizen/SomeDotnetPlugin.csproj" />
+    <ProjectReference Include="${pluginDir.path}/tizen/SomeDotnetPlugin.csproj" AdditionalProperties="TizenCoreEnabled=\$(TizenCoreEnabled)" />
   </ItemGroup>
 </Project>
 '''));

--- a/test/general/tizen_project_test.dart
+++ b/test/general/tizen_project_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tizen/build_targets/utils.dart';
 import 'package:flutter_tizen/tizen_project.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -33,6 +34,83 @@ void main() {
 
     final xmlDocument = XmlDocument.parse(userFile.readAsStringSync());
     expect(xmlDocument.findAllElements('FlutterEmbeddingPath'), isNotEmpty);
+    expect(xmlDocument.findAllElements('TizenCoreEnabled'), isNotEmpty);
+  });
+
+  testUsingContext('Enables tizen-core for API version 11.0 or later', () async {
+    project.editableDirectory.childFile('Runner.csproj').createSync(recursive: true);
+
+    final File userFile = project.editableDirectory.childFile('Runner.csproj.user');
+
+    for (final MapEntry<String, String> entry in <String, String>{
+      '6.0': 'false',
+      '10.0': 'false',
+      '10.1': 'false',
+      '11.0': 'true',
+      '12.0': 'true',
+      '8.0': 'false',
+    }.entries) {
+      project.manifestFile
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="package_id" version="1.0.0" api-version="${entry.key}">
+    <profile name="common"/>
+</manifest>
+''');
+
+      await project.ensureReadyForPlatformSpecificTooling();
+
+      final xmlDocument = XmlDocument.parse(userFile.readAsStringSync());
+      expect(
+        xmlDocument.findAllElements('TizenCoreEnabled').single.innerText,
+        entry.value,
+        reason: 'api-version ${entry.key}',
+      );
+      final propsDocument = XmlDocument.parse(
+          project.hostAppRoot.childDirectory('obj').childFile('Flutter.props').readAsStringSync());
+      expect(propsDocument.findAllElements('TizenCoreEnabled').single.innerText, entry.value);
+      expect(propsDocument.findAllElements('Import').single.getAttribute('Project'),
+          endsWith('FlutterApplication.props'));
+      expect(propsDocument.findAllElements('TargetFramework'), isEmpty);
+      expect(propsDocument.findAllElements('PackageReference'), isEmpty);
+      expect(
+        getEmbedderArtifactsDirectory(entry.key, 'arm64').basename,
+        entry.value == 'true' ? '11.0' : (entry.key == '6.0' ? '6.0' : '6.5'),
+      );
+      final XmlElement reference = xmlDocument.findAllElements('ProjectReference').single;
+      final XmlElement restore =
+          xmlDocument.findAllElements('RestoreUseStaticGraphEvaluation').single;
+      expect(restore.innerText, 'true');
+      expect(restore.getAttribute('Condition'), r"'$(TizenCoreEnabled)' == 'true'");
+      expect(xmlDocument.findAllElements('ImportProjectExtensionTargets').single.innerText, 'true');
+      expect(reference.getAttribute('Update'), r'@(ProjectReference)');
+      expect(
+        reference.getAttribute('AdditionalProperties'),
+        r'%(ProjectReference.AdditionalProperties);TizenCoreEnabled=$(TizenCoreEnabled)',
+      );
+    }
+  });
+
+  testUsingContext('Generates backend props separately for UI and service apps', () async {
+    project.uiAppDirectory.childFile('Runner.csproj').createSync(recursive: true);
+    project.serviceAppDirectory.childFile('RunnerService.csproj').createSync(recursive: true);
+    project.uiManifestFile
+        .writeAsStringSync('<manifest package="ui" version="1.0.0" api-version="11.0"/>');
+    project.serviceManifestFile
+        .writeAsStringSync('<manifest package="service" version="1.0.0" api-version="6.0"/>');
+
+    await project.ensureReadyForPlatformSpecificTooling();
+
+    for (final directory in <Directory>[
+      project.uiAppDirectory,
+      project.serviceAppDirectory,
+    ]) {
+      final props = XmlDocument.parse(
+          directory.childDirectory('obj').childFile('Flutter.props').readAsStringSync());
+      expect(props.findAllElements('TizenCoreEnabled').single.innerText,
+          directory.path == project.uiAppDirectory.path ? 'true' : 'false');
+    }
   });
 
   testUsingContext('Can update existing csproj.user file', () async {


### PR DESCRIPTION
Select the Tcore embedder and initialize its main loop before running C++ and C# UI applications, then shut it down after view destruction. Use tizen_core.h and the managed Tizen.Core API directly while preserving Ecore on older platforms.

Share C# app framework, legacy package, and embedding reference settings in static FlutterApplication.props. Keep Microsoft.NET.Sdk and a single props import in app templates. Generate the backend selector and import path, and propagate the backend to embedding and plugin references during build and restore.